### PR TITLE
pyobvector dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "click>=8.0.0",
     "rank-bm25>=0.2.2",
     "pyobvector>=0.2.24,<0.3.0",
+    "sqlglot>=26.0.1,<26.25.0",
     "jieba>=0.42.1",
     "azure-identity>=1.24.0",
     "psycopg2-binary>=2.9.0",


### PR DESCRIPTION
## Summary
Resolve pyobvector dependencies


## Solution Description
Pyobvector requires sqlglot>=26.0.1, but there is no upper limit set. The problem is that the new version of sqlglot (possibly after v26.25.0) has changed the API and removed the direct export of expressions.
Pyproject.toml: Add sqlglot>=26.0.1,<26.25.0 version limit, ensure installation compatibility version