### PR TITLE
fix(config): resolve sparse_embedder provider from dict on MemoryConf…

### DIFF
--- a/src/powermem/configs.py
+++ b/src/powermem/configs.py
@@ -6,7 +6,7 @@ of the memory system.
 """
 
 from typing import Optional, Dict, Any
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from powermem.integrations.embeddings.config.base import BaseEmbedderConfig
 from powermem.integrations.embeddings.config.providers import OpenAIEmbeddingConfig
@@ -265,6 +265,19 @@ class MemoryConfig(BaseModel):
         description="Configuration for query rewrite module",
         default=None,
     )
+
+    @field_validator('sparse_embedder', mode='before')
+    @classmethod
+    def resolve_sparse_embedder(cls, v):
+        if isinstance(v, dict) and 'provider' in v:
+            provider = v['provider'].lower()
+            config_dict = v.get('config', {})
+            config_cls = (
+                BaseSparseEmbedderConfig.get_provider_config_cls(provider)
+                or BaseSparseEmbedderConfig
+            )
+            return config_cls(**config_dict)
+        return v
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/src/powermem/configs.py
+++ b/src/powermem/configs.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, field_validator
 from powermem.integrations.embeddings.config.base import BaseEmbedderConfig
 from powermem.integrations.embeddings.config.providers import OpenAIEmbeddingConfig
 from powermem.integrations.embeddings.config.sparse_base import BaseSparseEmbedderConfig
+import powermem.integrations.embeddings.config.sparse_providers  # noqa: F401 — ensures sparse provider registry is populated
 from powermem.integrations.llm.config.base import BaseLLMConfig
 from powermem.integrations.llm.config.qwen import QwenConfig
 from powermem.storage.config.base import BaseVectorStoreConfig, BaseGraphStoreConfig


### PR DESCRIPTION
…ig deserialization

When Memory is initialized with a dict config (e.g. from auto_config()), MemoryConfig coerced sparse_embedder dicts into BaseSparseEmbedderConfig, leaving _provider_name=None and all fields empty. Add a field_validator that resolves the correct provider subclass before Pydantic coercion.

Fixes #904

