### PR TITLE
fix(cli): show ellipsis for truncated fields in interactive memory list

### DIFF
--- a/src/powermem/cli/commands/interactive.py
+++ b/src/powermem/cli/commands/interactive.py
@@ -460,17 +460,29 @@ Examples:
             
             click.echo(f"\nFound {len(memories)} memories:")
             click.echo("-" * 70)
-            click.echo(f"{'ID':<20} {'User ID':<12} {'Content':<35}")
+            click.echo(f"{'ID':<20} {'User ID':<22} {'Content':<35}")
             click.echo("-" * 70)
+
+            def _truncate_with_ellipsis(value: str, max_len: int) -> str:
+                """Truncate long display values with visible ellipsis."""
+                if len(value) <= max_len:
+                    return value
+                if max_len <= 3:
+                    return value[:max_len]
+                return value[: max_len - 3] + "..."
             
             for mem in memories:
-                memory_id = str(mem.get("id") or mem.get("memory_id", "N/A"))[:18]
-                user_id = str(mem.get("user_id", "N/A"))[:10]
-                content = mem.get("memory") or mem.get("content", "N/A")
-                if len(content) > 33:
-                    content = content[:30] + "..."
+                memory_id = _truncate_with_ellipsis(
+                    str(mem.get("id") or mem.get("memory_id", "N/A")),
+                    18,
+                )
+                user_id = _truncate_with_ellipsis(str(mem.get("user_id", "N/A")), 20)
+                content = _truncate_with_ellipsis(
+                    str(mem.get("memory") or mem.get("content", "N/A")),
+                    33,
+                )
                 
-                click.echo(f"{memory_id:<20} {user_id:<12} {content:<35}")
+                click.echo(f"{memory_id:<20} {user_id:<22} {content:<35}")
             
             click.echo("-" * 70)
             

--- a/tests/regression/test_powermem_cli.py
+++ b/tests/regression/test_powermem_cli.py
@@ -829,6 +829,28 @@ class TestShell:
         """shell list command should work properly"""
         rc, out, err = cli_runner.pmem("shell", timeout=15, input_text="list -l 1\nexit\n")
         assert_success(rc, out, err, "Found", "memories")
+
+    def test_shell_list_user_id_truncation_shows_ellipsis(self, cli_runner):
+        """shell list should show ellipsis when user_id is truncated"""
+        long_user_id = "shell_user_id_1234567890"
+
+        rc, out, err = cli_runner.pmem(
+            f'memory add "shell long user id test" --user-id {long_user_id} --agent-id shell_agent'
+        )
+        assert_success(rc, out, err, "added")
+
+        rc, out, err = cli_runner.pmem(
+            "shell",
+            timeout=15,
+            input_text=f"list --user-id {long_user_id} -l 5\nexit\n",
+        )
+        assert_success(rc, out, err, "Found", "memories")
+        assert_contains(rc, out, err, ["shell_user_id_12345..."])
+
+        cli_runner.pmem(
+            f"memory delete-all --user-id {long_user_id} --confirm",
+            input_text="y\n",
+        )
     
     def test_shell_exit(self, cli_runner):
         """shell exit should exit normally"""


### PR DESCRIPTION
```bash
$pmem memory add "Test data: user prefers dark mode" --user-id demo_user_20260326 --agent-id demo_agent
[SUCCESS] Memory ADD: ID=692280644264263680


$pmem memory add "Test data: user prefers dark mode" --user-id demo_user_20260326111111111 --agent-id demo_agent
[SUCCESS] Memory ADD: ID=692280716913803264

$pmem shell

==================================================
  PowerMem Interactive Mode
==================================================
Type 'help' for available commands, 'exit' to quit
Tab: complete commands; Up/Down: command history

powermem> list

Found 2 memories:
----------------------------------------------------------------------
ID                   User ID                Content
----------------------------------------------------------------------
692280644264263680   demo_user_20260326     User prefers dark mode
692280716913803264   demo_user_2026032...   User prefers dark mode
----------------------------------------------------------------------
powermem> exit
[INFO] Goodbye!
```


close #360 