### PR TITLE
fix: replace bare except with specific exceptions in rerank modules

### DIFF
--- a/src/powermem/integrations/rerank/generic.py
+++ b/src/powermem/integrations/rerank/generic.py
@@ -180,7 +180,7 @@ class GenericRerank(RerankBase):
                     error_msg += f": {error_detail['detail']}"
                 elif "error" in error_detail:
                     error_msg += f": {error_detail['error']}"
-            except:
+            except (ValueError, KeyError):
                 error_msg += f": {e.response.text}"
             raise Exception(f"Failed to rerank documents: {error_msg}")
         except Exception as e:

--- a/src/powermem/integrations/rerank/jina.py
+++ b/src/powermem/integrations/rerank/jina.py
@@ -143,7 +143,7 @@ class JinaRerank(RerankBase):
                 error_detail = e.response.json()
                 if "detail" in error_detail:
                     error_msg += f": {error_detail['detail']}"
-            except:
+            except (ValueError, KeyError):
                 error_msg += f": {e.response.text}"
             raise Exception(f"Failed to rerank documents: {error_msg}")
         except Exception as e:

--- a/src/powermem/integrations/rerank/zai.py
+++ b/src/powermem/integrations/rerank/zai.py
@@ -152,7 +152,7 @@ class ZaiRerank(RerankBase):
                 error_detail = e.response.json()
                 if "detail" in error_detail:
                     error_msg += f": {error_detail['detail']}"
-            except:
+            except (ValueError, KeyError):
                 error_msg += f": {e.response.text}"
             raise Exception(f"Failed to rerank documents: {error_msg}")
         except Exception as e:


### PR DESCRIPTION
## Problem

Three rerank integration modules use bare `except:` when parsing JSON error responses from the rerank API. This catches `BaseException` including `SystemExit` and `KeyboardInterrupt`.

## Fix

Replace with `except (ValueError, KeyError):` — `ValueError` for JSON decode failures, `KeyError` for missing keys in the error response.

## Files

- `src/powermem/integrations/rerank/generic.py`
- `src/powermem/integrations/rerank/jina.py`
- `src/powermem/integrations/rerank/zai.py`