### PR TITLE
docs:Add Moltbot(clawdbot) memory Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Add the following configuration to your Claude Desktop config file:
 The MCP server provides tools for memory management including adding, searching, updating, and deleting memories. For complete MCP documentation and usage examples, see the [MCP Server Documentation](docs/api/0004-mcp.md).
 
 ## 🔗 Integrations & Demos
-
+- 🔗 **Moltbot Memory Plugin**: Use PowerMem as long-term memory in [Moltbot](https://github.com/moltbot/moltbot) via HTTP API—intelligent extraction, Ebbinghaus forgetting curve, multi-agent isolation. [View Plugin](https://github.com/oceanbase/moltbot-extension-powermem)
 - 🔗 **LangChain Integration**: Build medical support chatbot using LangChain + PowerMem + OceanBase, [View Example](examples/langchain/README.md)
 - 🔗 **LangGraph Integration**: Build customer service chatbot using LangGraph + PowerMem + OceanBase, [View Example](examples/langgraph/README.md)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -190,7 +190,7 @@ uvx powermem-mcp streamable-http 8001
 MCP Server提供记忆管理工具，包括添加、搜索、更新和删除记忆。完整的 MCP 文档和使用示例，请参阅 [MCP Server文档](docs/api/0004-mcp.md)。
 
 ## 🔗 集成与演示
-
+- 🔗 **Moltbot 外挂记忆插件**：在 [Moltbot](https://github.com/moltbot/moltbot) 中通过 HTTP API 使用 PowerMem 长期记忆，支持智能抽取、艾宾浩斯遗忘曲线、多 Agent 隔离。[查看插件](https://github.com/oceanbase/moltbot-extension-powermem)
 - 🔗 **LangChain 集成**：基于 LangChain + PowerMem + OceanBase 构建医疗支持机器人，[查看示例](examples/langchain/README.md)
 - 🔗 **LangGraph 集成**：基于 LangGraph + PowerMem + OceanBase 构建客户服务机器人，[查看示例](examples/langgraph/README.md)
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -189,7 +189,7 @@ Claude Desktop 設定ファイルに次の設定を追加します：
 MCP サーバーは、メモリの追加、検索、更新、削除を含むメモリ管理ツールを提供します。完全な MCP ドキュメントと使用例については、[MCP サーバードキュメント](docs/api/0004-mcp.md) を参照してください。
 
 ## 🔗 統合とデモ
-
+- 🔗 **Moltbot メモリプラグイン**: [Moltbot](https://github.com/moltbot/moltbot) で HTTP API により PowerMem を長期メモリとして利用。インテリジェント抽出、エビングハウス忘却曲線、マルチエージェント分離に対応。[プラグインを参照](https://github.com/oceanbase/moltbot-extension-powermem)
 - 🔗 **LangChain 統合**: LangChain + PowerMem + OceanBase を使用して医療サポートロボットを構築、[例を参照](examples/langchain/README.md)
 - 🔗 **LangGraph 統合**: LangGraph + PowerMem + OceanBase を使用してカスタマーサービスロボットを構築、[例を参照](examples/langgraph/README.md)
 


### PR DESCRIPTION
# Moltbot Memory (PowerMem) Plugin

This plugin lets [Moltbot](https://github.com/moltbot/moltbot) use long-term memory via the [PowerMem](https://github.com/oceanbase/powermem) HTTP API: intelligent extraction, Ebbinghaus forgetting curve, multi-agent isolation. **No Python inside Moltbot**—only a separately running PowerMem server is required.