### PR TITLE
fix(dashboard): remove incorrect no-data toast description on refresh

### DIFF
--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -139,9 +139,7 @@ function OverviewPage() {
         refetchStatus(),
         refetchQuality(),
       ]);
-      toast.success(t("dashboard.refresh"), {
-        description: t("common.noData"),
-      });
+      toast.success(t("dashboard.refresh"));
     } catch (error) {
       toast.error(t("common.error"), {
         description: t("common.tryAgain"),


### PR DESCRIPTION
handleRefresh was always showing t("common.noData") as the toast description after a successful refresh, regardless of data presence. Remove the misleading description from the success toast.

Fixes #914
