### PR TITLE
refactor(server/config): validate with the native pydantic-settings approach

### DIFF
--- a/src/server/config.py
+++ b/src/server/config.py
@@ -1,221 +1,125 @@
 """
-Configuration management for PowerMem API Server
+Configuration management for PowerMem API Server.
 """
 
-import os
+from __future__ import annotations
 from typing import List, Optional
-from pydantic_settings import BaseSettings
-from pydantic import Field, ConfigDict, field_validator, model_validator
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class ServerConfig(BaseSettings):
-    """Server configuration settings"""
-    
-    model_config = ConfigDict(
+def _parse_boolish(value: object) -> object:
+    """
+    Backward-compatible boolean parsing.
+
+    Historically we accepted values like: true/1/yes/on/enabled.
+    `pydantic` already accepts many truthy strings, but "enabled"/"disabled" are not
+    guaranteed across versions, so we normalize explicitly.
+    """
+
+    if value is None or isinstance(value, bool):
+        return value
+
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"1", "true", "t", "yes", "y", "on", "enabled"}:
+            return True
+        if text in {"0", "false", "f", "no", "n", "off", "disabled"}:
+            return False
+
+    return value
+
+
+class ServerSettings(BaseSettings):
+    model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        env_prefix="POWERMEM_SERVER_",
         case_sensitive=False,
-        extra="ignore",  # Ignore extra fields from .env that are not in this model
+        extra="ignore",
     )
-    
+
     # Server settings
-    host: str = Field(default="0.0.0.0", env="POWERMEM_SERVER_HOST")
-    port: int = Field(default=8000, env="POWERMEM_SERVER_PORT")
-    workers: int = Field(default=4, env="POWERMEM_SERVER_WORKERS")
-    reload: bool = Field(default=False, env="POWERMEM_SERVER_RELOAD")
-    
+    host: str = Field(default="0.0.0.0")
+    port: int = Field(default=8000)
+    workers: int = Field(default=4)
+    reload: bool = Field(default=False)
+
     # Authentication settings
-    auth_enabled: bool = Field(default=True, env="POWERMEM_SERVER_AUTH_ENABLED")
-    api_keys: str = Field(default="", env="POWERMEM_SERVER_API_KEYS")
-    
-    @model_validator(mode='after')
-    def parse_auth_enabled_from_env(self):
-        """Parse auth_enabled from environment variable, handling string 'false'"""
-        # Read directly from environment to bypass Pydantic's bool parsing
-        env_value = os.getenv('POWERMEM_SERVER_AUTH_ENABLED', '').strip().lower()
-        if env_value:
-            # Only update if explicitly set in environment
-            self.auth_enabled = env_value in ('true', '1', 'yes', 'on', 'enabled')
-        return self
-    
+    auth_enabled: bool = Field(default=True)
+    api_keys: str = Field(default="")
+
     # Rate limiting settings
-    rate_limit_enabled: bool = Field(default=True, env="POWERMEM_SERVER_RATE_LIMIT_ENABLED")
-    rate_limit_per_minute: int = Field(default=100, env="POWERMEM_SERVER_RATE_LIMIT_PER_MINUTE")
-    
+    rate_limit_enabled: bool = Field(default=True)
+    rate_limit_per_minute: int = Field(default=100)
+
     # Logging settings
-    log_level: str = Field(default="INFO", env="POWERMEM_SERVER_LOG_LEVEL")
-    log_format: str = Field(default="json", env="POWERMEM_SERVER_LOG_FORMAT")  # json or text
-    log_file: Optional[str] = Field(default="server.log", env="POWERMEM_SERVER_LOG_FILE")  # Log file path, None to disable file logging
-    
+    log_level: str = Field(default="INFO")
+    log_format: str = Field(default="json")
+    log_file: Optional[str] = Field(default="server.log")
+
     # API settings
-    api_title: str = Field(default="PowerMem API", env="POWERMEM_SERVER_API_TITLE")
-    api_version: str = Field(default="v1", env="POWERMEM_SERVER_API_VERSION")
+    api_title: str = Field(default="PowerMem API")
+    api_version: str = Field(default="v1")
     api_description: str = Field(
-        default="PowerMem HTTP API Server - Intelligent Memory System",
-        env="POWERMEM_SERVER_API_DESCRIPTION"
+        default="PowerMem HTTP API Server - Intelligent Memory System"
     )
-    
+
     # CORS settings
-    cors_enabled: bool = Field(default=True, env="POWERMEM_SERVER_CORS_ENABLED")
-    cors_origins: str = Field(default="*", env="POWERMEM_SERVER_CORS_ORIGINS")
-    
+    cors_enabled: bool = Field(default=True)
+    cors_origins: str = Field(default="*")
+
+    @field_validator(
+        "reload",
+        "auth_enabled",
+        "rate_limit_enabled",
+        "cors_enabled",
+        mode="before",
+    )
+    @classmethod
+    def normalize_bool_fields(cls, value: object) -> object:
+        return _parse_boolish(value)
+
+    @field_validator("log_file", mode="before")
+    @classmethod
+    def normalize_log_file(cls, value: object) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value  # type: ignore[return-value]
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def normalize_log_level(cls, value: object) -> object:
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped.upper() if stripped else value
+        return value
+
+    @field_validator("log_format", mode="before")
+    @classmethod
+    def normalize_log_format(cls, value: object) -> object:
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped.lower() if stripped else value
+        return value
+
     def get_api_keys_list(self) -> List[str]:
-        """Get list of valid API keys"""
+        """Get list of API keys"""
         if not self.api_keys:
             return []
         return [key.strip() for key in self.api_keys.split(",") if key.strip()]
-    
+
     def get_cors_origins_list(self) -> List[str]:
         """Get list of CORS origins"""
         if self.cors_origins == "*":
             return ["*"]
-        return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
+        return [
+            origin.strip() for origin in self.cors_origins.split(",") if origin.strip()
+        ]
 
 
-# Global config instance
-config = ServerConfig()
-
-# Manually override config values from .env file if set
-# This handles the case where Pydantic doesn't properly parse certain values
-try:
-    env_file_path = os.path.join(os.getcwd(), '.env')
-    if os.path.exists(env_file_path):
-        with open(env_file_path, 'r', encoding='utf-8') as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith('#') and '=' in line:
-                    key, value = line.split('=', 1)
-                    key = key.strip()
-                    value = value.strip().strip('"').strip("'")
-                    key_upper = key.upper()
-                    
-                    # Handle server settings
-                    if key_upper == 'POWERMEM_SERVER_HOST':
-                        config.host = value
-                    elif key_upper == 'POWERMEM_SERVER_PORT':
-                        try:
-                            config.port = int(value)
-                        except ValueError:
-                            pass
-                    elif key_upper == 'POWERMEM_SERVER_WORKERS':
-                        try:
-                            config.workers = int(value)
-                        except ValueError:
-                            pass
-                    elif key_upper == 'POWERMEM_SERVER_RELOAD':
-                        config.reload = value.lower() in ('true', '1', 'yes', 'on', 'enabled')
-                    # Handle auth_enabled
-                    elif key_upper == 'POWERMEM_SERVER_AUTH_ENABLED':
-                        config.auth_enabled = value.lower() in ('true', '1', 'yes', 'on', 'enabled')
-                    # Handle api_keys
-                    elif key_upper == 'POWERMEM_SERVER_API_KEYS':
-                        config.api_keys = value
-                    # Handle rate limiting settings
-                    elif key_upper == 'POWERMEM_SERVER_RATE_LIMIT_ENABLED':
-                        config.rate_limit_enabled = value.lower() in ('true', '1', 'yes', 'on', 'enabled')
-                    elif key_upper == 'POWERMEM_SERVER_RATE_LIMIT_PER_MINUTE':
-                        try:
-                            config.rate_limit_per_minute = int(value)
-                        except ValueError:
-                            pass
-                    # Handle log_format
-                    elif key_upper == 'POWERMEM_SERVER_LOG_FORMAT':
-                        config.log_format = value.lower()
-                    # Handle log_level
-                    elif key_upper == 'POWERMEM_SERVER_LOG_LEVEL':
-                        config.log_level = value.upper()
-                    # Handle log_file
-                    elif key_upper == 'POWERMEM_SERVER_LOG_FILE':
-                        config.log_file = value if value else None
-                    # Handle API settings
-                    elif key_upper == 'POWERMEM_SERVER_API_TITLE':
-                        config.api_title = value
-                    elif key_upper == 'POWERMEM_SERVER_API_VERSION':
-                        config.api_version = value
-                    elif key_upper == 'POWERMEM_SERVER_API_DESCRIPTION':
-                        config.api_description = value
-                    # Handle CORS settings
-                    elif key_upper == 'POWERMEM_SERVER_CORS_ENABLED':
-                        config.cors_enabled = value.lower() in ('true', '1', 'yes', 'on', 'enabled')
-                    elif key_upper == 'POWERMEM_SERVER_CORS_ORIGINS':
-                        config.cors_origins = value
-except Exception:
-    # Fallback to environment variables
-    # Server settings
-    _host_env = os.getenv('POWERMEM_SERVER_HOST', '').strip()
-    if _host_env:
-        config.host = _host_env
-    
-    _port_env = os.getenv('POWERMEM_SERVER_PORT', '').strip()
-    if _port_env:
-        try:
-            config.port = int(_port_env)
-        except ValueError:
-            pass
-    
-    _workers_env = os.getenv('POWERMEM_SERVER_WORKERS', '').strip()
-    if _workers_env:
-        try:
-            config.workers = int(_workers_env)
-        except ValueError:
-            pass
-    
-    _reload_env = os.getenv('POWERMEM_SERVER_RELOAD', '').strip().lower()
-    if _reload_env:
-        config.reload = _reload_env in ('true', '1', 'yes', 'on', 'enabled')
-    
-    # Authentication settings
-    _auth_env = os.getenv('POWERMEM_SERVER_AUTH_ENABLED', '').strip().lower()
-    if _auth_env:
-        config.auth_enabled = _auth_env in ('true', '1', 'yes', 'on', 'enabled')
-    
-    _api_keys_env = os.getenv('POWERMEM_SERVER_API_KEYS', '').strip()
-    if _api_keys_env:
-        config.api_keys = _api_keys_env
-    
-    # Rate limiting settings
-    _rate_limit_enabled_env = os.getenv('POWERMEM_SERVER_RATE_LIMIT_ENABLED', '').strip().lower()
-    if _rate_limit_enabled_env:
-        config.rate_limit_enabled = _rate_limit_enabled_env in ('true', '1', 'yes', 'on', 'enabled')
-    
-    _rate_limit_per_minute_env = os.getenv('POWERMEM_SERVER_RATE_LIMIT_PER_MINUTE', '').strip()
-    if _rate_limit_per_minute_env:
-        try:
-            config.rate_limit_per_minute = int(_rate_limit_per_minute_env)
-        except ValueError:
-            pass
-    
-    # Logging settings
-    _log_format_env = os.getenv('POWERMEM_SERVER_LOG_FORMAT', '').strip().lower()
-    if _log_format_env:
-        config.log_format = _log_format_env
-    
-    _log_level_env = os.getenv('POWERMEM_SERVER_LOG_LEVEL', '').strip().upper()
-    if _log_level_env:
-        config.log_level = _log_level_env
-    
-    _log_file_env = os.getenv('POWERMEM_SERVER_LOG_FILE', '').strip()
-    if _log_file_env:
-        config.log_file = _log_file_env if _log_file_env else None
-    
-    # API settings
-    _api_title_env = os.getenv('POWERMEM_SERVER_API_TITLE', '').strip()
-    if _api_title_env:
-        config.api_title = _api_title_env
-    
-    _api_version_env = os.getenv('POWERMEM_SERVER_API_VERSION', '').strip()
-    if _api_version_env:
-        config.api_version = _api_version_env
-    
-    _api_description_env = os.getenv('POWERMEM_SERVER_API_DESCRIPTION', '').strip()
-    if _api_description_env:
-        config.api_description = _api_description_env
-    
-    # CORS settings
-    _cors_enabled_env = os.getenv('POWERMEM_SERVER_CORS_ENABLED', '').strip().lower()
-    if _cors_enabled_env:
-        config.cors_enabled = _cors_enabled_env in ('true', '1', 'yes', 'on', 'enabled')
-    
-    _cors_origins_env = os.getenv('POWERMEM_SERVER_CORS_ORIGINS', '').strip()
-    if _cors_origins_env:
-        config.cors_origins = _cors_origins_env
+config = ServerSettings()

--- a/tests/unit/server/test_settings.py
+++ b/tests/unit/server/test_settings.py
@@ -1,0 +1,20 @@
+def test_server_settings_parsing(monkeypatch):
+    monkeypatch.setenv("POWERMEM_SERVER_AUTH_ENABLED", "false")
+    monkeypatch.setenv("POWERMEM_SERVER_LOG_FILE", "")
+    monkeypatch.setenv("POWERMEM_SERVER_API_KEYS", " a, b ,, c ")
+    monkeypatch.setenv(
+        "POWERMEM_SERVER_CORS_ORIGINS", "https://a.example, https://b.example"
+    )
+    monkeypatch.setenv("POWERMEM_SERVER_RELOAD", "enabled")
+
+    from server.config import ServerSettings
+
+    settings = ServerSettings(_env_file=None)
+
+    assert settings.auth_enabled is False
+    assert settings.log_file is None
+    assert settings.get_api_keys_list() == ["a", "b", "c"]
+    assert settings.get_cors_origins_list() == [
+        "https://a.example",
+        "https://b.example",
+    ]


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

as title.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->


For env prefix and .env file parsing, we can directly rely on pydantic-settings. For specific requirements, such as logic that requires converting multiple values to booleans, corresponding function `_parse_boolish` have been implemented.

I have verified that some basic functions, such as auth and rate limit are working properly.
