### PR TITLE
fix(server): clear port on server-stop when PID file is stale (fixes #267)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,13 @@ server-stop: ## Stop the PowerMem API server
 		fi; \
 		echo "Server stopped"; \
 	else \
-		echo "Server process (PID: $$PID) not found, cleaning up PID file"; \
+		echo "Server process (PID: $$PID) not found (stale PID), cleaning up PID file"; \
+		PORT_PID=$$(lsof -t -i:$(SERVER_PORT) 2>/dev/null || echo ""); \
+		if [ -n "$$PORT_PID" ]; then \
+			echo "Found process $$PORT_PID on port $(SERVER_PORT), stopping it..."; \
+			kill $$PORT_PID 2>/dev/null || kill -9 $$PORT_PID 2>/dev/null; \
+			echo "Port $(SERVER_PORT) cleared"; \
+		fi; \
 	fi; \
 	rm -f $(SERVER_PID_FILE); \
 	echo "✓ Server stopped"


### PR DESCRIPTION
When the server process was killed directly, server-stop only removed the
PID file and did not kill whatever was listening on the configured port.
That left the port in use and caused server-start to fail or old process
to keep responding (e.g. 401).

- In server-stop, if the PID from the file is not running, also find and
  kill the process bound to SERVER_PORT via lsof before removing the PID file.
- Add scripts/test_issue_267.sh and make target test-issue-267 to verify
  the fix.

#267 