### PR TITLE
feat(config): expand provider validation using factory classes

### DIFF
--- a/src/powermem/integrations/embeddings/configs.py
+++ b/src/powermem/integrations/embeddings/configs.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from powermem.integrations.embeddings.factory import EmbedderFactory
+
 
 class EmbedderConfig(BaseModel):
     provider: str = Field(
@@ -13,7 +15,7 @@ class EmbedderConfig(BaseModel):
     @field_validator("config")
     def validate_config(cls, v, values):
         provider = values.data.get("provider")
-        if provider in [
+        initialized_providers = [
             "openai",
             "ollama",
             "huggingface",
@@ -25,7 +27,8 @@ class EmbedderConfig(BaseModel):
             "langchain",
             "aws_bedrock",
             "qwen",
-        ]:
+        ]
+        if provider in initialized_providers or provider in EmbedderFactory.provider_to_class or provider == "mock":
             return v
         else:
             raise ValueError(f"Unsupported embedding provider: {provider}")

--- a/src/powermem/integrations/llm/configs.py
+++ b/src/powermem/integrations/llm/configs.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from powermem.integrations.llm.factory import LLMFactory
+
 
 class LLMConfig(BaseModel):
     provider: str = Field(description="Provider of the LLM (e.g., 'ollama', 'openai')", default="openai")
@@ -10,7 +12,7 @@ class LLMConfig(BaseModel):
     @field_validator("config")
     def validate_config(cls, v, info):
         provider = info.data.get("provider")
-        if provider in (
+        initialized_providers = (
             "openai",
             "ollama",
             "anthropic",
@@ -20,7 +22,8 @@ class LLMConfig(BaseModel):
             "vllm",
             "langchain",
             "qwen",
-        ):
+        )
+        if provider in initialized_providers or provider in LLMFactory.provider_to_class:
             return v
         else:
             raise ValueError(f"Unsupported LLM provider: {provider}")


### PR DESCRIPTION
# feat(config): expand provider validation using factory classes

EmbedderConfig, LLMConfig, and VectorStoreConfig now validate providers against both hardcoded lists and dynamically registered providers in their respective Factory classes. This allows for easier extension and support of custom providers without modifying the config files directly.
