### PR TITLE
feat(examples): Add MoonBit client example for PowerMem HTTP API

### DIFF
--- a/examples/moonbit/.gitignore
+++ b/examples/moonbit/.gitignore
@@ -1,0 +1,2 @@
+_build/
+.mooncakes/

--- a/examples/moonbit/README.md
+++ b/examples/moonbit/README.md
@@ -1,0 +1,263 @@
+# PowerMem MoonBit Client Example
+
+A simple, lightweight MoonBit client example demonstrating how to integrate PowerMem's intelligent memory capabilities into MoonBit applications.
+
+## Prerequisites
+
+1. **MoonBit toolchain** installed from <https://www.moonbitlang.com>
+2. **PowerMem API Server** running (see [API Server Documentation](../../docs/api/0005-api_server.md))
+3. **LLM/Embedding API Key** — Required for creating memories and semantic search. Configure in the server's `.env` file
+
+> **Note**: PowerMem uses **SQLite** by default, no OceanBase installation required. SQLite is perfect for development and testing.
+
+## Quick Start
+
+### 1. Start the PowerMem Server
+
+> **Note**:
+> - Default database is **SQLite** (no OceanBase required)
+> - Authentication is **disabled** by default (`POWERMEM_SERVER_AUTH_ENABLED=false`)
+
+```bash
+pip install powermem
+powermem-server --host 0.0.0.0 --port 8000
+```
+
+#### Configure API Keys (Required)
+
+Configure the server's `.env` file with your LLM/Embedding provider API key:
+
+```bash
+# Copy from .env.example if not exists
+cp .env.example .env
+
+# Edit .env and set your API keys:
+LLM_API_KEY=your-llm-api-key                # Required for intelligent memory extraction
+EMBEDDING_API_KEY=your-embedding-api-key    # Required for creating memories and search
+
+# Database (SQLite is default, no changes needed)
+DATABASE_PROVIDER=sqlite
+SQLITE_PATH=./data/powermem_dev.db
+```
+
+#### Enable Authentication (Optional)
+
+To enable API key authentication, configure the server's `.env` file:
+
+```bash
+# In your .env file
+POWERMEM_SERVER_AUTH_ENABLED=true
+POWERMEM_SERVER_API_KEYS=your-api-key-123,another-key-456
+```
+
+### 2. Run the MoonBit Example
+
+```bash
+cd examples/moonbit
+
+# Run with default settings (localhost:8000, no auth).
+# `moon run` fetches dependencies on first invocation.
+moon run --target native .
+
+# Or with custom configuration
+# Base URL of the PowerMem API server
+export POWERMEM_BASE_URL=http://localhost:8000
+# API key for authentication (if server auth enabled)
+export POWERMEM_API_KEY=your-api-key-123
+moon run --target native .
+```
+
+## API Operations
+
+### 1. Health Check
+
+Check the health status of the PowerMem API server. This is a public endpoint that does not require authentication.
+
+```moonbit
+let client = Client::new("http://localhost:8000", api_key="your-api-key")
+let health = client.health()
+println("Status: \{health.status}")
+```
+
+**Example Output:**
+
+```
+  status: healthy
+```
+
+### 2. System Status
+
+Get runtime information about the server — version, status, storage backend, and the active LLM provider.
+
+```moonbit
+let s = client.system_status()
+println("Version: \{s.version}")
+println("Status:  \{s.status}")
+```
+
+**Example Output:**
+
+```
+  version: 1.1.0
+  status:  operational
+  storage: sqlite
+  llm:     ollama
+```
+
+### 3. Create Memory
+
+Create a new memory. When `infer` is enabled, PowerMem uses LLM to automatically extract multiple facts from the content and stores them as separate memories.
+
+```moonbit
+let metadata = Json::object({
+  "source": "conversation".to_json(),
+  "importance": "high".to_json(),
+})
+let memories = client.create_memory(
+  content="User likes coffee and goes to Starbucks every morning. They prefer latte.",
+  user_id="user-123",
+  agent_id="agent-456",
+  metadata~,
+  infer=true,
+)
+for m in memories {
+  println("Created: \{m.id} - \{m.content}")
+}
+```
+
+**Example Output:**
+
+```
+  created 3 memory(ies):
+    [1] 672687041732935680: User is a coffee drinker
+    [2] 672687041741324288: User has preference for latte
+    [3] 672687041749712896: User goes to Starbucks every morning
+```
+
+### 4. List Memories
+
+Retrieve a list of memories with pagination and filtering by user or agent.
+
+```moonbit
+let list = client.list_memories(user_id="user-123", limit=10)
+println("Total: \{list.total} memories")
+for m in list.memories {
+  println("  \{m.id}: \{m.content}")
+}
+```
+
+**Example Output:**
+
+```
+  total: 3, showing 3:
+    [1] 672687041749712896: User goes to Starbucks every morning
+    [2] 672687041741324288: User has preference for latte
+    [3] 672687041732935680: User is a coffee drinker
+```
+
+### 5. Search Memories
+
+Perform semantic search to find relevant memories based on natural language queries. Results are ranked by relevance score.
+
+```moonbit
+let resp = client.search_memories(
+  query="What beverages does the user like?",
+  user_id="user-123",
+  limit=5,
+)
+println("Total: \{resp.total}")
+for r in resp.results {
+  let score = match r.score {
+    Some(s) => s.to_string()
+    None => "-"
+  }
+  println("\{r.memory_id} score=\{score}: \{r.content}")
+}
+```
+
+**Example Output:**
+
+```
+  query: What beverages does the user like?
+  total: 3
+    [1] 672687041732935680 score=0.7046449923421033: User is a coffee drinker
+    [2] 672687041741324288 score=0.6876197672707064: User has preference for latte
+    [3] 672687041749712896 score=0.5320688635347244: User goes to Starbucks every morning
+```
+
+### 6. Update Memory
+
+Update an existing memory's content and/or metadata. The memory ID is required.
+
+```moonbit
+let updated = client.update_memory(
+  memory_id="672687041732935680",
+  content="User loves espresso and visits Starbucks daily",
+)
+println("Updated \{updated.id}: \{updated.content}")
+match updated.updated_at {
+  Some(ts) => println("At: \{ts}")
+  None => ()
+}
+```
+
+**Example Output:**
+
+```
+  updated 672687041732935680: User loves espresso and visits Starbucks daily
+  at: 2026-04-21T05:45:47.342816Z
+```
+
+### 7. Delete Memory
+
+Permanently delete a memory by its ID.
+
+```moonbit
+let deleted = client.delete_memory(memory_id="672687041732935680")
+println("Deleted \{deleted.memory_id}")
+```
+
+**Example Output:**
+
+```
+  deleted 672687041732935680
+```
+
+## Handling 64-bit Memory IDs
+
+PowerMem uses 64-bit Snowflake integers for memory IDs, which exceed MoonBit's 32-bit `Int`. The server sidesteps this by serializing `memory_id` as a JSON string, and this client mirrors that choice:
+
+```moonbit
+struct Memory {
+  id : String        // always a string — no precision loss, ready for paths and URLs
+  content : String
+  // ...
+}
+```
+
+You can pass these IDs directly to `update_memory`, `delete_memory`, and path-building helpers without any conversion.
+
+## Error Handling
+
+The client raises a typed `ApiError` suberror with specific variants so callers can distinguish transport failures from server-side rejections:
+
+```moonbit
+suberror ApiError {
+  Http(status_code~ : Int, body~ : String)   // 4xx/5xx with response body
+  Server(String)                             // success=false envelope from the API
+  Parse(String)                              // malformed JSON or unexpected shape
+  Request(String)                            // connection / transport failure
+} derive(Debug)
+```
+
+Use a `try`/`catch` block to handle each case. Pattern-match the caught value to branch on specific variants:
+
+```moonbit
+try {
+  let memories = client.create_memory(content="...", user_id="user-123")
+  println("created \{memories.length()}")
+} catch {
+  Http(status_code=401, ..) => println("auth failed — check POWERMEM_API_KEY")
+  e => println("other failure: \{@debug.to_string(e)}")
+}
+```

--- a/examples/moonbit/client.mbt
+++ b/examples/moonbit/client.mbt
@@ -1,0 +1,267 @@
+///|
+/// Minimal PowerMem HTTP client. Mirrors examples/go/client.go in shape —
+/// inline, self-contained, no dependencies outside moonbitlang/core and
+/// moonbitlang/async.
+
+///|
+priv suberror ApiError {
+  Http(status_code~ : Int, body~ : String)
+  Server(String)
+  Parse(String)
+  Request(String)
+} derive(Debug)
+
+///|
+priv struct Client {
+  base_url : String
+  api_key : String?
+}
+
+///|
+fn Client::new(base_url : String, api_key? : String) -> Client {
+  { base_url, api_key }
+}
+
+// -----------------------------------------------------------------------------
+// HTTP plumbing
+// -----------------------------------------------------------------------------
+
+///|
+fn Client::headers(self : Client) -> Map[String, String] {
+  let h : Map[String, String] = { "Content-Type": "application/json" }
+  match self.api_key {
+    Some(key) => h["X-API-Key"] = key
+    None => ()
+  }
+  h
+}
+
+///|
+/// Issue a request whose response envelope is `{success, data, message, ...}`.
+/// Returns the unwrapped `data` field on success.
+async fn Client::do_request(
+  self : Client,
+  meth : @http.RequestMethod,
+  path : String,
+  query : Array[(String, String)],
+  body : Json?,
+) -> Json raise ApiError {
+  let full_path = "/api/v1" + path + encode_query(query)
+  let http = @http.Client::new(self.base_url, headers=self.headers()) catch {
+    e => raise Request("\{e}")
+  }
+  let resp = try {
+    match (meth, body) {
+      (Get, _) => http.get(full_path)
+      (Post, Some(b)) => http.post(full_path, b.stringify())
+      (Post, None) => http.post(full_path, "")
+      (Put, Some(b)) => http.put(full_path, b.stringify())
+      (Put, None) => http.put(full_path, "")
+      (_, Some(b)) => {
+        http.request(meth, full_path)
+        http.write(b.stringify())
+        http.end_request()
+      }
+      (_, None) => {
+        http.request(meth, full_path)
+        http.end_request()
+      }
+    }
+  } catch {
+    e => raise Request("\{e}")
+  }
+  let data = http.read_all() catch { e => raise Parse("\{e}") }
+  http.close()
+  let body_text = data.text() catch { e => raise Parse("\{e}") }
+  if resp.code >= 400 {
+    raise Http(status_code=resp.code, body=body_text)
+  }
+  if body_text == "" {
+    return Json::object({})
+  }
+  let json = @json.parse(body_text) catch { e => raise Parse("\{e}") }
+  unwrap_envelope(json)
+}
+
+///|
+fn unwrap_envelope(json : Json) -> Json raise ApiError {
+  match json {
+    Object({ "success": False, "message": String(msg), .. }) =>
+      raise Server(msg)
+    Object({ "success": False, .. }) => raise Server("API request failed")
+    Object({ "data": data, .. }) => data
+    _ => json
+  }
+}
+
+///|
+fn[T : @json.FromJson] parse_as(json : Json) -> T raise ApiError {
+  @json.from_json(json) catch {
+    e => raise Parse("\{e}")
+  }
+}
+
+///|
+/// Percent-encode a value for use in a URL query string. Keeps the unreserved
+/// set [A-Z a-z 0-9 - _ . ~] as-is and escapes everything else.
+fn percent_encode(value : String) -> String {
+  let bytes = @utf8.encode(value)
+  let out = StringBuilder::new()
+  for i in 0..<bytes.length() {
+    let code = bytes.unsafe_get(i).to_int()
+    let is_unreserved = (code >= 0x30 && code <= 0x39) ||
+      (code >= 0x41 && code <= 0x5A) ||
+      (code >= 0x61 && code <= 0x7A) ||
+      code == 0x2D ||
+      code == 0x2E ||
+      code == 0x5F ||
+      code == 0x7E
+    if is_unreserved {
+      out.write_char(Int::unsafe_to_char(code))
+    } else {
+      out.write_char('%')
+      out.write_char(hex_digit(code / 16))
+      out.write_char(hex_digit(code % 16))
+    }
+  }
+  out.to_string()
+}
+
+///|
+fn hex_digit(n : Int) -> Char {
+  if n < 10 {
+    Int::unsafe_to_char('0'.to_int() + n)
+  } else {
+    Int::unsafe_to_char('A'.to_int() + (n - 10))
+  }
+}
+
+///|
+fn encode_query(pairs : Array[(String, String)]) -> String {
+  if pairs.is_empty() {
+    return ""
+  }
+  let out = StringBuilder::new()
+  out.write_char('?')
+  for i, pair in pairs {
+    if i > 0 {
+      out.write_char('&')
+    }
+    out.write_string(percent_encode(pair.0))
+    out.write_char('=')
+    out.write_string(percent_encode(pair.1))
+  }
+  out.to_string()
+}
+
+///|
+fn json_object(entries : Array[(String, Json?)]) -> Json {
+  let map : Map[String, Json] = {}
+  for entry in entries {
+    match entry {
+      (key, Some(value)) => map[key] = value
+      _ => ()
+    }
+  }
+  Json::object(map)
+}
+
+// -----------------------------------------------------------------------------
+// System endpoints
+// -----------------------------------------------------------------------------
+
+///|
+async fn Client::health(self : Client) -> HealthStatus raise ApiError {
+  parse_as(self.do_request(Get, "/system/health", [], None))
+}
+
+///|
+async fn Client::system_status(self : Client) -> SystemStatus raise ApiError {
+  parse_as(self.do_request(Get, "/system/status", [], None))
+}
+
+// -----------------------------------------------------------------------------
+// Memory CRUD
+// -----------------------------------------------------------------------------
+
+///|
+async fn Client::create_memory(
+  self : Client,
+  content~ : String,
+  user_id? : String,
+  agent_id? : String,
+  metadata? : Json,
+  infer? : Bool,
+) -> Array[Memory] raise ApiError {
+  let body = json_object([
+    ("content", Some(content.to_json())),
+    ("user_id", user_id.map(fn(s) { s.to_json() })),
+    ("agent_id", agent_id.map(fn(s) { s.to_json() })),
+    ("metadata", metadata),
+    ("infer", infer.map(fn(b) { b.to_json() })),
+  ])
+  parse_as(self.do_request(Post, "/memories", [], Some(body)))
+}
+
+///|
+async fn Client::list_memories(
+  self : Client,
+  user_id? : String,
+  agent_id? : String,
+  limit? : Int,
+  offset? : Int,
+) -> MemoryList raise ApiError {
+  let query : Array[(String, String)] = []
+  if user_id is Some(v) {
+    query.push(("user_id", v))
+  }
+  if agent_id is Some(v) {
+    query.push(("agent_id", v))
+  }
+  if limit is Some(v) {
+    query.push(("limit", v.to_string()))
+  }
+  if offset is Some(v) {
+    query.push(("offset", v.to_string()))
+  }
+  parse_as(self.do_request(Get, "/memories", query, None))
+}
+
+///|
+async fn Client::search_memories(
+  self : Client,
+  query~ : String,
+  user_id? : String,
+  agent_id? : String,
+  limit? : Int,
+) -> SearchResponse raise ApiError {
+  let body = json_object([
+    ("query", Some(query.to_json())),
+    ("user_id", user_id.map(fn(s) { s.to_json() })),
+    ("agent_id", agent_id.map(fn(s) { s.to_json() })),
+    ("limit", limit.map(fn(n) { n.to_json() })),
+  ])
+  parse_as(self.do_request(Post, "/memories/search", [], Some(body)))
+}
+
+///|
+async fn Client::update_memory(
+  self : Client,
+  memory_id~ : String,
+  content? : String,
+  metadata? : Json,
+) -> Memory raise ApiError {
+  let body = json_object([
+    ("content", content.map(fn(s) { s.to_json() })),
+    ("metadata", metadata),
+  ])
+  parse_as(self.do_request(Put, "/memories/\{memory_id}", [], Some(body)))
+}
+
+///|
+async fn Client::delete_memory(
+  self : Client,
+  memory_id~ : String,
+) -> DeletedMemory raise ApiError {
+  parse_as(self.do_request(Delete, "/memories/\{memory_id}", [], None))
+}

--- a/examples/moonbit/main.mbt
+++ b/examples/moonbit/main.mbt
@@ -1,0 +1,235 @@
+///|
+/// Runnable demo of the PowerMem HTTP API from MoonBit.
+///
+/// Usage:
+///   moon run --target native examples/moonbit
+///
+/// Environment variables:
+///   POWERMEM_BASE_URL  Base URL of the server (default: http://localhost:8000)
+///   POWERMEM_API_KEY   API key (optional, required only if server auth is on)
+
+///|
+async fn main {
+  let banner = "=".repeat(60)
+  println(banner)
+  println("PowerMem MoonBit Client Example")
+  println(banner)
+  let client = init_client()
+  run_examples(client)
+  println("")
+  println(banner)
+  println("All examples completed.")
+  println(banner)
+}
+
+///|
+fn init_client() -> Client {
+  let base_url = match @env.get_env_var("POWERMEM_BASE_URL") {
+    Some(v) => v
+    None => "http://localhost:8000"
+  }
+  let api_key = @env.get_env_var("POWERMEM_API_KEY")
+  println("")
+  println("Configuration:")
+  println("  Base URL: \{base_url}")
+  match api_key {
+    Some(_) => println("  API Key:  (set)")
+    None => println("  API Key:  (not set)")
+  }
+  match api_key {
+    Some(key) => Client::new(base_url, api_key=key)
+    None => Client::new(base_url)
+  }
+}
+
+///|
+async fn run_examples(client : Client) -> Unit {
+  let user_id = "moonbit-example-user"
+  let agent_id = "moonbit-example-agent"
+
+  example_health(client)
+  example_system_status(client)
+  let created = example_create(client, user_id~, agent_id~)
+  example_list(client, user_id~)
+  example_search(client, user_id~, agent_id~)
+  match created {
+    Some(memories) if memories.length() > 0 => {
+      let first = memories[0]
+      example_update(client, memory_id=first.id)
+      example_delete(client, memory_id=first.id)
+    }
+    _ => {
+      section("6. Update Memory")
+      println("  skipped (no memories created)")
+      section("7. Delete Memory")
+      println("  skipped (no memories created)")
+    }
+  }
+}
+
+///|
+fn section(title : String) -> Unit {
+  println("")
+  println("-".repeat(40))
+  println(title)
+  println("-".repeat(40))
+}
+
+///|
+async fn example_health(client : Client) -> Unit {
+  section("1. Health Check")
+  try {
+    let h = client.health()
+    println("  status: \{h.status}")
+  } catch {
+    e => println("  failed: " + @debug.to_string(e))
+  }
+}
+
+///|
+async fn example_system_status(client : Client) -> Unit {
+  section("2. System Status")
+  try {
+    let s = client.system_status()
+    println("  version: \{s.version}")
+    println("  status:  \{s.status}")
+    match s.storage_type {
+      Some(v) => println("  storage: \{v}")
+      None => ()
+    }
+    match s.llm_provider {
+      Some(v) => println("  llm:     \{v}")
+      None => ()
+    }
+  } catch {
+    e => println("  failed: " + @debug.to_string(e))
+  }
+}
+
+///|
+async fn example_create(
+  client : Client,
+  user_id~ : String,
+  agent_id~ : String,
+) -> Array[Memory]? {
+  section("3. Create Memory")
+  let metadata = Json::object({
+    "source": "moonbit-client-example".to_json(),
+    "importance": "high".to_json(),
+  })
+  try
+    client.create_memory(
+      content="User likes coffee and goes to Starbucks every morning. They prefer latte.",
+      user_id~,
+      agent_id~,
+      metadata~,
+      infer=true,
+    )
+  catch {
+    e => {
+      println("  skipped: " + @debug.to_string(e))
+      None
+    }
+  } noraise {
+    memories => {
+      println("  created \{memories.length()} memory(ies):")
+      for i, m in memories {
+        println("    [\{i + 1}] \{m.id}: \{m.content}")
+      }
+      Some(memories)
+    }
+  }
+}
+
+///|
+async fn example_list(client : Client, user_id~ : String) -> Unit {
+  section("4. List Memories")
+  try {
+    let list = client.list_memories(user_id~, limit=10)
+    println("  total: \{list.total}, showing \{list.memories.length()}:")
+    for i, m in list.memories {
+      println("    [\{i + 1}] \{m.id}: \{truncate(m.content, 60)}")
+    }
+  } catch {
+    e => println("  skipped: " + @debug.to_string(e))
+  }
+}
+
+///|
+async fn example_search(
+  client : Client,
+  user_id~ : String,
+  agent_id~ : String,
+) -> Unit {
+  section("5. Search Memories")
+  try {
+    let resp = client.search_memories(
+      query="What beverages does the user like?",
+      user_id~,
+      agent_id~,
+      limit=5,
+    )
+    println("  query: \{resp.query}")
+    println("  total: \{resp.total}")
+    for i, r in resp.results {
+      let score = match r.score {
+        Some(s) => s.to_string()
+        None => "-"
+      }
+      println(
+        "    [\{i + 1}] \{r.memory_id} score=\{score}: \{truncate(r.content, 60)}",
+      )
+    }
+  } catch {
+    e => println("  skipped: " + @debug.to_string(e))
+  }
+}
+
+///|
+async fn example_update(client : Client, memory_id~ : String) -> Unit {
+  section("6. Update Memory")
+  try {
+    let m = client.update_memory(
+      memory_id~,
+      content="User loves espresso and visits Starbucks daily",
+    )
+    println("  updated \{m.id}: \{m.content}")
+    match m.updated_at {
+      Some(ts) => println("  at: \{ts}")
+      None => ()
+    }
+  } catch {
+    e => println("  skipped: " + @debug.to_string(e))
+  }
+}
+
+///|
+async fn example_delete(client : Client, memory_id~ : String) -> Unit {
+  section("7. Delete Memory")
+  try {
+    let d = client.delete_memory(memory_id~)
+    println("  deleted \{d.memory_id}")
+  } catch {
+    e => println("  skipped: " + @debug.to_string(e))
+  }
+}
+
+///|
+/// Truncate for display, measured in Unicode characters rather than UTF-16
+/// code units. Appends "..." when truncation happens. `offset_of_nth_char`
+/// keeps surrogate pairs intact — raw offset slicing on a String can split
+/// them and abort.
+fn truncate(s : String, n : Int) -> String {
+  if !s.char_length_ge(n + 1) {
+    return s
+  }
+  let suffix = "..."
+  let keep = n - suffix.char_length()
+  if keep <= 0 {
+    return suffix
+  }
+  match s.offset_of_nth_char(keep) {
+    Some(off) => s.view(end_offset=off).to_string() + suffix
+    None => s
+  }
+}

--- a/examples/moonbit/models.mbt
+++ b/examples/moonbit/models.mbt
@@ -1,0 +1,186 @@
+///|
+/// Request/response types for the PowerMem HTTP API. Each one has manual
+/// `ToJson` / `FromJson` impls so the example runs on the MoonBit core +
+/// async packages only — no third-party dependencies.
+
+///|
+priv struct Memory {
+  id : String
+  content : String
+  updated_at : String?
+}
+
+///|
+impl @json.FromJson for Memory with from_json(json, path) {
+  let obj = expect_object(json, path, "Memory")
+  {
+    id: require_string(obj, "id", path),
+    content: require_string(obj, "content", path),
+    updated_at: opt_string(obj, "updated_at"),
+  }
+}
+
+///|
+priv struct MemoryList {
+  memories : Array[Memory]
+  total : Int
+}
+
+///|
+impl @json.FromJson for MemoryList with from_json(json, path) {
+  let obj = expect_object(json, path, "MemoryList")
+  {
+    memories: require_array(obj, "memories", path),
+    total: require_int(obj, "total", path),
+  }
+}
+
+///|
+priv struct SearchResult {
+  memory_id : String
+  content : String
+  score : Double?
+}
+
+///|
+impl @json.FromJson for SearchResult with from_json(json, path) {
+  let obj = expect_object(json, path, "SearchResult")
+  {
+    memory_id: require_string(obj, "memory_id", path),
+    content: require_string(obj, "content", path),
+    score: opt_double(obj, "score"),
+  }
+}
+
+///|
+priv struct SearchResponse {
+  results : Array[SearchResult]
+  total : Int
+  query : String
+}
+
+///|
+impl @json.FromJson for SearchResponse with from_json(json, path) {
+  let obj = expect_object(json, path, "SearchResponse")
+  {
+    results: require_array(obj, "results", path),
+    total: require_int(obj, "total", path),
+    query: require_string(obj, "query", path),
+  }
+}
+
+///|
+priv struct HealthStatus {
+  status : String
+}
+
+///|
+impl @json.FromJson for HealthStatus with from_json(json, path) {
+  let obj = expect_object(json, path, "HealthStatus")
+  { status: require_string(obj, "status", path) }
+}
+
+///|
+priv struct SystemStatus {
+  version : String
+  status : String
+  storage_type : String?
+  llm_provider : String?
+}
+
+///|
+impl @json.FromJson for SystemStatus with from_json(json, path) {
+  let obj = expect_object(json, path, "SystemStatus")
+  {
+    version: require_string(obj, "version", path),
+    status: require_string(obj, "status", path),
+    storage_type: opt_string(obj, "storage_type"),
+    llm_provider: opt_string(obj, "llm_provider"),
+  }
+}
+
+///|
+priv struct DeletedMemory {
+  memory_id : String
+}
+
+///|
+impl @json.FromJson for DeletedMemory with from_json(json, path) {
+  let obj = expect_object(json, path, "DeletedMemory")
+  { memory_id: require_string(obj, "memory_id", path) }
+}
+
+// -----------------------------------------------------------------------------
+// Small JSON helpers used by the manual FromJson impls above.
+// -----------------------------------------------------------------------------
+
+///|
+fn expect_object(
+  json : Json,
+  path : @json.JsonPath,
+  type_name : String,
+) -> Map[String, Json] raise @json.JsonDecodeError {
+  match json {
+    Object(obj) => obj
+    _ =>
+      raise @json.JsonDecodeError((path, type_name + ": expected JSON object"))
+  }
+}
+
+///|
+fn require_string(
+  obj : Map[String, Json],
+  key : String,
+  path : @json.JsonPath,
+) -> String raise @json.JsonDecodeError {
+  match obj.get(key) {
+    Some(String(s)) => s
+    _ => raise @json.JsonDecodeError((path.add_key(key), "expected string"))
+  }
+}
+
+///|
+fn require_int(
+  obj : Map[String, Json],
+  key : String,
+  path : @json.JsonPath,
+) -> Int raise @json.JsonDecodeError {
+  match obj.get(key) {
+    Some(Number(n, ..)) => n.to_int()
+    _ => raise @json.JsonDecodeError((path.add_key(key), "expected number"))
+  }
+}
+
+///|
+fn[T : @json.FromJson] require_array(
+  obj : Map[String, Json],
+  key : String,
+  path : @json.JsonPath,
+) -> Array[T] raise @json.JsonDecodeError {
+  match obj.get(key) {
+    Some(Array(items)) => {
+      let result : Array[T] = []
+      for i, item in items {
+        result.push(@json.from_json(item, path=path.add_key(key).add_index(i)))
+      }
+      result
+    }
+    _ => raise @json.JsonDecodeError((path.add_key(key), "expected array"))
+  }
+}
+
+///|
+fn opt_string(obj : Map[String, Json], key : String) -> String? {
+  match obj.get(key) {
+    Some(String(s)) => Some(s)
+    _ => None
+  }
+}
+
+///|
+fn opt_double(obj : Map[String, Json], key : String) -> Double? {
+  match obj.get(key) {
+    Some(Number(n, ..)) => Some(n)
+    _ => None
+  }
+}

--- a/examples/moonbit/moon.mod.json
+++ b/examples/moonbit/moon.mod.json
@@ -1,0 +1,10 @@
+{
+  "name": "oceanbase/powermem-example-moonbit",
+  "version": "0.1.0",
+  "deps": {
+    "moonbitlang/async": "0.18.0"
+  },
+  "license": "Apache-2.0",
+  "description": "MoonBit client example for the PowerMem HTTP API",
+  "preferred-target": "native"
+}

--- a/examples/moonbit/moon.pkg
+++ b/examples/moonbit/moon.pkg
@@ -1,0 +1,15 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/io",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/encoding/utf8" @utf8,
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+}
+
+supported_targets = "native"
+
+options(
+  "is-main": true,
+)

--- a/examples/moonbit/pkg.generated.mbti
+++ b/examples/moonbit/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "oceanbase/powermem-example-moonbit"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary

This PR adds a simple, lightweight MoonBit client example demonstrating how to integrate PowerMem's intelligent memory capabilities into MoonBit applications.

## Solution Description

It mirrors the structure of `examples/go/` — a self-contained, runnable demo with an inline HTTP client, inline request/response types, and a single `main` that walks through the core API surface. No dependencies beyond `moonbitlang/core` and `moonbitlang/async` (MoonBit's stdlib-tier packages), so the directory is copy-out runnable.

Uses the same `POWERMEM_BASE_URL` / `POWERMEM_API_KEY` environment variables as the Go example.

Tested against a local server (`powermem-server --host 0.0.0.0 --port 8000`, SQLite + Ollama.