### PR TITLE
fix(intelligence): use per-memory decay rate for Ebbinghaus decay

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ strict_equality = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/src/powermem/config_loader.py
+++ b/src/powermem/config_loader.py
@@ -291,6 +291,13 @@ class IntelligentMemorySettings(_BasePowermemSettings):
     enabled: bool = Field(default=True)
     initial_retention: float = Field(default=1.0)
     decay_rate: float = Field(default=0.1)
+    decay_rate_multipliers: Dict[str, float] = Field(
+        default_factory=lambda: {
+            "working": 0.5,
+            "short_term": 1.5,
+            "long_term": 2.0,
+        }
+    )
     reinforcement_factor: float = Field(default=0.3)
     working_threshold: float = Field(default=0.3)
     short_term_threshold: float = Field(default=0.6)

--- a/src/powermem/configs.py
+++ b/src/powermem/configs.py
@@ -38,7 +38,18 @@ class IntelligentMemoryConfig(BaseModel):
     )
     decay_rate: float = Field(
         default=0.1,
-        description="Rate at which memories decay over time"
+        description="Base memory decay strength; larger values decay slower"
+    )
+    decay_rate_multipliers: Dict[str, float] = Field(
+        default_factory=lambda: {
+            "working": 0.5,
+            "short_term": 1.5,
+            "long_term": 2.0,
+        },
+        description=(
+            "Per memory_type multiplier on base decay_rate. Larger multipliers "
+            "decay slower and should satisfy working < short_term < long_term."
+        ),
     )
     reinforcement_factor: float = Field(
         default=0.3,

--- a/src/powermem/intelligence/ebbinghaus_algorithm.py
+++ b/src/powermem/intelligence/ebbinghaus_algorithm.py
@@ -17,6 +17,11 @@ class EbbinghausAlgorithm:
     """
     Implements Ebbinghaus forgetting curve algorithm for memory management.
     """
+    DEFAULT_DECAY_RATE_MULTIPLIERS = {
+        "working": 0.5,
+        "short_term": 1.5,
+        "long_term": 2.0,
+    }
     
     def __init__(self, config: Dict[str, Any]):
         """
@@ -30,6 +35,9 @@ class EbbinghausAlgorithm:
         # Ebbinghaus curve parameters
         self.initial_retention = config.get("initial_retention", 1.0)
         self.decay_rate = config.get("decay_rate", 0.1)
+        self.decay_rate_multipliers = self._load_decay_rate_multipliers(
+            config.get("decay_rate_multipliers")
+        )
         self.reinforcement_factor = config.get("reinforcement_factor", 0.3)
         
         # Memory type thresholds
@@ -118,12 +126,17 @@ class EbbinghausAlgorithm:
                 }
             }
     
-    def calculate_decay(self, created_at) -> float:
+    def calculate_decay(
+        self,
+        created_at,
+        decay_rate: Optional[float] = None,
+    ) -> float:
         """
         Calculate decay factor based on time elapsed.
         
         Args:
             created_at: When the memory was created (datetime object or ISO string)
+            decay_rate: Per-memory strength parameter. Larger values decay slower.
             
         Returns:
             Decay factor between 0 and 1
@@ -143,9 +156,14 @@ class EbbinghausAlgorithm:
             time_elapsed = get_current_datetime() - created_at
             hours_elapsed = time_elapsed.total_seconds() / 3600
             
+            rate = self.decay_rate if decay_rate is None else decay_rate
+            if rate <= 0:
+                logger.warning("Invalid decay_rate %s, falling back to default", rate)
+                rate = self.decay_rate
+            
             # Ebbinghaus forgetting curve: R = e^(-t/S)
-            # where R is retention, t is time, S is strength
-            decay_factor = math.exp(-hours_elapsed / (24 * self.decay_rate))
+            # where R is retention, t is time, S is strength.
+            decay_factor = math.exp(-hours_elapsed / (24 * rate))
             
             return max(decay_factor, 0.0)
             
@@ -236,7 +254,10 @@ class EbbinghausAlgorithm:
             # Check decay factor
             created_at = memory.get("created_at")
             if created_at:
-                decay_factor = self.calculate_decay(created_at)
+                decay_factor = self.calculate_decay(
+                    created_at,
+                    decay_rate=self._resolve_decay_rate(memory),
+                )
                 if decay_factor < self.working_threshold:
                     return True
             
@@ -319,14 +340,70 @@ class EbbinghausAlgorithm:
             logger.error(f"Failed to get review schedule: {e}")
             return []
     
+    def _load_decay_rate_multipliers(
+        self, raw: Optional[Dict[str, Any]]
+    ) -> Dict[str, float]:
+        """Load per-memory-type decay multipliers with safe defaults."""
+        multipliers = self.DEFAULT_DECAY_RATE_MULTIPLIERS.copy()
+        if raw:
+            for memory_type, value in raw.items():
+                try:
+                    multiplier = float(value)
+                except (TypeError, ValueError):
+                    logger.warning("Invalid decay multiplier for %s: %s", memory_type, value)
+                    continue
+                if multiplier > 0:
+                    multipliers[memory_type] = multiplier
+        self._validate_decay_rate_multipliers(multipliers)
+        return multipliers
+
+    def _validate_decay_rate_multipliers(
+        self, multipliers: Dict[str, float]
+    ) -> None:
+        """Warn when default tier ordering would not make higher tiers last longer."""
+        working = multipliers.get("working", self.decay_rate)
+        short_term = multipliers.get("short_term", self.decay_rate)
+        long_term = multipliers.get("long_term", self.decay_rate)
+        if not working < short_term < long_term:
+            logger.warning(
+                "decay_rate_multipliers should satisfy "
+                "working < short_term < long_term"
+            )
+    
     def _get_decay_rate_for_type(self, memory_type: str) -> float:
-        """Get decay rate based on memory type."""
-        decay_rates = {
-            "working": self.decay_rate * 2.0,  # Faster decay for working memory
-            "short_term": self.decay_rate * 1.5,  # Medium decay for short-term
-            "long_term": self.decay_rate,  # Standard decay for long-term
-        }
-        return decay_rates.get(memory_type, self.decay_rate)
+        """Get decay strength S based on memory type; larger S decays slower."""
+        multiplier = self.decay_rate_multipliers.get(memory_type)
+        if multiplier is None:
+            return self.decay_rate
+        return self.decay_rate * multiplier
+
+    def _resolve_decay_rate(self, memory: Dict[str, Any]) -> float:
+        """Resolve the effective decay strength for a memory dict."""
+        meta = memory.get("metadata") or {}
+        intelligence = meta.get("intelligence") or memory.get("intelligence") or {}
+
+        memory_type = (
+            memory.get("memory_type")
+            or meta.get("memory_type")
+            or intelligence.get("memory_type")
+        )
+        if memory_type:
+            return self._get_decay_rate_for_type(memory_type)
+
+        stored = (
+            memory.get("decay_rate")
+            or meta.get("decay_rate")
+            or intelligence.get("decay_rate")
+        )
+        if stored is not None:
+            try:
+                rate = float(stored)
+            except (TypeError, ValueError):
+                logger.warning("Invalid stored decay_rate: %s", stored)
+            else:
+                if rate > 0:
+                    return rate
+        return self.decay_rate
     
     def _parse_datetime(self, value: Any) -> datetime:
         """Parse datetime from object or ISO string."""

--- a/src/powermem/intelligence/intelligent_memory_manager.py
+++ b/src/powermem/intelligence/intelligent_memory_manager.py
@@ -178,9 +178,11 @@ class IntelligentMemoryManager:
                     result, query
                 )
                 
-                # Apply decay based on age
+                # Apply decay based on age and memory type
+                decay_rate = self.ebbinghaus_algorithm._resolve_decay_rate(result)
                 decay_factor = self.ebbinghaus_algorithm.calculate_decay(
-                    result.get("created_at", get_current_datetime())
+                    result.get("created_at", get_current_datetime()),
+                    decay_rate=decay_rate,
                 )
                 
                 # Update result with processed information

--- a/tests/unit/intelligence/test_ebbinghaus_decay_rate.py
+++ b/tests/unit/intelligence/test_ebbinghaus_decay_rate.py
@@ -1,0 +1,140 @@
+"""Unit tests for per-memory Ebbinghaus decay rates."""
+
+from datetime import timedelta
+
+import pytest
+
+from powermem.intelligence.ebbinghaus_algorithm import EbbinghausAlgorithm
+from powermem.intelligence.intelligent_memory_manager import IntelligentMemoryManager
+from powermem.utils.utils import get_current_datetime
+
+
+@pytest.fixture
+def algo():
+    return EbbinghausAlgorithm({"decay_rate": 0.1})
+
+
+def test_decay_rate_ordering_by_type(algo):
+    working = algo._get_decay_rate_for_type("working")
+    short_term = algo._get_decay_rate_for_type("short_term")
+    long_term = algo._get_decay_rate_for_type("long_term")
+
+    assert working == pytest.approx(0.05)
+    assert short_term == pytest.approx(0.15)
+    assert long_term == pytest.approx(0.2)
+    assert working < short_term < long_term
+
+
+def test_calculate_decay_uses_explicit_decay_rate(algo):
+    created_at = get_current_datetime() - timedelta(hours=4)
+
+    working_decay = algo.calculate_decay(created_at, decay_rate=0.05)
+    long_term_decay = algo.calculate_decay(created_at, decay_rate=0.2)
+
+    assert working_decay < long_term_decay
+
+
+def test_should_forget_uses_memory_type_decay_rate(algo):
+    created_at = get_current_datetime() - timedelta(hours=2)
+
+    working_memory = {
+        "created_at": created_at,
+        "memory_type": "working",
+        "access_count": 1,
+    }
+    long_term_memory = {
+        "created_at": created_at,
+        "memory_type": "long_term",
+        "access_count": 1,
+    }
+
+    assert algo.should_forget(working_memory) is True
+    assert algo.should_forget(long_term_memory) is False
+
+
+def test_resolve_decay_rate_prefers_memory_type_over_stored_decay_rate(algo):
+    memory = {
+        "metadata": {
+            "memory_type": "working",
+            "intelligence": {
+                "memory_type": "working",
+                "decay_rate": 0.2,
+            },
+        }
+    }
+
+    assert algo._resolve_decay_rate(memory) == pytest.approx(0.05)
+
+
+def test_resolve_decay_rate_reads_nested_intelligence_memory_type(algo):
+    memory = {
+        "metadata": {
+            "intelligence": {
+                "memory_type": "long_term",
+                "decay_rate": 0.1,
+            },
+        }
+    }
+
+    assert algo._resolve_decay_rate(memory) == pytest.approx(0.2)
+
+
+def test_resolve_decay_rate_falls_back_to_stored_rate(algo):
+    memory = {
+        "metadata": {
+            "intelligence": {
+                "decay_rate": 0.17,
+            },
+        }
+    }
+
+    assert algo._resolve_decay_rate(memory) == pytest.approx(0.17)
+
+
+def test_promotion_changes_effective_rate(algo):
+    memory = {"memory_type": "working"}
+    promoted = {"memory_type": "long_term"}
+
+    assert algo._resolve_decay_rate(memory) < algo._resolve_decay_rate(promoted)
+
+
+def test_custom_decay_rate_multipliers_are_applied():
+    custom = EbbinghausAlgorithm(
+        {
+            "decay_rate": 0.2,
+            "decay_rate_multipliers": {
+                "working": 0.25,
+                "short_term": 1.0,
+                "long_term": 3.0,
+            },
+        }
+    )
+
+    assert custom._get_decay_rate_for_type("working") == pytest.approx(0.05)
+    assert custom._get_decay_rate_for_type("short_term") == pytest.approx(0.2)
+    assert custom._get_decay_rate_for_type("long_term") == pytest.approx(0.6)
+
+
+def test_search_results_use_type_specific_decay_rate():
+    manager = IntelligentMemoryManager({"intelligent_memory": {"decay_rate": 0.1}})
+    created_at = get_current_datetime() - timedelta(hours=4)
+    results = [
+        {
+            "id": "working",
+            "content": "shared keyword",
+            "created_at": created_at,
+            "memory_type": "working",
+        },
+        {
+            "id": "long",
+            "content": "shared keyword",
+            "created_at": created_at,
+            "memory_type": "long_term",
+        },
+    ]
+
+    processed = manager.process_search_results(results, "keyword")
+    by_id = {item["id"]: item for item in processed}
+
+    assert by_id["working"]["decay_factor"] < by_id["long"]["decay_factor"]
+    assert processed[0]["id"] == "long"


### PR DESCRIPTION
Fixes #955

## Summary

This PR fixes the per-memory-type Ebbinghaus decay behavior described in #955.

Before this change, `process_memory_metadata()` wrote a type-specific `metadata.intelligence.decay_rate`, but runtime decay paths still used the global `self.decay_rate`. As a result, `working`, `short_term`, and `long_term` memories shared the same time-decay curve during forget checks and optional search re-ranking.

The fix makes runtime decay use the effective per-memory strength parameter, and also corrects the tier multiplier semantics for the current formula:

```text
decay_factor = exp(-hours_elapsed / (24 * S))
```

In this formula, larger `S` means slower decay, so the default tier strengths now satisfy:

```text
working < short_term < long_term
```

## Changes

- Added default `decay_rate_multipliers`:
  - `working`: `0.5`
  - `short_term`: `1.5`
  - `long_term`: `2.0`
- Added `EbbinghausAlgorithm._resolve_decay_rate(memory)` to resolve the effective per-memory decay strength.
- Updated `calculate_decay()` to accept an optional `decay_rate` parameter.
- Updated `should_forget()` to call `calculate_decay(created_at, decay_rate=...)`.
- Updated `IntelligentMemoryManager.process_search_results()` so search re-ranking uses the same per-memory decay resolution.
- Added `decay_rate_multipliers` to both config paths:
  - `IntelligentMemoryConfig`
  - `IntelligentMemorySettings`
- Added regression tests in `tests/unit/intelligence/test_ebbinghaus_decay_rate.py`.
- Added `pythonpath = ["src"]` to pytest config so tests reliably import the current checkout.

## Compatibility Notes

Existing memories may contain old metadata values such as `working = 0.2`, `short_term = 0.15`, `long_term = 0.1`. Those old values are no longer treated as authoritative when a `memory_type` can be resolved. Runtime now prefers `memory_type` and recomputes the effective decay strength from the corrected multipliers. Stored `metadata.intelligence.decay_rate` remains a fallback only for records that do not expose a usable `memory_type`.

## Test plan

- [x] `pytest tests/unit/intelligence/test_ebbinghaus_decay_rate.py -v` (9 passed)
- [x] `pytest tests/unit/intelligence -v`
