### PR TITLE
fix: user_id isolation in _intelligent_add and PGVectorConfig defaults (#255, #256)

### DIFF
--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -831,6 +831,13 @@ class Memory(MemoryBase):
                 }
                 search_filters.update(simple_metadata)
 
+            # Ensure user_id/agent_id are always in search_filters for correct isolation
+            # This prevents cross-user memory deduplication when content is similar
+            if user_id is not None:
+                search_filters['user_id'] = user_id
+            if agent_id is not None:
+                search_filters['agent_id'] = agent_id
+
             # Search for similar memories with reduced limit to reduce noise
             # Pass fact text to enable hybrid search for better results
             similar = self.storage.search_memories(

--- a/src/powermem/storage/config/pgvector.py
+++ b/src/powermem/storage/config/pgvector.py
@@ -40,12 +40,12 @@ class PGVectorConfig(BaseVectorStoreConfig):
     )
     
     user: Optional[str] = Field(
-        default=None,
+        default="postgres",
         validation_alias=AliasChoices(
             "POSTGRES_USER",
             "user", # avoid using system USER environment variable first
         ),
-        description="Database user"
+        description="Database user. Default is postgres"
     )
     
     password: Optional[str] = Field(
@@ -58,7 +58,7 @@ class PGVectorConfig(BaseVectorStoreConfig):
     )
     
     host: Optional[str] = Field(
-        default=None,
+        default="127.0.0.1",
         validation_alias=AliasChoices(
             "host",
             "POSTGRES_HOST",
@@ -67,7 +67,7 @@ class PGVectorConfig(BaseVectorStoreConfig):
     )
     
     port: Optional[int] = Field(
-        default=None,
+        default=5432,
         validation_alias=AliasChoices(
             "port",
             "POSTGRES_PORT",
@@ -131,10 +131,17 @@ class PGVectorConfig(BaseVectorStoreConfig):
             return values
         user, password = values.get("user"), values.get("password")
         host, port = values.get("host"), values.get("port")
-        if user is not None or password is not None:
-            if not user or not password:
-                raise ValueError("Both 'user' and 'password' must be provided.")
-        if host is not None or port is not None:
-            if not host or not port:
-                raise ValueError("Both 'host' and 'port' must be provided.")
+        # Only enforce pairing when one is explicitly provided as non-default
+        # Allow defaults to fill in missing values
+        if user is not None and password is not None:
+            # Both explicitly provided — ok
+            pass
+        elif user is not None and user != "postgres" and password is None:
+            raise ValueError("'password' must be provided when 'user' is set.")
+        if host is not None and port is not None:
+            pass
+        elif host is not None and host != "127.0.0.1" and port is None:
+            raise ValueError("'port' must be provided when 'host' is set.")
+        elif port is not None and port != 5432 and host is None:
+            raise ValueError("'host' must be provided when 'port' is set.")
         return values


### PR DESCRIPTION
## Summary

Fixes two related issues:

### 1. user_id isolation in _intelligent_add (#255)

**Problem:** When `_intelligent_add` searches for similar memories to deduplicate, it doesn't include `user_id`/`agent_id` in the search filters. This means User A's memory could be considered a duplicate of User B's memory if the content is similar enough, causing silent data loss.

**Fix:** Explicitly set `user_id` and `agent_id` in `search_filters` before calling `search_memories`, ensuring deduplication only happens within the same user's scope.

### 2. PGVectorConfig defaults (#256)

**Problem:** `PGVectorConfig` has `host`, `port`, and `user` defaulting to `None`, but the validator requires both `host+port` and `user+password` to be provided together. This means a minimal config like `{"password": "secret"}` fails validation even though sensible defaults (localhost:5432, postgres) exist.

**Fix:**
- Set defaults: `host="127.0.0.1"`, `port=5432`, `user="postgres"`
- Relax validator to only enforce pairing when non-default values are explicitly provided

## Testing

- Verified that `_intelligent_add` now correctly scopes similarity search per user
- Verified that `PGVectorConfig(password="secret")` works with defaults
- Verified that explicit non-default values still require their pair