### PR TITLE
refactor(cli): nest memory commands under memory

### DIFF
--- a/src/powermem/cli/commands/__init__.py
+++ b/src/powermem/cli/commands/__init__.py
@@ -8,13 +8,12 @@ from .memory import memory_group
 from .config import config_group
 from .stats import stats_cmd
 from .manage import manage_group
-from .interactive import interactive_cmd, shell_cmd
+from .interactive import shell_cmd
 
 __all__ = [
     "memory_group",
     "config_group",
     "stats_cmd",
     "manage_group",
-    "interactive_cmd",
     "shell_cmd",
 ]

--- a/src/powermem/cli/commands/interactive.py
+++ b/src/powermem/cli/commands/interactive.py
@@ -491,31 +491,13 @@ Examples:
         self.running = False
 
 
-@click.command(name="interactive")
-@pass_context
-def interactive_cmd(ctx: CLIContext):
-    """
-    Start interactive mode (REPL).
-    
-    Provides a shell-like interface for PowerMem operations.
-    
-    \b
-    Examples:
-        pmem interactive
-    """
-    try:
-        session = InteractiveSession(ctx)
-        session.run()
-    except Exception as e:
-        print_error(f"Interactive mode error: {e}")
-        sys.exit(1)
-
-
 @click.command(name="shell")
 @pass_context
 def shell_cmd(ctx: CLIContext):
     """
-    Start interactive mode (alias for 'interactive').
+    Start interactive mode (REPL).
+    
+    Provides a shell-like interface for PowerMem operations.
     
     \b
     Examples:

--- a/src/powermem/cli/commands/memory.py
+++ b/src/powermem/cli/commands/memory.py
@@ -61,8 +61,8 @@ def add_cmd(ctx: CLIContext, content, user_id, agent_id, run_id, metadata,
     
     \b
     Examples:
-        pmem add "User prefers dark mode" --user-id user123
-        pmem add "API key is stored in vault" --metadata '{"category": "security"}'
+        pmem memory add "User prefers dark mode" --user-id user123
+        pmem memory add "API key is stored in vault" --metadata '{"category": "security"}'
     """
     ctx.json_output = ctx.json_output or json_output
     try:
@@ -131,8 +131,8 @@ def search_cmd(ctx: CLIContext, query, user_id, agent_id, run_id, limit,
     
     \b
     Examples:
-        pmem search "user preferences" --user-id user123
-        pmem search "dark mode" --limit 5 --json
+        pmem memory search "user preferences" --user-id user123
+        pmem memory search "dark mode" --limit 5 --json
     """
     ctx.json_output = ctx.json_output or json_output
     try:
@@ -187,8 +187,8 @@ def get_cmd(ctx: CLIContext, memory_id, user_id, agent_id, json_output):
     
     \b
     Examples:
-        pmem get 123456789
-        pmem get 123456789 --user-id user123
+        pmem memory get 123456789
+        pmem memory get 123456789 --user-id user123
     """
     ctx.json_output = ctx.json_output or json_output
     try:
@@ -235,8 +235,8 @@ def update_cmd(ctx: CLIContext, memory_id, content, user_id, agent_id, metadata,
     
     \b
     Examples:
-        pmem update 123456789 "Updated content"
-        pmem update 123456789 "New content" --metadata '{"updated": true}'
+        pmem memory update 123456789 "Updated content"
+        pmem memory update 123456789 "New content" --metadata '{"updated": true}'
     """
     ctx.json_output = ctx.json_output or json_output
     try:
@@ -289,8 +289,8 @@ def delete_cmd(ctx: CLIContext, memory_id, user_id, agent_id, yes):
     
     \b
     Examples:
-        pmem delete 123456789
-        pmem delete 123456789 --yes
+        pmem memory delete 123456789
+        pmem memory delete 123456789 --yes
     """
     try:
         # Confirm deletion
@@ -351,9 +351,9 @@ def list_cmd(ctx: CLIContext, user_id, agent_id, run_id, limit, offset,
     
     \b
     Examples:
-        pmem list --user-id user123
-        pmem list --limit 20 --offset 0
-        pmem list --sort-by created_at --order desc
+        pmem memory list --user-id user123
+        pmem memory list --limit 20 --offset 0
+        pmem memory list --sort-by created_at --order desc
     """
     ctx.json_output = ctx.json_output or json_output
     try:
@@ -413,8 +413,8 @@ def delete_all_cmd(ctx: CLIContext, user_id, agent_id, run_id, confirm):
     
     \b
     Examples:
-        pmem delete-all --user-id user123 --confirm
-        pmem delete-all --run-id session1 --confirm
+        pmem memory delete-all --user-id user123 --confirm
+        pmem memory delete-all --run-id session1 --confirm
     """
     if not confirm:
         print_error("This will delete ALL matching memories!")

--- a/src/powermem/cli/main.py
+++ b/src/powermem/cli/main.py
@@ -76,8 +76,7 @@ def json_option(f):
 # Static command tree for fast shell completion (no Python process on TAB).
 # Keep in sync with cli.add_command / group.add_command below.
 _COMPLETION_COMMANDS = [
-    "add", "config", "delete", "delete-all", "get", "interactive", "list",
-    "manage", "memory", "search", "shell", "stats", "update",
+    "config", "manage", "memory", "shell", "stats",
 ]
 _COMPLETION_SUBCOMMANDS = {
     "config": ["init", "show", "test", "validate"],
@@ -117,8 +116,8 @@ def cli(ctx, env_file, json_output, verbose, install_completion):
     
     \b
     Examples:
-        pmem add "User prefers dark mode" --user-id user123
-        pmem search "preferences" --user-id user123
+        pmem memory add "User prefers dark mode" --user-id user123
+        pmem memory search "preferences" --user-id user123
         pmem stats --json
         pmem config show
     
@@ -152,9 +151,10 @@ def _static_bash_completion_script() -> str:
         "_pmem_completion() {",
         "  local cur=${COMP_WORDS[COMP_CWORD]}",
         "  local prev=${COMP_WORDS[COMP_CWORD-1]}",
-        "  if [ $COMP_CWORD -eq 1 ]; then",
+        "  local cword=${COMP_CWORD:-0}",
+        "  if [ \"$cword\" -eq 1 ]; then",
         f"    COMPREPLY=($(compgen -W \"{top}\" -- \"$cur\"))",
-        "  elif [ $COMP_CWORD -eq 2 ]; then",
+        "  elif [ \"$cword\" -eq 2 ]; then",
         "    case \"$prev\" in",
     ]
     for group, subcmds in _COMPLETION_SUBCOMMANDS.items():
@@ -178,9 +178,10 @@ def _static_zsh_completion_script() -> str:
     cmds = " ".join(_COMPLETION_COMMANDS)
     return f"""#compdef pmem powermem-cli
 _pmem_completion() {{
-  if [ $CURRENT -eq 2 ]; then
+  local current=${{CURRENT:-0}}
+  if [ "$current" -eq 2 ]; then
     compadd ${{(s: :)'{cmds}'}}
-  elif [ $CURRENT -eq 3 ]; then
+  elif [ "$current" -eq 3 ]; then
     case ${{words[2]}} in
       config) compadd init show test validate ;;
       manage) compadd backup cleanup migrate restore ;;
@@ -300,27 +301,19 @@ Register-ArgumentCompleter -Native -CommandName pmem,powermem-cli -ScriptBlock $
 
 
 # Import and register command groups
-from .commands.memory import add_cmd, search_cmd, get_cmd, update_cmd, delete_cmd, list_cmd, delete_all_cmd
+from .commands.memory import memory_group
 from .commands.config import config_group
 from .commands.stats import stats_cmd
 from .commands.manage import manage_group
-from .commands.interactive import interactive_cmd, shell_cmd
+from .commands.interactive import shell_cmd
 
-# Memory commands at root: add, search, get, update, delete, list, delete-all
-
-cli.add_command(add_cmd)
-cli.add_command(search_cmd)
-cli.add_command(get_cmd)
-cli.add_command(update_cmd)
-cli.add_command(delete_cmd)
-cli.add_command(list_cmd)
-cli.add_command(delete_all_cmd)
+# Memory commands under "memory": pmem memory add/search/get/update/delete/list/delete-all
+cli.add_command(memory_group)
 
 # Register other command groups
 cli.add_command(config_group)
 cli.add_command(stats_cmd)
 cli.add_command(manage_group)
-cli.add_command(interactive_cmd)
 cli.add_command(shell_cmd)
 
 


### PR DESCRIPTION
refactor(cli): nest memory commands under "memory", keep only shell, fix completion

- Move memory operations under "pmem memory": add, search, get, update,
  delete, list, delete-all (was pmem <cmd> at root)
- Remove redundant "interactive" command; keep "pmem shell" as the single
  REPL entry point
- Fix shell completion: use default for COMP_CWORD/CURRENT so [ -eq ] never
  gets an empty operand (fixes "unknown condition: -eq")
- Update completion command list and in-command examples to match