### PR TITLE
fix(cli): pass -f/--filters from pmem list to storage (fixes #301)

### DIFF
--- a/src/powermem/core/async_memory.py
+++ b/src/powermem/core/async_memory.py
@@ -1306,7 +1306,8 @@ class AsyncMemory(MemoryBase):
         """
         try:
             results = await self.storage.get_all_memories_async(
-                user_id, agent_id, run_id, limit, offset, sort_by=sort_by, order=order
+                user_id, agent_id, run_id, limit, offset,
+                sort_by=sort_by, order=order, filters=filters
             )
             
             await self.audit.log_event_async("memory.get_all", {

--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -1572,7 +1572,8 @@ class Memory(MemoryBase):
         """
         try:
             results = self.storage.get_all_memories(
-                user_id, agent_id, run_id, limit, offset, sort_by=sort_by, order=order
+                user_id, agent_id, run_id, limit, offset,
+                sort_by=sort_by, order=order, filters=filters
             )
             
             self.audit.log_event("memory.get_all", {

--- a/src/powermem/storage/adapter.py
+++ b/src/powermem/storage/adapter.py
@@ -475,19 +475,20 @@ class StorageAdapter:
         offset: int = 0,
         sort_by: Optional[str] = None,
         order: str = "desc",
+        filters: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """Get all memories with optional filtering and sorting."""
-        # Build filters for database-level filtering
-        filters = {}
+        # Build filters for database-level filtering (only scope keys; backends use payload top-level)
+        db_filters: Dict[str, Any] = {}
         if user_id:
-            filters["user_id"] = user_id
+            db_filters["user_id"] = user_id
         if agent_id:
-            filters["agent_id"] = agent_id
+            db_filters["agent_id"] = agent_id
         if run_id:
-            filters["run_id"] = run_id
-        
+            db_filters["run_id"] = run_id
+        # Pass only scope to DB; extra filters (e.g. metadata.name) applied in-memory below
         results = self.vector_store.list(
-            filters=filters if filters else None,
+            filters=db_filters if db_filters else None,
             limit=limit,
             offset=offset,
             order_by=sort_by,
@@ -547,6 +548,21 @@ class StorageAdapter:
                 continue
             if run_id and memory.get("run_id") != run_id:
                 continue
+            # Apply extra filters (e.g. metadata or payload fields backend may not have filtered)
+            if filters:
+                for key, expected in filters.items():
+                    if key in ("user_id", "agent_id", "run_id"):
+                        continue
+                    actual = memory.get(key)
+                    if actual is None and memory.get("metadata"):
+                        actual = memory["metadata"].get(key)
+                    if actual != expected:
+                        break
+                else:
+                    pass  # all extra filters matched
+                    memories.append(memory)
+                    continue
+                continue  # one extra filter did not match, skip this memory
             
             memories.append(memory)
         
@@ -605,11 +621,12 @@ class StorageAdapter:
         offset: int = 0,
         sort_by: Optional[str] = None,
         order: str = "desc",
+        filters: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """Get all memories with optional filtering and sorting asynchronously."""
         import asyncio
         return await asyncio.to_thread(
-            self.get_all_memories, user_id, agent_id, run_id, limit, offset, sort_by, order
+            self.get_all_memories, user_id, agent_id, run_id, limit, offset, sort_by, order, filters
         )
     
     async def clear_memories_async(


### PR DESCRIPTION
1. CLI 已正确解析 -f
pmem list -f '{"name": "123"}' 时，CLI 会把 -f 解析成 filters，并调用 ctx.memory.get_all(..., filters=filter_dict)。
2. Core 层没有把 filters 传下去
Memory.get_all() 虽然接收了 filters 参数，但调用存储时没有传：
- 只调用了 self.storage.get_all_memories(user_id, agent_id, run_id, limit, offset, sort_by=..., order=...)
- 没有把 filters 传给 storage，所以“按 JSON 过滤”的语义在存储层完全丢失。
3. 存储层也没有 filters 能力
StorageAdapter.get_all_memories() 本身没有 filters 参数，只根据 user_id / agent_id / run_id 查库，无法做“按 metadata 等字段过滤”。
因此：-f 只在 CLI 被解析，没有传到 Memory，再传到 Storage，等价于没生效，pmem list -f '{"name": "123"}' 和 不加 -f 的 pmem list 结果一样。

close #301 
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
1. CLI correctly parses -f
When pmem list -f '{"name": "123"}' is used, the CLI will parse -f into filters and call ctx.memory.get_all(..., filters=filter_dict).
2. The Core layer does not pass filters to
Although Memory.get_all() received the filters parameter, it did not pass it when calling storage:
- Only self.storage.get_all_memories(user_id, agent_id, run_id, limit, offset, sort_by=..., order=...) is called
- Filters are not passed to storage, so the semantics of "filtering by JSON" are completely lost at the storage layer.
3. The storage layer does not have filters capability.
StorageAdapter.get_all_memories() itself has no filters parameter. It only checks the database based on user_id / agent_id / run_id, and cannot filter by fields such as metadata.
Therefore: -f is only parsed in the CLI and is not passed to Memory and then to Storage, which is equivalent to not taking effect. The result of pmem list -f '{"name": "123"}' is the same as that of pmem list without -f.

close #301
