### PR TITLE
fix(intelligence): unify review-schedule formulas and stored-query behavior

### DIFF
--- a/src/powermem/config_loader.py
+++ b/src/powermem/config_loader.py
@@ -292,6 +292,8 @@ class IntelligentMemorySettings(_BasePowermemSettings):
     working_threshold: float = Field(default=0.3)
     short_term_threshold: float = Field(default=0.6)
     long_term_threshold: float = Field(default=0.8)
+    review_adjustment_factor: float = Field(default=0.3)
+    review_interval_min_hours: float = Field(default=0.5)
     fallback_to_simple_add: bool = Field(default=False)
 
     def to_config(self) -> Dict[str, Any]:

--- a/src/powermem/configs.py
+++ b/src/powermem/configs.py
@@ -51,6 +51,14 @@ class IntelligentMemoryConfig(BaseModel):
         default=0.8,
         description="Threshold for long-term memory classification"
     )
+    review_adjustment_factor: float = Field(
+        default=0.3,
+        description="How strongly importance shortens review intervals (0-1 scale)",
+    )
+    review_interval_min_hours: float = Field(
+        default=0.5,
+        description="Minimum hours between scheduled reviews",
+    )
     fallback_to_simple_add: bool = Field(
         default=False,
         description="Whether to fallback to simple add mode when intelligent processing fails (no facts extracted or no actions returned)"

--- a/src/powermem/intelligence/ebbinghaus_algorithm.py
+++ b/src/powermem/intelligence/ebbinghaus_algorithm.py
@@ -39,6 +39,9 @@ class EbbinghausAlgorithm:
         
         # Time intervals (in hours)
         self.review_intervals = config.get("review_intervals", [1, 6, 24, 72, 168])
+        # Review schedule: higher importance -> shorter intervals (shared by persist + query)
+        self.review_adjustment_factor = config.get("review_adjustment_factor", 0.3)
+        self.review_interval_min_hours = config.get("review_interval_min_hours", 0.5)
         
         logger.info("EbbinghausAlgorithm initialized")
     
@@ -287,38 +290,31 @@ class EbbinghausAlgorithm:
             logger.error(f"Failed to check archiving: {e}")
             return False
     
-    def get_review_schedule(self, memory: Dict[str, Any]) -> list:
+    def get_review_schedule(
+        self, memory: Dict[str, Any], *, prefer_stored: bool = True
+    ) -> list:
         """
-        Get review schedule for a memory based on Ebbinghaus curve.
-        
+        Get review schedule for a memory.
+
+        When ``prefer_stored`` is True (default), returns persisted
+        ``metadata.intelligence.review_schedule`` if present so query results
+        match the database. Otherwise recomputes using the same formula as
+        ``_generate_review_schedule()`` (via ``_build_review_schedule``).
+
         Args:
-            memory: Memory data
-            
+            memory: Memory data (top-level or metadata fields)
+            prefer_stored: If True, use persisted ISO timestamps when available
+
         Returns:
             List of review times
         """
         try:
-            created_at = memory.get("created_at", get_current_datetime())
-            # Parse string to datetime if needed
-            if isinstance(created_at, str):
-                created_at = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
-            importance = memory.get("importance_score", 0.5)
-            
-            # Adjust intervals based on importance
-            adjusted_intervals = []
-            for interval in self.review_intervals:
-                # Higher importance = shorter intervals
-                adjusted_interval = interval * (1 - importance * 0.5)
-                adjusted_intervals.append(adjusted_interval)
-            
-            # Calculate review times
-            review_times = []
-            for interval in adjusted_intervals:
-                review_time = created_at + timedelta(hours=interval)
-                review_times.append(review_time)
-            
-            return review_times
-            
+            if prefer_stored:
+                stored = self._parse_stored_review_schedule(memory)
+                if stored:
+                    return stored
+            importance, created_at = self._resolve_review_schedule_inputs(memory)
+            return self._build_review_schedule(importance, created_at)
         except Exception as e:
             logger.error(f"Failed to get review schedule: {e}")
             return []
@@ -332,24 +328,76 @@ class EbbinghausAlgorithm:
         }
         return decay_rates.get(memory_type, self.decay_rate)
     
-    def _generate_review_schedule(self, importance_score: float, created_at: datetime) -> List[datetime]:
+    def _parse_datetime(self, value: Any) -> datetime:
+        """Parse datetime from object or ISO string."""
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str) and value:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return get_current_datetime()
+
+    def _parse_stored_review_schedule(
+        self, memory: Dict[str, Any]
+    ) -> Optional[List[datetime]]:
+        """Parse persisted review_schedule ISO strings from memory metadata."""
+        meta = memory.get("metadata") or {}
+        intelligence = meta.get("intelligence") or memory.get("intelligence") or {}
+        raw = intelligence.get("review_schedule")
+        if not raw or not isinstance(raw, list):
+            return None
+        times: List[datetime] = []
+        for item in raw:
+            if not item:
+                continue
+            times.append(self._parse_datetime(item))
+        return times if times else None
+
+    def _resolve_review_schedule_inputs(
+        self, memory: Dict[str, Any]
+    ) -> tuple[float, datetime]:
+        """Resolve importance and created_at from a memory dict (incl. metadata)."""
+        meta = memory.get("metadata") or {}
+        intelligence = meta.get("intelligence") or memory.get("intelligence") or {}
+
+        importance = memory.get("importance_score")
+        if importance is None:
+            importance = meta.get("importance_score")
+        if importance is None:
+            importance = intelligence.get("importance_score", 0.5)
+
+        created_at = memory.get("created_at")
+        if created_at is None:
+            created_at = meta.get("created_at")
+        if created_at is None:
+            created_at = intelligence.get("created_at", get_current_datetime())
+
+        return float(importance), self._parse_datetime(created_at)
+
+    def _adjust_review_intervals(self, importance_score: float) -> List[float]:
+        """Scale base review intervals by importance (higher -> shorter)."""
+        factor = self.review_adjustment_factor
+        floor = self.review_interval_min_hours
+        adjusted = []
+        for interval in self.review_intervals:
+            hours = interval * (1 - importance_score * factor)
+            adjusted.append(max(hours, floor))
+        return adjusted
+
+    def _build_review_schedule(
+        self, importance_score: float, created_at: datetime
+    ) -> List[datetime]:
+        """Build review datetimes from importance and anchor time."""
+        intervals = self._adjust_review_intervals(importance_score)
+        return [
+            created_at + timedelta(hours=hours) for hours in intervals
+        ]
+
+    def _generate_review_schedule(
+        self, importance_score: float, created_at: datetime
+    ) -> List[datetime]:
         """Generate review schedule based on importance and Ebbinghaus curve."""
         try:
-            # Adjust intervals based on importance
-            adjusted_intervals = []
-            for interval in self.review_intervals:
-                # Higher importance = shorter intervals (more frequent reviews)
-                adjusted_interval = interval * (1 - importance_score * 0.3)
-                adjusted_intervals.append(max(adjusted_interval, 0.5))  # Minimum 0.5 hours
-            
-            # Calculate review times
-            review_times = []
-            for interval in adjusted_intervals:
-                review_time = created_at + timedelta(hours=interval)
-                review_times.append(review_time)
-            
-            return review_times
-            
+            return self._build_review_schedule(importance_score, created_at)
         except Exception as e:
             logger.error(f"Failed to generate review schedule: {e}")
             return []

--- a/tests/unit/intelligence/test_ebbinghaus_review_schedule.py
+++ b/tests/unit/intelligence/test_ebbinghaus_review_schedule.py
@@ -1,0 +1,94 @@
+"""Unit tests for EbbinghausAlgorithm review schedule consistency."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from powermem.intelligence.ebbinghaus_algorithm import EbbinghausAlgorithm
+
+
+@pytest.fixture
+def algo():
+    return EbbinghausAlgorithm({})
+
+
+@pytest.fixture
+def anchor():
+    return datetime(2026, 5, 23, 12, 0, 0)
+
+
+def test_generate_and_get_review_schedule_match(algo, anchor):
+    importance = 0.8
+    private = algo._generate_review_schedule(importance, anchor)
+    public = algo.get_review_schedule(
+        {"importance_score": importance, "created_at": anchor},
+        prefer_stored=False,
+    )
+    assert private == public
+
+
+def test_review_schedule_respects_min_hours(algo, anchor):
+    aggressive = EbbinghausAlgorithm(
+        {"review_adjustment_factor": 1.0, "review_interval_min_hours": 0.5}
+    )
+    schedule = aggressive._generate_review_schedule(1.0, anchor)
+    first_delta = schedule[0] - anchor
+    assert first_delta == timedelta(hours=0.5)
+
+
+def test_custom_adjustment_factor_changes_intervals(algo, anchor):
+    mild = EbbinghausAlgorithm({"review_adjustment_factor": 0.1})
+    strong = EbbinghausAlgorithm({"review_adjustment_factor": 0.5})
+    mild_first = mild._generate_review_schedule(0.8, anchor)[0]
+    strong_first = strong._generate_review_schedule(0.8, anchor)[0]
+    assert strong_first < mild_first
+
+
+def test_get_review_schedule_reads_metadata_fields(algo, anchor):
+    memory = {
+        "metadata": {
+            "importance_score": 0.7,
+            "created_at": anchor.isoformat(),
+        }
+    }
+    direct = algo._generate_review_schedule(0.7, anchor)
+    from_meta = algo.get_review_schedule(memory, prefer_stored=False)
+    assert direct == from_meta
+
+
+def test_prefer_stored_returns_persisted_schedule(algo, anchor):
+    stored_times = [
+        anchor + timedelta(hours=1),
+        anchor + timedelta(hours=10),
+    ]
+    memory = {
+        "metadata": {
+            "intelligence": {
+                "review_schedule": [t.isoformat() for t in stored_times],
+            },
+            "importance_score": 0.8,
+            "created_at": anchor.isoformat(),
+        }
+    }
+    recomputed = algo.get_review_schedule(memory, prefer_stored=False)
+    assert algo.get_review_schedule(memory, prefer_stored=True) == stored_times
+    assert algo.get_review_schedule(memory, prefer_stored=True) != recomputed
+
+
+def test_prefer_stored_falls_back_when_missing(algo, anchor):
+    memory = {"importance_score": 0.6, "created_at": anchor}
+    assert algo.get_review_schedule(memory, prefer_stored=True) == (
+        algo.get_review_schedule(memory, prefer_stored=False)
+    )
+
+
+def test_parse_stored_review_schedule_top_level_intelligence(algo, anchor):
+    t = anchor + timedelta(hours=3)
+    memory = {"intelligence": {"review_schedule": [t.isoformat()]}}
+    assert algo._parse_stored_review_schedule(memory) == [t]
+
+
+def test_adjust_review_intervals_formula(algo):
+    intervals = algo._adjust_review_intervals(0.8)
+    assert intervals[0] == pytest.approx(0.76, rel=1e-6)
+    assert intervals[1] == pytest.approx(4.56, rel=1e-6)


### PR DESCRIPTION
Fixes #937

## Summary

- **Configurable unified formula:** Add `review_adjustment_factor` (default `0.3`) and `review_interval_min_hours` (default `0.5`). Both `_generate_review_schedule()` and `get_review_schedule(..., prefer_stored=False)` now call shared `_build_review_schedule()` / `_adjust_review_intervals()`, removing the old `0.3` vs `0.5` split and the missing floor on the public path.
- **Stored schedule first:** `get_review_schedule(memory, prefer_stored=True)` (default) returns persisted `metadata.intelligence.review_schedule` when present, so Dashboard/query results match the DB; falls back to the unified formula when no schedule is stored. Use `prefer_stored=False` to recompute (preview/simulation).

## Changes

- `ebbinghaus_algorithm.py`: shared helpers, config fields, `prefer_stored` on `get_review_schedule`
- `configs.py`, `config_loader.py`: expose new settings
- `tests/unit/intelligence/test_ebbinghaus_review_schedule.py`: parity, config, and `prefer_stored` tests

## Test plan

- [x] `pytest tests/unit/intelligence/test_ebbinghaus_review_schedule.py`
