### PR TITLE
refactor tests: migrate LangChain integration to 1.1.0+ API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ test = [
     "pytest>=8.2.2",
     "pytest-mock>=3.14.0",
     "pytest-asyncio>=0.23.7",
+    "langchain>=1.1.0",
+    "langchain-core>=1.1.0",
+    "langchain-openai>=1.1.0",
+    "langchain-community>=0.4.1",
 ]
 extras = [
     "sentence-transformers>=5.0.0",


### PR DESCRIPTION

- Update test_step4_langchain_integration to use LangChain 1.1.0+ API
  - Replace deprecated ConversationBufferMemory with custom PowermemLangChainMemory class
  - Use langchain_core.prompts.ChatPromptTemplate and RunnableLambda
  - Implement LCEL (LangChain Expression Language) for chain composition
  - Add graceful error handling when langchain dependencies are missing

- Add LangChain dependencies to test requirements in pyproject.toml
  - langchain>=1.1.0
  - langchain-core>=1.1.0
  - langchain-openai>=1.1.0
  - langchain-community>=0.4.1

This update aligns the test with examples/langchain implementation and
ensures compatibility with the latest LangChain API.