### PR TITLE
Fix #350: [Enhancement]: When some fields in UserProfile are NULL, th...

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -49,8 +49,8 @@ export interface UserProfile {
   user_id: string;
   profile_content?: string;
   topics?: Record<string, any>;
-  created_at: string;
-  updated_at: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface UserProfileListResponse {

--- a/dashboard/src/routes/user-profile.tsx
+++ b/dashboard/src/routes/user-profile.tsx
@@ -119,7 +119,8 @@ function UserProfilePage() {
     return topicKeys.slice(0, 3).join(", ") + (topicKeys.length > 3 ? "..." : "");
   };
 
-  const formatDate = (dateString: string) => {
+  const formatDate = (dateString: string | undefined) => {
+    if (!dateString) return nullDisplay;
     try {
       return new Date(dateString).toLocaleString();
     } catch {


### PR DESCRIPTION
Closes #350

## Before

`UserProfile.created_at` and `updated_at` were typed as required `string` fields in `dashboard/src/lib/api.ts`. When the backend returned `NULL` for these fields, `formatDate()` in `dashboard/src/routes/user-profile.tsx` received `undefined` and passed it directly to `new Date()`, producing `"Invalid Date"` in some cells while other parts of the dashboard rendered nothing — causing visible inconsistency across the UI.

## After

`created_at` and `updated_at` are now typed as `string | undefined` (`created_at?: string`, `updated_at?: string`), accurately reflecting that these fields can be `NULL`. `formatDate()` now accepts `string | undefined` and returns the `nullDisplay` sentinel value early when the input is falsy, ensuring a consistent, intentional display for missing timestamps throughout the dashboard.

## Changes

- **`dashboard/src/lib/api.ts`** — Marked `created_at` and `updated_at` as optional (`?`) in the `UserProfile` interface to match actual backend behavior.
- **`dashboard/src/routes/user-profile.tsx`** — Updated the `formatDate` signature from `(dateString: string)` to `(dateString: string | undefined)` and added an early-return guard (`if (!dateString) return nullDisplay;`) before the `new Date()` call.

## Testing

1. Seed or locate a `UserProfile` record with `NULL` values for `created_at` and/or `updated_at`.
2. Open the dashboard and navigate to the User Profile page.
3. Verify the affected date cells display the consistent null placeholder (e.g., `—`) instead of `"Invalid Date"` or a blank.
4. Verify that profiles with valid timestamps continue to display correctly formatted dates via `toLocaleString()`.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*