### PR TITLE
fix: default base_url for SiliconFlowLLM

### DIFF
--- a/src/powermem/config_loader.py
+++ b/src/powermem/config_loader.py
@@ -133,7 +133,7 @@ def load_config_from_env() -> Dict[str, Any]:
             llm_config['openai_base_url'] = base_url
     elif llm_provider == 'siliconflow':
         # SiliconFlow uses OpenAI-compatible API
-        base_url = os.getenv('LLM_BASE_URL', 'https://api.siliconflow.cn/v1')
+        base_url = os.getenv('LLM_BASE_URL', 'https://api.siliconflow.com/v1')
         llm_config['openai_base_url'] = base_url
 
 

--- a/src/powermem/integrations/llm/siliconflow.py
+++ b/src/powermem/integrations/llm/siliconflow.py
@@ -15,7 +15,7 @@ class SiliconFlowLLM(LLMBase):
     SiliconFlow LLM provider implementation.
     
     SiliconFlow (硅基流动) is compatible with OpenAI API format.
-    Base URL: https://api.siliconflow.cn/v1
+    Base URL: https://api.siliconflow.com/v1
     """
     
     def __init__(self, config: Optional[Union[BaseLLMConfig, OpenAIConfig, Dict]] = None):
@@ -50,7 +50,7 @@ class SiliconFlowLLM(LLMBase):
             self.config.openai_base_url 
             or os.getenv("SILICONFLOW_BASE_URL") 
             or os.getenv("LLM_BASE_URL")
-            or "https://api.siliconflow.cn/v1"
+            or "https://api.siliconflow.com/v1"
         )
 
         self.client = OpenAI(api_key=api_key, base_url=base_url)


### PR DESCRIPTION

Update the default base_url from https://api.siliconflow.cn/v1 to 
https://api.siliconflow.com/v1 in both siliconflow.py and config_loader.py.

This fixes the authentication error (401 - Api key is invalid) reported 
in issue #94. The correct endpoint is now used by default while still 
allowing users to override via environment variables.

close #94
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
Update the default base_url from https://api.siliconflow.cn/v1 to 
https://api.siliconflow.com/v1 in both siliconflow.py and config_loader.py.

This fixes the authentication error (401 - Api key is invalid) reported 
in issue #94. The correct endpoint is now used by default while still 
allowing users to override via environment variables.

close #94
