### PR TITLE
fix(intelligence): unify memory-type classification thresholds

### DIFF
--- a/src/powermem/intelligence/intelligent_memory_manager.py
+++ b/src/powermem/intelligence/intelligent_memory_manager.py
@@ -76,6 +76,15 @@ class IntelligentMemoryManager:
         except Exception as e:
             logger.error(f"Failed to initialize LLM for importance evaluation: {e}")
             logger.warning("Falling back to rule-based evaluation only")
+
+    def _classify_memory_type(self, importance_score: float) -> str:
+        """Map importance score to memory tier using EbbinghausAlgorithm thresholds."""
+        algo = self.ebbinghaus_algorithm
+        if importance_score >= algo.long_term_threshold:
+            return "long_term"
+        if importance_score >= algo.short_term_threshold:
+            return "short_term"
+        return "working"
     
     def process_metadata(
         self,
@@ -104,13 +113,8 @@ class IntelligentMemoryManager:
                 content, metadata, context
             )
             
-            # Determine memory type based on importance
-            if importance_score >= 0.8:
-                memory_type = "long_term"
-            elif importance_score >= 0.5:
-                memory_type = "short_term"
-            else:
-                memory_type = "working"
+            # Determine memory type using the same thresholds as EbbinghausIntelligencePlugin
+            memory_type = self._classify_memory_type(importance_score)
             
             # Process with Ebbinghaus algorithm to get intelligence metadata
             intelligence_metadata = self.ebbinghaus_algorithm.process_memory_metadata(

--- a/tests/unit/intelligence/test_intelligent_memory_manager.py
+++ b/tests/unit/intelligence/test_intelligent_memory_manager.py
@@ -1,0 +1,62 @@
+"""Unit tests for IntelligentMemoryManager memory-type classification."""
+
+from unittest.mock import patch
+
+import pytest
+
+from powermem.intelligence.intelligent_memory_manager import IntelligentMemoryManager
+
+
+@pytest.fixture
+def manager():
+    return IntelligentMemoryManager(
+        {
+            "intelligent_memory": {
+                "short_term_threshold": 0.6,
+                "long_term_threshold": 0.8,
+            }
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "importance_score,expected_type",
+    [
+        (0.4, "working"),
+        (0.55, "working"),
+        (0.6, "short_term"),
+        (0.75, "short_term"),
+        (0.8, "long_term"),
+        (0.95, "long_term"),
+    ],
+)
+def test_classify_memory_type_matches_ebbinghaus_thresholds(
+    manager, importance_score, expected_type
+):
+    assert manager._classify_memory_type(importance_score) == expected_type
+
+
+def test_process_metadata_uses_configured_thresholds(manager):
+    with patch.object(
+        manager.importance_evaluator,
+        "evaluate_importance",
+        return_value=0.55,
+    ):
+        result = manager.process_metadata("User prefers dark theme")
+
+    assert result["intelligence"]["memory_type"] == "working"
+    assert result["intelligence"]["importance_score"] == 0.55
+
+
+def test_process_metadata_respects_custom_short_term_threshold():
+    custom = IntelligentMemoryManager(
+        {"intelligent_memory": {"short_term_threshold": 0.5, "long_term_threshold": 0.8}}
+    )
+    with patch.object(
+        custom.importance_evaluator,
+        "evaluate_importance",
+        return_value=0.55,
+    ):
+        result = custom.process_metadata("test content")
+
+    assert result["intelligence"]["memory_type"] == "short_term"


### PR DESCRIPTION
## Summary

- Replace hardcoded `0.8` / `0.5` thresholds in `IntelligentMemoryManager.process_metadata()` with `EbbinghausAlgorithm.long_term_threshold` and `short_term_threshold`.
- Add `_classify_memory_type()` so Manager and `EbbinghausIntelligencePlugin` use the same configuration source.
- Add unit tests for default (0.6) and custom `short_term_threshold` boundary behavior.

Fixes #935

## Test plan

- [x] `pytest tests/unit/intelligence/test_intelligent_memory_manager.py -v`