### PR TITLE
fix(logging): SDK file logging, trace context, and gzip rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -223,7 +223,7 @@ AUDIT_LOG_ROTATION_SIZE=100MB
 # =============================================================================
 # General logging settings
 LOGGING_LEVEL=DEBUG
-LOGGING_FORMAT=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+LOGGING_FORMAT=%(asctime)s - %(name)s - %(levelname)s - [%(request_id)s] [%(user_id)s] [%(agent_id)s] - %(message)s
 LOGGING_FILE=./logs/powermem.log
 LOGGING_MAX_SIZE=100MB
 LOGGING_BACKUP_COUNT=5

--- a/src/powermem/config_loader.py
+++ b/src/powermem/config_loader.py
@@ -107,7 +107,7 @@ class LoggingSettings(_BasePowermemSettings):
 
     level: str = Field(default="DEBUG")
     format: str = Field(
-        default="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        default="%(asctime)s - %(name)s - %(levelname)s - [%(request_id)s] [%(user_id)s] [%(agent_id)s] - %(message)s"
     )
     file: str = Field(default="./logs/powermem.log")
     max_size: str = Field(default="100MB")

--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -157,6 +157,10 @@ class Memory(MemoryBase):
             })
             ```
         """
+        from powermem.logging_config import setup_powermem_logging
+
+        setup_powermem_logging()
+
         # Handle MemoryConfig object or dict
 
         if isinstance(config, MemoryConfig):

--- a/src/powermem/log_context.py
+++ b/src/powermem/log_context.py
@@ -1,0 +1,44 @@
+"""
+Async-safe trace context propagation for the ``powermem`` logger tree.
+
+Uses ``contextvars`` so each async request carries its own request_id /
+user_id / agent_id without explicit parameter threading.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar, Token
+from typing import Tuple
+
+_ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+
+_request_id_var: ContextVar[str] = ContextVar("request_id", default=_ZERO_UUID)
+_user_id_var: ContextVar[str] = ContextVar("user_id", default="")
+_agent_id_var: ContextVar[str] = ContextVar("agent_id", default="")
+
+
+def set_log_context(
+    *,
+    request_id: str = _ZERO_UUID,
+    user_id: str = "",
+    agent_id: str = "",
+) -> Tuple[Token, Token, Token]:
+    t1 = _request_id_var.set(request_id)
+    t2 = _user_id_var.set(user_id)
+    t3 = _agent_id_var.set(agent_id)
+    return (t1, t2, t3)
+
+
+def reset_log_context(tokens: Tuple[Token, Token, Token]) -> None:
+    _request_id_var.reset(tokens[0])
+    _user_id_var.reset(tokens[1])
+    _agent_id_var.reset(tokens[2])
+
+
+class TraceContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = _request_id_var.get()  # type: ignore[attr-defined]
+        record.user_id = _user_id_var.get()  # type: ignore[attr-defined]
+        record.agent_id = _agent_id_var.get()  # type: ignore[attr-defined]
+        return True

--- a/src/powermem/logging_config.py
+++ b/src/powermem/logging_config.py
@@ -4,8 +4,11 @@ Configure the ``powermem`` logger tree from ``LOGGING_*`` environment variables.
 - ``LOGGING_FILE`` (default ``./logs/powermem.log``): file for SDK/storage logs
 - ``LOGGING_LEVEL`` / ``LOGGING_FORMAT``: level and text format for file output
 - ``LOGGING_MAX_SIZE`` / ``LOGGING_BACKUP_COUNT``: rotating file handler
-- ``LOGGING_COMPRESS_BACKUPS``: gzip rotated backup files when true
+- ``LOGGING_COMPRESS_BACKUPS``: gzip rotated backup files as ``<file>.N.gz``
 - ``LOGGING_CONSOLE_*``: optional stderr console output for the SDK tree
+
+Note: HTTP server access logs use ``server`` config (e.g. ``server.log``); this module
+only configures the ``powermem.*`` SDK logger tree (default ``./logs/powermem.log``).
 """
 
 from __future__ import annotations
@@ -17,6 +20,8 @@ import shutil
 import sys
 from logging.handlers import RotatingFileHandler
 from typing import Optional
+
+from powermem.log_context import TraceContextFilter
 
 _powermem_logging_configured = False
 
@@ -39,24 +44,63 @@ def parse_log_max_bytes(size_str: Optional[str], default: int = 100 * 1024 * 102
 
 
 class CompressingRotatingFileHandler(RotatingFileHandler):
-    """RotatingFileHandler that optionally gzip-compresses rolled backup files."""
+    """
+    RotatingFileHandler that keeps backups as ``<base>.1.gz``, ``<base>.2.gz``, ...
+
+    When ``compress_backups`` is false, defers to the standard uncompressed rotation.
+    """
 
     def __init__(self, *args, compress_backups: bool = False, **kwargs):
         self.compress_backups = compress_backups
         super().__init__(*args, **kwargs)
 
+    def _backup_gz_path(self, index: int) -> str:
+        return f"{self.baseFilename}.{index}.gz"
+
+    @staticmethod
+    def _gzip_plain_file(plain_path: str, gz_path: str) -> None:
+        with open(plain_path, "rb") as source, gzip.open(gz_path, "wb") as dest:
+            shutil.copyfileobj(source, dest)
+        os.remove(plain_path)
+
+    def _migrate_legacy_plain_backup(self, index: int) -> None:
+        """Upgrade ``<base>.N`` files left by older handlers to ``<base>.N.gz``."""
+        plain = f"{self.baseFilename}.{index}"
+        gz_path = self._backup_gz_path(index)
+        if os.path.exists(plain) and not os.path.exists(gz_path):
+            self._gzip_plain_file(plain, gz_path)
+
     def doRollover(self) -> None:
-        super().doRollover()
-        if not self.compress_backups or self.backupCount <= 0:
-            return
-        for index in range(1, self.backupCount + 1):
-            rotated = f"{self.baseFilename}.{index}"
-            if not os.path.exists(rotated) or rotated.endswith(".gz"):
-                continue
-            gz_path = f"{rotated}.gz"
-            with open(rotated, "rb") as source, gzip.open(gz_path, "wb") as dest:
-                shutil.copyfileobj(source, dest)
-            os.remove(rotated)
+        if not self.compress_backups:
+            return super().doRollover()
+
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        if self.backupCount > 0:
+            oldest = self._backup_gz_path(self.backupCount)
+            if os.path.exists(oldest):
+                os.remove(oldest)
+
+            for index in range(self.backupCount - 1, 0, -1):
+                self._migrate_legacy_plain_backup(index)
+                src = self._backup_gz_path(index)
+                dst = self._backup_gz_path(index + 1)
+                if os.path.exists(src):
+                    if os.path.exists(dst):
+                        os.remove(dst)
+                    os.rename(src, dst)
+
+            if os.path.exists(self.baseFilename):
+                dst = self._backup_gz_path(1)
+                if os.path.exists(dst):
+                    os.remove(dst)
+                staging = f"{self.baseFilename}.1"
+                os.rename(self.baseFilename, staging)
+                self._gzip_plain_file(staging, dst)
+
+        self.stream = self._open()
 
 
 def setup_powermem_logging(*, force: bool = False) -> bool:
@@ -105,6 +149,7 @@ def setup_powermem_logging(*, force: bool = False) -> bool:
         file_handler = RotatingFileHandler(log_file_path, **handler_kwargs)
     file_handler.setLevel(log_level)
     file_handler.setFormatter(file_formatter)
+    file_handler.addFilter(TraceContextFilter())
 
     powermem_logger = logging.getLogger("powermem")
     powermem_logger.setLevel(log_level)
@@ -123,6 +168,7 @@ def setup_powermem_logging(*, force: bool = False) -> bool:
         )
         console_handler = logging.StreamHandler(sys.stderr)
         console_handler.setLevel(console_level)
+        console_handler.addFilter(TraceContextFilter())
         console_handler.setFormatter(
             logging.Formatter(settings.console_format or "%(levelname)s - %(message)s")
         )

--- a/src/powermem/logging_config.py
+++ b/src/powermem/logging_config.py
@@ -1,0 +1,142 @@
+"""
+Configure the ``powermem`` logger tree from ``LOGGING_*`` environment variables.
+
+- ``LOGGING_FILE`` (default ``./logs/powermem.log``): file for SDK/storage logs
+- ``LOGGING_LEVEL`` / ``LOGGING_FORMAT``: level and text format for file output
+- ``LOGGING_MAX_SIZE`` / ``LOGGING_BACKUP_COUNT``: rotating file handler
+- ``LOGGING_COMPRESS_BACKUPS``: gzip rotated backup files when true
+- ``LOGGING_CONSOLE_*``: optional stderr console output for the SDK tree
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import os
+import shutil
+import sys
+from logging.handlers import RotatingFileHandler
+from typing import Optional
+
+_powermem_logging_configured = False
+
+
+def parse_log_max_bytes(size_str: Optional[str], default: int = 100 * 1024 * 1024) -> int:
+    """Parse size strings such as ``100MB``, ``1GB``, or plain byte counts."""
+    if not size_str:
+        return default
+    text = str(size_str).strip().upper()
+    try:
+        if text.endswith("GB"):
+            return int(float(text[:-2].strip()) * 1024 * 1024 * 1024)
+        if text.endswith("MB"):
+            return int(float(text[:-2].strip()) * 1024 * 1024)
+        if text.endswith("KB"):
+            return int(float(text[:-2].strip()) * 1024)
+        return int(text)
+    except ValueError:
+        return default
+
+
+class CompressingRotatingFileHandler(RotatingFileHandler):
+    """RotatingFileHandler that optionally gzip-compresses rolled backup files."""
+
+    def __init__(self, *args, compress_backups: bool = False, **kwargs):
+        self.compress_backups = compress_backups
+        super().__init__(*args, **kwargs)
+
+    def doRollover(self) -> None:
+        super().doRollover()
+        if not self.compress_backups or self.backupCount <= 0:
+            return
+        for index in range(1, self.backupCount + 1):
+            rotated = f"{self.baseFilename}.{index}"
+            if not os.path.exists(rotated) or rotated.endswith(".gz"):
+                continue
+            gz_path = f"{rotated}.gz"
+            with open(rotated, "rb") as source, gzip.open(gz_path, "wb") as dest:
+                shutil.copyfileobj(source, dest)
+            os.remove(rotated)
+
+
+def setup_powermem_logging(*, force: bool = False) -> bool:
+    """
+    Wire ``LOGGING_*`` settings to the ``powermem`` logger namespace.
+
+    Returns True when file logging was configured, False otherwise.
+    Safe to call multiple times; repeats are no-ops unless ``force=True``.
+    """
+    global _powermem_logging_configured
+
+    if _powermem_logging_configured and not force:
+        return False
+
+    try:
+        from powermem.config_loader import LoggingSettings
+    except Exception as exc:
+        print(f"Warning: powermem logging setup skipped: {exc}", file=sys.stderr)
+        return False
+
+    settings = LoggingSettings()
+    if not settings.file:
+        return False
+
+    log_level = getattr(logging, (settings.level or "INFO").upper(), logging.INFO)
+    file_formatter = logging.Formatter(
+        settings.format or "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    log_file_path = os.path.abspath(settings.file)
+    log_dir = os.path.dirname(log_file_path)
+    if log_dir:
+        os.makedirs(log_dir, exist_ok=True)
+
+    handler_kwargs = {
+        "mode": "a",
+        "maxBytes": parse_log_max_bytes(settings.max_size),
+        "backupCount": settings.backup_count or 5,
+        "encoding": "utf-8",
+    }
+    if settings.compress_backups:
+        file_handler = CompressingRotatingFileHandler(
+            log_file_path, compress_backups=True, **handler_kwargs
+        )
+    else:
+        file_handler = RotatingFileHandler(log_file_path, **handler_kwargs)
+    file_handler.setLevel(log_level)
+    file_handler.setFormatter(file_formatter)
+
+    powermem_logger = logging.getLogger("powermem")
+    powermem_logger.setLevel(log_level)
+
+    # Replace prior file handlers targeting the same path (idempotent reconfigure).
+    for existing in list(powermem_logger.handlers):
+        if getattr(existing, "baseFilename", None) == log_file_path:
+            powermem_logger.removeHandler(existing)
+            existing.close()
+
+    powermem_logger.addHandler(file_handler)
+
+    if settings.console_enabled:
+        console_level = getattr(
+            logging, (settings.console_level or settings.level or "INFO").upper(), logging.INFO
+        )
+        console_handler = logging.StreamHandler(sys.stderr)
+        console_handler.setLevel(console_level)
+        console_handler.setFormatter(
+            logging.Formatter(settings.console_format or "%(levelname)s - %(message)s")
+        )
+        has_console = any(
+            isinstance(h, logging.StreamHandler)
+            and not getattr(h, "baseFilename", None)
+            and getattr(h, "stream", None) is sys.stderr
+            for h in powermem_logger.handlers
+        )
+        if not has_console:
+            powermem_logger.addHandler(console_handler)
+
+    powermem_logger.propagate = False
+
+    powermem_logger.debug("PowerMem SDK logging initialized (file=%s)", log_file_path)
+    _powermem_logging_configured = True
+    return True

--- a/src/server/middleware/logging.py
+++ b/src/server/middleware/logging.py
@@ -4,6 +4,7 @@ Logging middleware for PowerMem API
 
 import logging
 import os
+import re
 import sys
 import json
 import time
@@ -176,17 +177,46 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(log_data, ensure_ascii=False)
 
 
+_USER_PATH_RE = re.compile(r"/users/([^/]+)")
+_AGENT_PATH_RE = re.compile(r"/agents/([^/]+)")
+
+
 class LoggingMiddleware(BaseHTTPMiddleware):
     """Middleware for request/response logging"""
-    
+
+    @staticmethod
+    def _extract_trace_ids(request: Request) -> tuple:
+        user_id = request.query_params.get("user_id", "")
+        if not user_id:
+            m = _USER_PATH_RE.search(request.url.path)
+            if m:
+                user_id = m.group(1)
+
+        agent_id = request.query_params.get("agent_id", "")
+        if not agent_id:
+            m = _AGENT_PATH_RE.search(request.url.path)
+            if m:
+                agent_id = m.group(1)
+
+        return user_id or "", agent_id or ""
+
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         # Generate request ID
         request_id = str(uuid.uuid4())
         request.state.request_id = request_id
-        
+
+        # Propagate trace context to SDK logger tree
+        from powermem.log_context import set_log_context, reset_log_context
+        user_id, agent_id = self._extract_trace_ids(request)
+        tokens = set_log_context(
+            request_id=request_id,
+            user_id=user_id,
+            agent_id=agent_id,
+        )
+
         # Start time
         start_time = time.time()
-        
+
         # Log request
         logger.info(
             f"{request.method} {request.url.path}",
@@ -197,14 +227,14 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                 "client": request.client.host if request.client else None,
             }
         )
-        
+
         try:
             # Process request
             response = await call_next(request)
-            
+
             # Calculate duration
             duration = time.time() - start_time
-            
+
             # Record metrics
             metrics_collector = get_metrics_collector()
             # Normalize path to endpoint
@@ -215,7 +245,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                 status_code=response.status_code,
                 duration=duration
             )
-            
+
             # Log response
             logger.info(
                 f"{request.method} {request.url.path} - {response.status_code}",
@@ -225,24 +255,24 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                     "duration_ms": duration * 1000,
                 }
             )
-            
+
             # Add request ID to response header
             response.headers["X-Request-ID"] = request_id
-            
+
             return response
-            
+
         except Exception as e:
             duration = time.time() - start_time
-            
+
             # Determine status code and whether this is an expected error
             status_code = 500
             is_expected_error = False
-            
+
             if isinstance(e, APIError):
                 status_code = e.status_code
                 # Client errors (4xx) are expected, server errors (5xx) are unexpected
                 is_expected_error = status_code < 500
-            
+
             # Record metrics for error
             metrics_collector = get_metrics_collector()
             endpoint = metrics_collector.normalize_endpoint(request.url.path)
@@ -252,7 +282,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                 status_code=status_code,
                 duration=duration
             )
-            
+
             # For expected errors (4xx), log without stack trace
             # For unexpected errors (5xx), log with full stack trace
             if is_expected_error:
@@ -277,6 +307,8 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                     exc_info=True,
                 )
             raise
+        finally:
+            reset_log_context(tokens)
 
 
 def log_request(request: Request, message: str, **kwargs):

--- a/src/server/middleware/logging.py
+++ b/src/server/middleware/logging.py
@@ -129,6 +129,13 @@ def setup_logging():
     # Prevent duplicate logs
     logger.propagate = False
 
+    try:
+        from powermem.logging_config import setup_powermem_logging
+
+        setup_powermem_logging()
+    except Exception as e:
+        print(f"Warning: Failed to setup powermem SDK logging: {e}", file=sys.stderr)
+
 
 class JsonFormatter(logging.Formatter):
     """JSON formatter for structured logging"""

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -6,6 +6,11 @@ import os
 
 import pytest
 
+from powermem.log_context import (
+    TraceContextFilter,
+    reset_log_context,
+    set_log_context,
+)
 from powermem.logging_config import (
     CompressingRotatingFileHandler,
     parse_log_max_bytes,
@@ -103,6 +108,116 @@ def test_setup_powermem_logging_idempotent(tmp_path, monkeypatch):
 # CompressingRotatingFileHandler
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# TraceContextFilter
+# ---------------------------------------------------------------------------
+
+def test_trace_filter_injects_fields(tmp_path):
+    log_file = str(tmp_path / "trace.log")
+    handler = logging.FileHandler(log_file, encoding="utf-8")
+    handler.setFormatter(logging.Formatter(
+        "%(message)s [%(request_id)s] [%(user_id)s] [%(agent_id)s]"
+    ))
+    handler.addFilter(TraceContextFilter())
+
+    test_logger = logging.getLogger("powermem.trace_test")
+    test_logger.addHandler(handler)
+    test_logger.setLevel(logging.DEBUG)
+
+    tokens = set_log_context(
+        request_id="aaaa-bbbb",
+        user_id="user-42",
+        agent_id="agent-7",
+    )
+    try:
+        test_logger.debug("hello")
+        handler.flush()
+
+        with open(log_file) as f:
+            content = f.read()
+        assert "[aaaa-bbbb]" in content
+        assert "[user-42]" in content
+        assert "[agent-7]" in content
+    finally:
+        reset_log_context(tokens)
+        test_logger.removeHandler(handler)
+        handler.close()
+
+
+def test_trace_filter_zero_uuid_default(tmp_path):
+    log_file = str(tmp_path / "default.log")
+    handler = logging.FileHandler(log_file, encoding="utf-8")
+    handler.setFormatter(logging.Formatter(
+        "%(message)s [%(request_id)s] [%(user_id)s] [%(agent_id)s]"
+    ))
+    handler.addFilter(TraceContextFilter())
+
+    test_logger = logging.getLogger("powermem.default_test")
+    test_logger.addHandler(handler)
+    test_logger.setLevel(logging.DEBUG)
+
+    try:
+        test_logger.debug("no context")
+        handler.flush()
+
+        with open(log_file) as f:
+            content = f.read()
+        zero = "00000000-0000-0000-0000-000000000000"
+        assert f"[{zero}]" in content  # request_id defaults to zero UUID
+        assert "[] []" in content  # user_id and agent_id default to empty
+    finally:
+        test_logger.removeHandler(handler)
+        handler.close()
+
+
+def test_reset_log_context_restores_previous():
+    tokens_outer = set_log_context(request_id="outer-id")
+    try:
+        tokens_inner = set_log_context(request_id="inner-id")
+        from powermem.log_context import _request_id_var
+        assert _request_id_var.get() == "inner-id"
+        reset_log_context(tokens_inner)
+        assert _request_id_var.get() == "outer-id"
+    finally:
+        reset_log_context(tokens_outer)
+
+
+def test_setup_powermem_logging_attaches_trace_filter(tmp_path, monkeypatch):
+    log_file = str(tmp_path / "trace_setup.log")
+    monkeypatch.setenv("LOGGING_FILE", log_file)
+    monkeypatch.setenv("LOGGING_LEVEL", "DEBUG")
+    monkeypatch.setenv("LOGGING_CONSOLE_ENABLED", "false")
+    monkeypatch.setenv(
+        "LOGGING_FORMAT",
+        "%(asctime)s - %(name)s - %(levelname)s - [%(request_id)s] - %(message)s",
+    )
+
+    import powermem.logging_config as mod
+    monkeypatch.setattr(mod, "_powermem_logging_configured", False)
+
+    tokens = set_log_context(request_id="req-from-setup-test")
+    try:
+        setup_powermem_logging(force=True)
+
+        test_logger = logging.getLogger("powermem.setup_trace")
+        test_logger.debug("trace check")
+
+        with open(log_file) as f:
+            content = f.read()
+        assert "req-from-setup-test" in content
+    finally:
+        reset_log_context(tokens)
+        powermem_logger = logging.getLogger("powermem")
+        for h in list(powermem_logger.handlers):
+            powermem_logger.removeHandler(h)
+            h.close()
+        monkeypatch.setattr(mod, "_powermem_logging_configured", False)
+
+
+# ---------------------------------------------------------------------------
+# CompressingRotatingFileHandler
+# ---------------------------------------------------------------------------
+
 def test_compressing_handler_creates_gz(tmp_path):
     log_file = str(tmp_path / "rotate.log")
     handler = CompressingRotatingFileHandler(
@@ -122,13 +237,44 @@ def test_compressing_handler_creates_gz(tmp_path):
         for i in range(20):
             test_logger.debug("line %d padding padding padding", i)
 
-        gz_files = [f for f in os.listdir(tmp_path) if f.endswith(".gz")]
-        assert len(gz_files) > 0, "Expected at least one .gz backup"
+        gz_files = sorted(f for f in os.listdir(tmp_path) if f.endswith(".gz"))
+        assert gz_files, "Expected at least one .gz backup"
+        assert all(name.startswith("rotate.log.") for name in gz_files)
 
-        gz_path = str(tmp_path / gz_files[0])
-        with gzip.open(gz_path, "rt") as f:
-            content = f.read()
-        assert "padding" in content
+        with gzip.open(tmp_path / gz_files[0], "rt") as f:
+            assert "padding" in f.read()
+    finally:
+        test_logger.removeHandler(handler)
+        handler.close()
+
+
+def test_compressing_handler_respects_backup_count(tmp_path):
+    log_file = str(tmp_path / "rotate.log")
+    handler = CompressingRotatingFileHandler(
+        log_file,
+        compress_backups=True,
+        maxBytes=40,
+        backupCount=2,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    test_logger = logging.getLogger("powermem.compress_backup_count")
+    test_logger.addHandler(handler)
+    test_logger.setLevel(logging.DEBUG)
+
+    try:
+        for i in range(80):
+            test_logger.debug("line %d xxxxxxxxxxxxxxxxxxxxxxxx", i)
+
+        gz_files = [f for f in os.listdir(tmp_path) if f.endswith(".gz")]
+        assert len(gz_files) <= 2, f"Expected at most 2 backups, got {gz_files}"
+        plain_backups = [
+            f
+            for f in os.listdir(tmp_path)
+            if f.startswith("rotate.log.") and not f.endswith(".gz")
+        ]
+        assert not plain_backups, f"Uncompressed backups should be migrated: {plain_backups}"
     finally:
         test_logger.removeHandler(handler)
         handler.close()

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,134 @@
+"""Tests for powermem.logging_config — SDK file logging wiring."""
+
+import gzip
+import logging
+import os
+
+import pytest
+
+from powermem.logging_config import (
+    CompressingRotatingFileHandler,
+    parse_log_max_bytes,
+    setup_powermem_logging,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_log_max_bytes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("100MB", 100 * 1024 * 1024),
+        ("1GB", 1024 * 1024 * 1024),
+        ("512KB", 512 * 1024),
+        ("2048", 2048),
+        ("  50mb  ", 50 * 1024 * 1024),
+        ("1.5GB", int(1.5 * 1024 * 1024 * 1024)),
+    ],
+)
+def test_parse_log_max_bytes_valid(input_str, expected):
+    assert parse_log_max_bytes(input_str) == expected
+
+
+def test_parse_log_max_bytes_none_returns_default():
+    assert parse_log_max_bytes(None) == 100 * 1024 * 1024
+
+
+def test_parse_log_max_bytes_empty_returns_default():
+    assert parse_log_max_bytes("") == 100 * 1024 * 1024
+
+
+def test_parse_log_max_bytes_invalid_returns_default():
+    assert parse_log_max_bytes("not-a-number") == 100 * 1024 * 1024
+
+
+def test_parse_log_max_bytes_custom_default():
+    assert parse_log_max_bytes(None, default=42) == 42
+
+
+# ---------------------------------------------------------------------------
+# setup_powermem_logging
+# ---------------------------------------------------------------------------
+
+def test_setup_powermem_logging_writes_to_file(tmp_path, monkeypatch):
+    log_file = str(tmp_path / "test.log")
+    monkeypatch.setenv("LOGGING_FILE", log_file)
+    monkeypatch.setenv("LOGGING_LEVEL", "DEBUG")
+    monkeypatch.setenv("LOGGING_CONSOLE_ENABLED", "false")
+
+    import powermem.logging_config as mod
+    monkeypatch.setattr(mod, "_powermem_logging_configured", False)
+
+    try:
+        assert setup_powermem_logging(force=True) is True
+        assert os.path.exists(log_file)
+
+        test_logger = logging.getLogger("powermem.test_logging_config")
+        test_logger.debug("hello from test")
+
+        with open(log_file) as f:
+            content = f.read()
+        assert "PowerMem SDK logging initialized" in content
+        assert "hello from test" in content
+    finally:
+        powermem_logger = logging.getLogger("powermem")
+        for h in list(powermem_logger.handlers):
+            powermem_logger.removeHandler(h)
+            h.close()
+        monkeypatch.setattr(mod, "_powermem_logging_configured", False)
+
+
+def test_setup_powermem_logging_idempotent(tmp_path, monkeypatch):
+    log_file = str(tmp_path / "test.log")
+    monkeypatch.setenv("LOGGING_FILE", log_file)
+    monkeypatch.setenv("LOGGING_CONSOLE_ENABLED", "false")
+
+    import powermem.logging_config as mod
+    monkeypatch.setattr(mod, "_powermem_logging_configured", False)
+
+    try:
+        assert setup_powermem_logging(force=True) is True
+        assert setup_powermem_logging() is False  # no-op second call
+    finally:
+        powermem_logger = logging.getLogger("powermem")
+        for h in list(powermem_logger.handlers):
+            powermem_logger.removeHandler(h)
+            h.close()
+        monkeypatch.setattr(mod, "_powermem_logging_configured", False)
+
+
+# ---------------------------------------------------------------------------
+# CompressingRotatingFileHandler
+# ---------------------------------------------------------------------------
+
+def test_compressing_handler_creates_gz(tmp_path):
+    log_file = str(tmp_path / "rotate.log")
+    handler = CompressingRotatingFileHandler(
+        log_file,
+        compress_backups=True,
+        maxBytes=50,
+        backupCount=2,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    test_logger = logging.getLogger("powermem.compress_test")
+    test_logger.addHandler(handler)
+    test_logger.setLevel(logging.DEBUG)
+
+    try:
+        for i in range(20):
+            test_logger.debug("line %d padding padding padding", i)
+
+        gz_files = [f for f in os.listdir(tmp_path) if f.endswith(".gz")]
+        assert len(gz_files) > 0, "Expected at least one .gz backup"
+
+        gz_path = str(tmp_path / gz_files[0])
+        with gzip.open(gz_path, "rt") as f:
+            content = f.read()
+        assert "padding" in content
+    finally:
+        test_logger.removeHandler(handler)
+        handler.close()


### PR DESCRIPTION
## Summary

- Connect `LOGGING_*` environment variables to the `powermem.*` SDK logger tree so SDK/storage logs are written to the configured file (default `./logs/powermem.log`) with rotation and optional gzip backups.
- Initialize logging from `Memory.__init__` and from server `setup_logging()` so both standalone SDK and HTTP server paths get file handlers.
- Propagate `request_id`, `user_id`, and `agent_id` into SDK logs via `contextvars` and `LoggingMiddleware` (parsed from query params or `/users/{id}` / `/agents/{id}` paths).
- Fix compressed log rotation: backups are stored as `base.N.gz` so `backupCount` semantics remain correct (avoids breaking the standard `RotatingFileHandler` chain).

## Motivation

`LOGGING_FILE` and related settings existed in `.env.example` but were not applied to the `powermem` logger namespace, so SDK logs often never reached `powermem.log`. This change makes configuration effective and aligns log format with trace fields for request correlation.

## Changes

| Area | What changed |
|------|----------------|
| `src/powermem/logging_config.py` | New module: `setup_powermem_logging()`, `CompressingRotatingFileHandler`, size parsing |
| `src/powermem/log_context.py` | New: async-safe trace context + `TraceContextFilter` |
| `src/powermem/core/memory.py` | Call `setup_powermem_logging()` on init |
| `src/server/middleware/logging.py` | Call SDK logging setup; propagate trace context per request |
| `src/powermem/config_loader.py`, `.env.example` | Default `LOGGING_FORMAT` includes trace fields |
| `tests/unit/test_logging_config.py` | Unit tests for parsing, setup, rotation, trace filter |

**Note:** HTTP access logs still use server config (e.g. `server.log`); this PR only configures the `powermem.*` SDK tree.

## Test plan

- [x] `uv run pytest tests/unit/test_logging_config.py`
- [ ] Start server with `LOGGING_FILE=./logs/powermem.log`, send a request with `user_id` / `agent_id` (query or path), confirm trace fields appear in `powermem.log`
- [ ] Instantiate `Memory()` in a script without server; confirm logs land in the configured file
- [ ] With `LOGGING_COMPRESS_BACKUPS=true`, trigger rotation and confirm backups are `*.N.gz` and count ≤ `LOGGING_BACKUP_COUNT`

## Security / privacy

- No secrets or credentials in this PR (only `.env.example` placeholder changes).
- Default log format includes `user_id` and `agent_id`; adjust `LOGGING_FORMAT` in production if those identifiers should not be persisted in log files.