### PR TITLE
fix(oceanbase): pass where_clause in pyobvector-compatible shape

### DIFF
--- a/src/powermem/storage/oceanbase/oceanbase.py
+++ b/src/powermem/storage/oceanbase/oceanbase.py
@@ -937,7 +937,7 @@ class OceanBaseVectorStore(VectorStoreBase):
         # Combine FTS condition with filter conditions
         where_conditions = [fts_condition]
         if filter_where_clause is not None:
-            where_conditions.append(filter_where_clause)
+            where_conditions.extend(filter_where_clause)
 
         # Build custom query to include score field
         try:


### PR DESCRIPTION
Ensure filter clauses are provided as a list of SQLAlchemy expressions for pyobvector search APIs, and fix FTS/LIKE fallback query construction to avoid SQLAlchemy type errors.
