### PR TITLE
  fix(ci): skip scheduled workflows on forked repositories

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -31,9 +31,13 @@ on:
 jobs:
   test1:
     runs-on: ubuntu-latest
-    # Only auto-run for internal PRs (same repo) or push/workflow_dispatch/schedule
-    # External PRs (from forks) require manual trigger via workflow_dispatch
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip on forks: schedule/push only run in the upstream repo (secrets are unavailable in forks).
+    # External PRs (from forks) require manual trigger via workflow_dispatch.
+    if: |
+      (github.event_name == 'push' && github.repository == 'oceanbase/powermem') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'oceanbase/powermem') ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -169,9 +173,13 @@ jobs:
           echo "✓ 清理完成"
   test2:
     runs-on: ubuntu-latest
-    # Only auto-run for internal PRs (same repo) or push/workflow_dispatch/schedule
-    # External PRs (from forks) require manual trigger via workflow_dispatch
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Skip on forks: schedule/push only run in the upstream repo (secrets are unavailable in forks).
+    # External PRs (from forks) require manual trigger via workflow_dispatch.
+    if: |
+      (github.event_name == 'push' && github.repository == 'oceanbase/powermem') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'oceanbase/powermem') ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       matrix:
         python-version: ["3.11"]

--- a/.github/workflows/sync-project-milestones.yml
+++ b/.github/workflows/sync-project-milestones.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   get-project-id:
+    if: github.repository == 'oceanbase/powermem'
     runs-on: ubuntu-latest
     outputs:
       project_id: ${{ steps.get_project.outputs.project_id }}

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -1280,7 +1280,7 @@ memory = Memory(config=config)
 
 - **Discord**: Join our [Discord community](https://discord.com/invite/74cF8vbNEs)
 - **GitHub Discussions**: Ask questions in [GitHub Discussions](https://github.com/oceanbase/powermem/discussions)
-- **Documentation**: Browse the [documentation](https://powermem.readthedocs.io)
+- **Documentation**: Browse the [documentation](https://www.powermem.ai/docs)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,10 @@ extras = [
 
 
 [project.urls]
-Homepage = "https://github.com/powermem/powermem"
-Documentation = "https://powermem.readthedocs.io"
-Repository = "https://github.com/powermem/powermem.git"
-Issues = "https://github.com/powermem/powermem/issues"
+Homepage = "https://github.com/oceanbase/powermem"
+Documentation = "https://www.powermem.ai/docs"
+Repository = "https://github.com/oceanbase/powermem.git"
+Issues = "https://github.com/oceanbase/powermem/issues"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary

  - Forked repos lack required secrets (`QWEN_API_KEY`, `SILICONFLOW_*_API_KEY`, `PROJECT_ACCESS_TOKEN`),
  causing daily CI failures and noisy email notifications for all fork maintainers.
  - Gate `schedule` and `push` events in `regression.yml` on `github.repository == 'oceanbase/powermem'` so
   fork repos silently skip instead of failing.
  - Apply the same guard to `sync-project-milestones.yml`.
  - Fix stale project URLs in `pyproject.toml` and `docs/development/overview.md`:
    - `powermem/powermem` → `oceanbase/powermem` (3 URLs)
    - `https://powermem.readthedocs.io` → `https://www.powermem.ai/docs` (2 occurrences, readthedocs
  returns 404)

  ## Changed files

  | File | Change |
  |------|--------|
  | `.github/workflows/regression.yml` | `schedule`/`push` gated on upstream repo; `workflow_dispatch` and
  `pull_request_target` unchanged |
  | `.github/workflows/sync-project-milestones.yml` | All jobs gated on upstream repo |
  | `pyproject.toml` | Fix `[project.urls]` — Homepage, Repository, Issues, Documentation |
  | `docs/development/overview.md` | Fix readthedocs link |

  ## Motivation

  Every fork of this repo receives daily failure emails from the `Regression Tests` and `Sync Project with
  Milestones` workflows. These workflows depend on repo-level secrets that are unavailable in forks, so
  they can never succeed. This is the standard approach used by large open-source projects (e.g.,
  kubernetes, pytorch) to handle this.

  ## Test plan

  - [x] Verify `readthedocs.io` returns 404 (confirmed via curl)
  - [x] Verify `https://www.powermem.ai/docs` returns 200 (confirmed via curl)
  - [x] Verify all `ob-labs/*` and `openclaw/openclaw` URLs are still valid (confirmed via