### PR TITLE
feat(config): add env var support for custom extraction/update/import…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -357,3 +357,18 @@ POWERMEM_SERVER_CORS_ENABLED=true
 # CORS allowed origins (comma-separated, use * for all origins)
 # Example: POWERMEM_SERVER_CORS_ORIGINS=http://localhost:3000,https://example.com
 POWERMEM_SERVER_CORS_ORIGINS=*
+
+# =============================================================================
+# 16. Custom Prompts Configuration (Optional)
+# =============================================================================
+# Override the built-in prompts used in the memory extraction pipeline.
+# Leave commented out to use the default prompts.
+
+# Custom prompt for fact extraction (replaces the default FACT_RETRIEVAL_PROMPT)
+# POWERMEM_CUSTOM_FACT_EXTRACTION_PROMPT=
+
+# Custom prompt for memory update decisions (replaces the default UPDATE_MEMORY_PROMPT)
+# POWERMEM_CUSTOM_UPDATE_MEMORY_PROMPT=
+
+# Custom prompt for importance evaluation (replaces the default importance scoring prompt)
+# POWERMEM_CUSTOM_IMPORTANCE_EVALUATION_PROMPT=

--- a/docs/guides/0003-configuration.md
+++ b/docs/guides/0003-configuration.md
@@ -1195,3 +1195,30 @@ memory = Memory(config=config)
 ```
 
 ---
+
+## Custom Prompts via Environment Variables
+
+The three core pipeline prompts can be overridden via environment variables without changing any code. This is useful for deployment environments or quick experimentation.
+
+| Environment Variable | SDK Config Key | Description |
+|---|---|---|
+| `POWERMEM_CUSTOM_FACT_EXTRACTION_PROMPT` | `custom_fact_extraction_prompt` | Overrides the default fact/memory extraction prompt |
+| `POWERMEM_CUSTOM_UPDATE_MEMORY_PROMPT` | `custom_update_memory_prompt` | Overrides the default memory update decision prompt |
+| `POWERMEM_CUSTOM_IMPORTANCE_EVALUATION_PROMPT` | `custom_importance_evaluation_prompt` | Overrides the default importance scoring prompt |
+
+**Example `.env`:**
+```bash
+POWERMEM_CUSTOM_FACT_EXTRACTION_PROMPT=You are an information extraction expert. Output JSON: {"facts": [...]}
+```
+
+**Usage:**
+```python
+from powermem import create_memory
+
+# Prompts are loaded automatically from env vars
+memory = create_memory()
+```
+
+If the env var is not set, the system falls back to the built-in default prompt. For detailed prompt examples and guidelines, see [Custom Prompts Usage Guide](0004-custom_prompts_usage.md).
+
+---

--- a/docs/guides/0004-custom_prompts_usage.md
+++ b/docs/guides/0004-custom_prompts_usage.md
@@ -127,7 +127,29 @@ Result: Do not delete (Alice can love both pizza and burger)
 memory = Memory(config=config)
 ```
 
-### Method 2: Using Dictionary Configuration
+### Method 2: Using Environment Variables
+
+Set environment variables in your `.env` file or shell. These are picked up automatically by `auto_config()` / `create_memory()` without any code changes.
+
+```bash
+# .env
+POWERMEM_CUSTOM_FACT_EXTRACTION_PROMPT=You are an information extraction expert. Extract user preferences, important facts, and plans from conversations. Output JSON format: {"facts": ["fact1", "fact2"]}
+
+POWERMEM_CUSTOM_UPDATE_MEMORY_PROMPT=You are a memory manager. Compare new facts with existing memories and decide: ADD, UPDATE, DELETE, or NONE.
+
+POWERMEM_CUSTOM_IMPORTANCE_EVALUATION_PROMPT=Evaluate the importance of memory content on a scale from 0.0 to 1.0. Return JSON containing importance_score and reasoning.
+```
+
+```python
+from powermem import create_memory
+
+# Prompts are loaded automatically from env vars
+memory = create_memory()
+```
+
+> **Note:** For multi-line prompts in `.env` files, use a single line or load the value programmatically. Environment variable configuration is best suited for short, single-line prompt overrides or deployment environments where config files are not convenient.
+
+### Method 3: Using Dictionary Configuration
 
 ```python
 from powermem import Memory

--- a/src/powermem/config_loader.py
+++ b/src/powermem/config_loader.py
@@ -585,6 +585,25 @@ class GraphStoreSettings(_BasePowermemSettings):
         return graph_store_config
 
 
+class CustomPromptsSettings(_BasePowermemSettings):
+    model_config = settings_config("POWERMEM_CUSTOM_")
+
+    fact_extraction_prompt: Optional[str] = Field(default=None)
+    update_memory_prompt: Optional[str] = Field(default=None)
+    importance_evaluation_prompt: Optional[str] = Field(default=None)
+
+    def to_config(self) -> Dict[str, Any]:
+        """Return non-None custom prompt fields keyed for MemoryConfig."""
+        result: Dict[str, Any] = {}
+        if self.fact_extraction_prompt:
+            result["custom_fact_extraction_prompt"] = self.fact_extraction_prompt
+        if self.update_memory_prompt:
+            result["custom_update_memory_prompt"] = self.update_memory_prompt
+        if self.importance_evaluation_prompt:
+            result["custom_importance_evaluation_prompt"] = self.importance_evaluation_prompt
+        return result
+
+
 class PowermemSettings:
     _COMPONENTS = {
         "vector_store": ("database", DatabaseSettings),
@@ -608,6 +627,7 @@ class PowermemSettings:
             setattr(self, attr_name, component_cls())
         self.graph_store = GraphStoreSettings()
         self.sparse_embedder = SparseEmbedderSettings()
+        self.custom_prompts = CustomPromptsSettings()
 
     def to_config(self) -> Dict[str, Any]:
         config = {}
@@ -623,6 +643,10 @@ class PowermemSettings:
         sparse_embedder_config = self.sparse_embedder.to_config()
         if sparse_embedder_config:
             config["sparse_embedder"] = sparse_embedder_config
+
+        custom_prompts_config = self.custom_prompts.to_config()
+        if custom_prompts_config:
+            config.update(custom_prompts_config)
 
         # Sync embedding_model_dims from embedder to vector_store and graph_store
         embedder_config = config.get("embedder", {})


### PR DESCRIPTION
…ance prompts

Three custom prompts were only configurable via SDK dict config. Add env var support following the existing GraphStoreSettings pattern:

  POWERMEM_CUSTOM_FACT_EXTRACTION_PROMPT
  POWERMEM_CUSTOM_UPDATE_MEMORY_PROMPT
  POWERMEM_CUSTOM_IMPORTANCE_EVALUATION_PROMPT

Adds CustomPromptsSettings class with POWERMEM_CUSTOM_ prefix. Keys are merged at top level of the config dict, matching where Memory.__init__ reads them. Unset vars produce no keys — default prompts are preserved.

Also updates .env.example (section 16) and both docs guides (0003-configuration.md, 0004-custom_prompts_usage.md) to document the new env vars and usage.
