### PR TITLE
fix(user_memory): prevent LLM no-op explanation from overwriting user profile

### DIFF
--- a/src/powermem/prompts/user_profile_prompts.py
+++ b/src/powermem/prompts/user_profile_prompts.py
@@ -111,11 +111,20 @@ The following topics are for guidance only. Please selectively extract informati
    - Updating existing information if the conversation provides more recent or different details
    - Keeping unchanged information that is still valid
 5. Combine all information into a coherent, updated profile description
-6. If no relevant profile information is found in the conversation, return the current profile as-is
-7. Write the profile in natural language, not as structured data
-8. Focus on current state and characteristics of the user
-9. If no user profile information can be extracted from the conversation at all, return an empty string ""
-10. The final extracted profile description must not exceed 1,000 characters. If it does, compress the content concisely without losing essential factual information.
+6. Write the profile in natural language, not as structured data
+7. Focus on current state and characteristics of the user
+8. If no user profile information can be extracted, or the conversation contains no new
+   information beyond the current profile, return {{"changed": false}} — no explanation,
+   no commentary, nothing else
+9. The final profile must not exceed 1,000 characters. If it does, compress concisely
+   without losing essential facts.
+
+[Output Format]:
+Return ONLY a JSON object — no markdown fences, no surrounding text:
+  {{"changed": true, "profile": "<updated profile text>"}}
+  {{"changed": false}}
+The keys "changed" and "profile" must always be in English, regardless of the profile
+content language.
 """
 
 
@@ -159,7 +168,9 @@ You MUST extract and write the profile content in {target_language}, regardless 
     user_prompt = f"""{USER_PROFILE_EXTRACTION_PROMPT}{current_profile_section}{language_instruction}
 
 [Target]:
-Extract and return the user profile information as a text description:
+Return ONLY a JSON object with no surrounding text:
+  {{"changed": true, "profile": "<updated profile text>"}}
+  {{"changed": false}}
 
 [Conversation]:
 {conversation}"""

--- a/src/powermem/user_memory/user_memory.py
+++ b/src/powermem/user_memory/user_memory.py
@@ -14,7 +14,10 @@ from ..prompts.user_profile_prompts import (
     get_user_profile_extraction_prompt,
     get_user_profile_topics_extraction_prompt,
 )
-from ..utils.utils import remove_code_blocks, parse_json_from_text, parse_conversation_text
+from ..utils.utils import (
+    remove_code_blocks, parse_json_from_text,
+    parse_conversation_text, llm_json_text_with_fallback,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -340,11 +343,8 @@ class UserMemory:
         Returns:
             LLM response text
         """
-        response = self.memory.llm.generate_response(
-            messages=[
-                {"role": "user", "content": user_prompt},
-            ],
-        )
+        messages = [{"role": "user", "content": user_prompt}]
+        response = llm_json_text_with_fallback(self.memory.llm, messages=messages)
         return remove_code_blocks(response).strip()
 
     def _extract_profile(
@@ -387,14 +387,30 @@ class UserMemory:
 
         # Call LLM to extract profile
         try:
-            profile_content = self._call_llm_for_extraction(user_prompt)
+            raw = self._call_llm_for_extraction(user_prompt)
 
-            # Return empty string if response is empty or indicates no profile
-            if not profile_content or profile_content.lower() in ["","\"\"", "none", "no profile information", "no relevant information"]:
+            # Layer 1: structured JSON — primary path
+            parsed = parse_json_from_text(raw, expected_type=dict)
+            if parsed is not None:
+                if not parsed.get("changed", False):
+                    return ""
+                profile = parsed.get("profile", "").strip()
+                return profile if profile else ""
+
+            # Layer 2: exact-match no-op strings
+            if not raw or raw.lower() in {
+                "", '""', "none", "no profile information", "no relevant information"
+            }:
                 return ""
-            
-            return profile_content
-            
+
+            # Layer 3: non-JSON, non-exact-match — plain text fallback
+            # Handles models that don't follow structured output instructions
+            logger.info(
+                "Non-JSON profile response treated as plain text; "
+                "model may not support structured output"
+            )
+            return raw
+
         except Exception as e:
             logger.error(f"Error extracting profile: {e}")
             raise

--- a/tests/unit/test_extract_profile.py
+++ b/tests/unit/test_extract_profile.py
@@ -1,0 +1,102 @@
+"""Tests for _extract_profile() — structured JSON output and fallback chain."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+MESSAGES = [{"role": "user", "content": "今天天气很好"}]
+
+
+@pytest.fixture
+def um():
+    patches = [
+        patch("powermem.user_memory.user_memory.UserProfileStoreFactory"),
+        patch("powermem.core.memory.VectorStoreFactory"),
+        patch("powermem.core.memory.LLMFactory"),
+        patch("powermem.core.memory.EmbedderFactory"),
+    ]
+    for p in patches:
+        p.start()
+    from powermem.user_memory.user_memory import UserMemory
+    instance = UserMemory()
+    instance._get_existing_profile_data = MagicMock(return_value=None)
+    yield instance
+    for p in patches:
+        p.stop()
+
+
+# --- Layer 1: JSON path ---
+
+def test_json_changed_true_returns_profile(um):
+    um._call_llm_for_extraction = MagicMock(
+        return_value='{"changed": true, "profile": "用户是一名软件工程师"}'
+    )
+    assert um._extract_profile(MESSAGES, "u1") == "用户是一名软件工程师"
+
+
+def test_json_changed_false_returns_empty(um):
+    um._call_llm_for_extraction = MagicMock(return_value='{"changed": false}')
+    assert um._extract_profile(MESSAGES, "u1") == ""
+
+
+def test_json_changed_true_empty_profile_returns_empty(um):
+    um._call_llm_for_extraction = MagicMock(
+        return_value='{"changed": true, "profile": ""}'
+    )
+    assert um._extract_profile(MESSAGES, "u1") == ""
+
+
+def test_json_changed_true_missing_profile_key_returns_empty(um):
+    um._call_llm_for_extraction = MagicMock(return_value='{"changed": true}')
+    assert um._extract_profile(MESSAGES, "u1") == ""
+
+
+def test_json_embedded_in_prose(um):
+    um._call_llm_for_extraction = MagicMock(
+        return_value='结果如下：{"changed": true, "profile": "用户喜欢跑步"}'
+    )
+    assert um._extract_profile(MESSAGES, "u1") == "用户喜欢跑步"
+
+
+def test_json_keys_english_with_native_language(um):
+    um._call_llm_for_extraction = MagicMock(
+        return_value='{"changed": true, "profile": "用户是工程师"}'
+    )
+    assert um._extract_profile(MESSAGES, "u1", native_language="zh") == "用户是工程师"
+
+
+def test_profile_value_containing_braces(um):
+    """json.loads handles braces inside string values; regex fallback would fail."""
+    um._call_llm_for_extraction = MagicMock(
+        return_value='{"changed": true, "profile": "用户在 {科技公司} 担任工程师"}'
+    )
+    result = um._extract_profile(MESSAGES, "u1")
+    assert "科技公司" in result
+
+
+# --- Layer 2: exact-match ---
+
+@pytest.mark.parametrize("response", [
+    "", '""', "none", "no profile information", "no relevant information",
+])
+def test_exact_match_noop_returns_empty(um, response):
+    um._call_llm_for_extraction = MagicMock(return_value=response)
+    assert um._extract_profile(MESSAGES, "u1") == ""
+
+
+# --- Layer 3: plain text fallback ---
+
+def test_non_json_non_noop_returns_raw_text(um):
+    um._call_llm_for_extraction = MagicMock(
+        return_value="用户是一名在北京工作的数据工程师，擅长 Python 和 SQL。"
+    )
+    result = um._extract_profile(MESSAGES, "u1")
+    assert "数据工程师" in result
+
+
+# --- 核心回归：已有 profile 在 no-op 时不被覆盖 ---
+
+def test_existing_profile_not_overwritten_on_noop(um):
+    um._get_existing_profile_data = MagicMock(return_value="用户是高级工程师")
+    um._call_llm_for_extraction = MagicMock(return_value='{"changed": false}')
+    assert um._extract_profile(MESSAGES, "u1") == ""


### PR DESCRIPTION
## Summary

- Replace the plain-text extraction contract with a structured JSON response `{"changed": bool, "profile": str}`, giving the LLM an unambiguous way to express "nothing to extract" without generating natural-language explanations that overwrite the stored profile.
- Wire `_call_llm_for_extraction` to `llm_json_text_with_fallback` so models that support `response_format={"type":"json_object"}` are constrained at the API level; unsupported models degrade automatically.
- Add a three-layer parse fallback so models that ignore structured-output instructions still work: JSON parse → exact-match no-op list → plain-text passthrough.

## Motivation

When a conversation contains no extractable profile information, the LLM sometimes returns a verbose refusal (e.g. `"整段对话未包含任何可提取的用户信息，保持不变"`) instead of an empty string. This bypassed the existing exact-match filter and silently overwrote the user's accumulated profile with the refusal text.

A regex guard was considered but rejected: patterns broad enough to catch all no-op phrasing (e.g. `没有.*信息`) also match valid profile content such as `"用户目前没有任何工作信息，正在求职"`, producing false positives with no reliable fix. Structured output resolves the ambiguity at the source.

## Changes

| Area | What changed |
|------|-------------|
| `src/powermem/prompts/user_profile_prompts.py` | Rewrite instructions 6–9 and `[Target]` section to require `{"changed": bool, "profile": str}`; clarify JSON keys are always English |
| `src/powermem/user_memory/user_memory.py` | `_call_llm_for_extraction`: use `llm_json_text_with_fallback`; `_extract_profile`: replace single-path logic with three-layer parse fallback; drop `_NOOP_PROFILE_RE` |
| `tests/unit/test_extract_profile.py` | 14 new unit tests covering all three layers, edge cases, and the core regression scenario |

**Note:** `_extract_topics` uses a separate JSON contract and is not affected by this change. The inconsistency is known and tracked separately.

## Test plan

- [x] `pytest tests/unit/test_extract_profile.py` — 14 passed
- [x] `pytest tests/unit/` — 186 existing tests passed, no regression
- [ ] Send a conversation with no user information (e.g. "今天天气好"), confirm existing profile is unchanged in storage
- [ ] Send a conversation with valid user information, confirm profile is correctly updated
- [ ] Configure a model that does not support `response_format` (e.g. local Ollama), confirm Layer 3 plain-text fallback activates and logs `INFO`

## Security / privacy

- All three fallback layers log fixed messages only — raw LLM responses are never written to logs, preventing profile content from leaking into log files.
- `profile` field values are written to storage only; they are not executed as code or commands. The indirect prompt-injection vector (profile content later included in LLM context) is pre-existing and out of scope for this PR.

Fixes #933