### PR TITLE
ci: add GitHub Actions workflow for building and packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           ls -lh dist/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-python-${{ matrix.python-version }}
           path: dist/*
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: dist-all
 
@@ -92,7 +92,7 @@ jobs:
           ls -1 dist/ | wc -l
 
       - name: Upload combined artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-packages
           path: dist/*
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Download combined artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
           path: dist


### PR DESCRIPTION
ci: add GitHub Actions workflow for building and packaging

- Build wheel and source distribution packages
- Support Python 3.10, 3.11, and 3.12
- Upload build artifacts for download
- Auto-create releases on version tags