### PR TITLE
Fixed a bug where metadata was empty due to the use of ORM mapping.

### DIFF
--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -854,7 +854,8 @@ class Memory(MemoryBase):
                     results.append({
                         "id": memory_id,
                         "memory": action_text,
-                        "event": event_type
+                        "event": event_type,
+                        "metadata": metadata or {}
                     })
                     action_counts["ADD"] += 1
                     

--- a/src/powermem/storage/adapter.py
+++ b/src/powermem/storage/adapter.py
@@ -387,6 +387,15 @@ class StorageAdapter:
         # Serialize datetime objects in update_data before merging
         serialized_update_data = serialize_datetime(update_data)
         
+        # Special handling for metadata: merge instead of replace
+        if "metadata" in serialized_update_data:
+            existing_metadata = updated_payload.get("metadata", {})
+            new_metadata = serialized_update_data.get("metadata", {})
+            # Merge: existing metadata + new metadata (new takes precedence)
+            merged_metadata = {**existing_metadata, **new_metadata}
+            serialized_update_data = serialized_update_data.copy()
+            serialized_update_data["metadata"] = merged_metadata
+        
         # Update other fields
         updated_payload.update(serialized_update_data)
         

--- a/src/powermem/storage/oceanbase/oceanbase.py
+++ b/src/powermem/storage/oceanbase/oceanbase.py
@@ -583,7 +583,8 @@ class OceanBaseVectorStore(VectorStoreBase):
         for col_name in self.model_class.__table__.c.keys():
             # Check if Row contains this column (queries may not include all columns)
             if col_name in row._mapping.keys():
-                setattr(record, col_name, row._mapping[col_name])
+                attr_name = 'metadata_' if col_name == 'metadata' else col_name
+                setattr(record, attr_name, row._mapping[col_name])
         
         return record
 


### PR DESCRIPTION
## Summary

The database column name is `metadata`, but the ORM attribute name is `metadata_`. `_row_to_model` does not handle this mapping relationship, causing `record.metadata_` to always return None when read.
During a search, the metadata is updated. However, due to the aforementioned issue, the previous metadata content is not merged; instead, it is overwritten, resulting in lost content or an empty metadata table.