### PR TITLE
fix(cli): show non-ASCII metadata as-is in memory get/output (fixes #312)

### DIFF
--- a/src/powermem/cli/utils/output.py
+++ b/src/powermem/cli/utils/output.py
@@ -98,7 +98,7 @@ class OutputFormatter:
         
         metadata = memory.get("metadata", {})
         if metadata:
-            lines.append(f"Metadata: {json.dumps(metadata, default=str)}")
+            lines.append(f"Metadata: {json.dumps(metadata, default=str, ensure_ascii=False)}")
         
         return "\n".join(lines)
     
@@ -127,7 +127,7 @@ class OutputFormatter:
         
         metadata = memory.get("metadata", {})
         if metadata:
-            lines.append(f"{'Metadata:':<15} {json.dumps(metadata, default=str)}")
+            lines.append(f"{'Metadata:':<15} {json.dumps(metadata, default=str, ensure_ascii=False)}")
         
         lines.append("=" * 60)
         return "\n".join(lines)

--- a/src/powermem/utils/utils.py
+++ b/src/powermem/utils/utils.py
@@ -250,7 +250,7 @@ def format_memory_for_display(memory: Dict[str, Any]) -> str:
     if created_at:
         formatted += f"Created: {created_at}\n"
     if metadata:
-        formatted += f"Metadata: {json.dumps(metadata, indent=2)}\n"
+        formatted += f"Metadata: {json.dumps(metadata, indent=2, ensure_ascii=False)}\n"
     
     return formatted
 


### PR DESCRIPTION
close #312 