### PR TITLE
  Support custom default headers for OpenAI-compatible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,11 +76,12 @@ LLM_PROVIDER=openai
 LLM_API_KEY=your_api_key_here
 LLM_MODEL=gpt-4o-mini
 OPENAI_LLM_BASE_URL=https://api.openai.com/v1
+# Extra headers for OpenAI-compatible LLM gateways. Prefer JSON for multiple
+# headers, e.g. {"X-Custom-Header":"your-value"}.
+# OPENAI_LLM_DEFAULT_HEADERS=
 QWEN_LLM_BASE_URL=https://dashscope.aliyuncs.com/api/v1
 SILICONFLOW_LLM_BASE_URL=https://api.siliconflow.cn/v1
 OLLAMA_LLM_BASE_URL=
 VLLM_LLM_BASE_URL=
 ANTHROPIC_LLM_BASE_URL=https://api.anthropic.com
 DEEPSEEK_LLM_BASE_URL=https://api.deepseek.com
-
-

--- a/.env.example.full
+++ b/.env.example.full
@@ -250,6 +250,9 @@ LLM_ENABLE_SEARCH=false
 #   - SiliconFlow:                      https://api.siliconflow.cn/v1
 #   - Local vLLM / Ollama:              http://localhost:8000/v1 / http://localhost:11434/v1
 OPENAI_LLM_BASE_URL=https://api.openai.com/v1
+# Extra headers for OpenAI-compatible LLM gateways. Prefer JSON for multiple
+# headers, e.g. {"X-Custom-Header":"your-value"}.
+# OPENAI_LLM_DEFAULT_HEADERS=
 #
 # The remaining URLs are only read when you pick that *native* provider instead
 # of routing through `openai` (e.g. LLM_PROVIDER=qwen). Override only when
@@ -310,6 +313,9 @@ EMBEDDING_DIMS=384
 # server, or http://localhost:11434/v1 for Ollama).
 QWEN_EMBEDDING_BASE_URL=https://dashscope.aliyuncs.com/api/v1
 OPENAI_EMBEDDING_BASE_URL=https://api.openai.com/v1
+# Extra headers for OpenAI-compatible embedding gateways. Prefer JSON for
+# multiple headers, e.g. {"X-Custom-Header":"your-value"}.
+# OPENAI_EMBEDDING_DEFAULT_HEADERS=
 # EMBEDDING_OPENAI_PASS_DIMENSIONS — set to `false` for OpenAI-compatible
 # gateways that reject Matryoshka / output-dimension overrides
 # (e.g. Qwen3-Embedding-8B served via an OpenAI-compatible endpoint).

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -132,22 +132,29 @@ jobs:
           echo "SILICONFLOW_CN_API_KEY length: ${#SILICONFLOW_CN_API_KEY}"
           echo "SILICONFLOW_COM_API_KEY length: ${#SILICONFLOW_COM_API_KEY}"
           cp .env.example .env
+          set_env_var() {
+            local key="$1"
+            local value="$2"
+            awk -v prefix="${key}=" 'index($0, prefix) != 1 { print }' .env > .env.tmp
+            mv .env.tmp .env
+            printf '%s=%s\n' "${key}" "${value}" >> .env
+          }
           # Update existing environment variables
-          sed -i 's|^OCEANBASE_HOST=.*|OCEANBASE_HOST=127.0.0.1|' .env
-          sed -i 's|^OCEANBASE_PORT=.*|OCEANBASE_PORT=10001|' .env
-          sed -i 's|^OCEANBASE_USER=.*|OCEANBASE_USER=root|' .env
-          sed -i 's|^OCEANBASE_PASSWORD=.*|OCEANBASE_PASSWORD=|' .env
-          sed -i 's|^OCEANBASE_DATABASE=.*|OCEANBASE_DATABASE=powermem|' .env
-          sed -i 's|^OCEANBASE_COLLECTION=.*|OCEANBASE_COLLECTION=memories|' .env
-          sed -i 's|^DATABASE_PROVIDER=.*|DATABASE_PROVIDER=oceanbase|' .env
-          sed -i 's|^LLM_PROVIDER=.*|LLM_PROVIDER=siliconflow|' .env
-          sed -i 's|^LLM_MODEL=.*|LLM_MODEL=THUDM/GLM-4-9B-0414|' .env
-          sed -i 's|^SILICONFLOW_LLM_BASE_URL=.*|SILICONFLOW_LLM_BASE_URL=https://api.siliconflow.cn/v1|' .env
-          sed -i 's|^GRAPH_STORE_PORT=.*|GRAPH_STORE_PORT=10001|' .env
-          sed -i 's|^GRAPH_STORE_PASSWORD=.*|GRAPH_STORE_PASSWORD=|' .env
-          sed -i "s|^LLM_API_KEY=.*|LLM_API_KEY=${SILICONFLOW_CN_API_KEY}|" .env
-          sed -i "s|^EMBEDDING_API_KEY=.*|EMBEDDING_API_KEY=${QWEN_API_KEY}|" .env
-          sed -i "s|^POWERMEM_SERVER_API_KEYS=.*|POWERMEM_SERVER_API_KEYS=key1,key2,key3|" .env
+          set_env_var OCEANBASE_HOST 127.0.0.1
+          set_env_var OCEANBASE_PORT 10001
+          set_env_var OCEANBASE_USER root
+          set_env_var OCEANBASE_PASSWORD ""
+          set_env_var OCEANBASE_DATABASE powermem
+          set_env_var OCEANBASE_COLLECTION memories
+          set_env_var DATABASE_PROVIDER oceanbase
+          set_env_var LLM_PROVIDER siliconflow
+          set_env_var LLM_MODEL THUDM/GLM-4-9B-0414
+          set_env_var SILICONFLOW_LLM_BASE_URL https://api.siliconflow.cn/v1
+          set_env_var GRAPH_STORE_PORT 10001
+          set_env_var GRAPH_STORE_PASSWORD ""
+          set_env_var LLM_API_KEY "${SILICONFLOW_CN_API_KEY}"
+          set_env_var EMBEDDING_API_KEY "${QWEN_API_KEY}"
+          set_env_var POWERMEM_SERVER_API_KEYS key1,key2,key3
 
       - name: Run regression tests
         id: run_tests
@@ -274,22 +281,29 @@ jobs:
           echo "SILICONFLOW_CN_API_KEY length: ${#SILICONFLOW_CN_API_KEY}"
           echo "SILICONFLOW_COM_API_KEY length: ${#SILICONFLOW_COM_API_KEY}"
           cp .env.example .env
+          set_env_var() {
+            local key="$1"
+            local value="$2"
+            awk -v prefix="${key}=" 'index($0, prefix) != 1 { print }' .env > .env.tmp
+            mv .env.tmp .env
+            printf '%s=%s\n' "${key}" "${value}" >> .env
+          }
           # Update existing environment variables
-          sed -i 's|^OCEANBASE_HOST=.*|OCEANBASE_HOST=127.0.0.1|' .env
-          sed -i 's|^OCEANBASE_PORT=.*|OCEANBASE_PORT=10001|' .env
-          sed -i 's|^OCEANBASE_USER=.*|OCEANBASE_USER=root|' .env
-          sed -i 's|^OCEANBASE_PASSWORD=.*|OCEANBASE_PASSWORD=|' .env
-          sed -i 's|^OCEANBASE_DATABASE=.*|OCEANBASE_DATABASE=powermem|' .env
-          sed -i 's|^OCEANBASE_COLLECTION=.*|OCEANBASE_COLLECTION=memories|' .env
-          sed -i 's|^DATABASE_PROVIDER=.*|DATABASE_PROVIDER=oceanbase|' .env
-          sed -i 's|^LLM_PROVIDER=.*|LLM_PROVIDER=siliconflow|' .env
-          sed -i 's|^LLM_MODEL=.*|LLM_MODEL=THUDM/GLM-4-9B-0414|' .env
-          sed -i 's|^SILICONFLOW_LLM_BASE_URL=.*|SILICONFLOW_LLM_BASE_URL=https://api.siliconflow.cn/v1|' .env
-          sed -i 's|^GRAPH_STORE_PORT=.*|GRAPH_STORE_PORT=10001|' .env
-          sed -i 's|^GRAPH_STORE_PASSWORD=.*|GRAPH_STORE_PASSWORD=|' .env
-          sed -i "s|^LLM_API_KEY=.*|LLM_API_KEY=${SILICONFLOW_CN_API_KEY}|" .env
-          sed -i "s|^EMBEDDING_API_KEY=.*|EMBEDDING_API_KEY=${QWEN_API_KEY}|" .env
-          sed -i "s|^POWERMEM_SERVER_API_KEYS=.*|POWERMEM_SERVER_API_KEYS=key1,key2,key3|" .env
+          set_env_var OCEANBASE_HOST 127.0.0.1
+          set_env_var OCEANBASE_PORT 10001
+          set_env_var OCEANBASE_USER root
+          set_env_var OCEANBASE_PASSWORD ""
+          set_env_var OCEANBASE_DATABASE powermem
+          set_env_var OCEANBASE_COLLECTION memories
+          set_env_var DATABASE_PROVIDER oceanbase
+          set_env_var LLM_PROVIDER siliconflow
+          set_env_var LLM_MODEL THUDM/GLM-4-9B-0414
+          set_env_var SILICONFLOW_LLM_BASE_URL https://api.siliconflow.cn/v1
+          set_env_var GRAPH_STORE_PORT 10001
+          set_env_var GRAPH_STORE_PASSWORD ""
+          set_env_var LLM_API_KEY "${SILICONFLOW_CN_API_KEY}"
+          set_env_var EMBEDDING_API_KEY "${QWEN_API_KEY}"
+          set_env_var POWERMEM_SERVER_API_KEYS key1,key2,key3
 
       - name: Run regression tests
         id: run_tests

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e ".[dev,test]"
+          pip install -e ".[dev,test,seekdb]"
 
       - name: Deploy SeekDB (OceanBase)
         run: |
@@ -232,7 +232,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e ".[dev,test]"
+          pip install -e ".[dev,test,seekdb]"
 
       - name: Deploy SeekDB (OceanBase)
         run: |
@@ -337,4 +337,3 @@ jobs:
           require_tests: false
           job_name: Regression Tests
           check_name: Test Report
-

--- a/docs/guides/0003-configuration.md
+++ b/docs/guides/0003-configuration.md
@@ -383,6 +383,7 @@ OpenAI GPT models are supported.
 | `LLM_API_KEY` | string | Yes* | - | OpenAI API key. Required when `LLM_PROVIDER=openai` |
 | `LLM_MODEL` | string | No | `gpt-4` | OpenAI model name. Options: `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo`, etc. |
 | `OPENAI_LLM_BASE_URL` | string | No | `https://api.openai.com/v1` | API base URL for OpenAI |
+| `OPENAI_LLM_DEFAULT_HEADERS` | JSON/string | No | - | Extra default HTTP headers for OpenAI-compatible gateways. JSON object is recommended for multiple headers. |
 | `LLM_TEMPERATURE` | float | No | `0.7` | Sampling temperature (0.0-2.0) |
 | `LLM_MAX_TOKENS` | integer | No | `1000` | Maximum number of tokens to generate |
 | `LLM_TOP_P` | float | No | `1.0` | Nucleus sampling parameter (0.0-1.0) |
@@ -393,6 +394,7 @@ LLM_PROVIDER=openai
 LLM_API_KEY=your-openai-api-key
 LLM_MODEL=gpt-4
 OPENAI_LLM_BASE_URL=https://api.openai.com/v1
+OPENAI_LLM_DEFAULT_HEADERS={"X-Custom-Header":"your-value"}
 LLM_TEMPERATURE=0.7
 LLM_MAX_TOKENS=1000
 LLM_TOP_P=1.0
@@ -407,6 +409,7 @@ LLM_TOP_P=1.0
       "api_key": "your-openai-api-key",
       "model": "gpt-4",
       "openai_base_url": "https://api.openai.com/v1",
+      "default_headers": {"X-Custom-Header": "your-value"},
       "temperature": 0.7,
       "max_tokens": 1000,
       "top_p": 1.0
@@ -502,6 +505,7 @@ OpenAI provides text embedding models.
 | `EMBEDDING_MODEL` | string | No | `text-embedding-ada-002` | OpenAI embedding model name. Options: `text-embedding-ada-002`, `text-embedding-3-small`, `text-embedding-3-large` |
 | `EMBEDDING_DIMS` | integer | Yes* | `1536` | Vector dimensions. Varies by model (ada-002: 1536, 3-small: 1536, 3-large: 3072). Required when `EMBEDDING_PROVIDER=openai` |
 | `OPEN_EMBEDDING_BASE_URL` | string | No | `https://api.openai.com/v1` | API base URL for OpenAI |
+| `OPENAI_EMBEDDING_DEFAULT_HEADERS` | JSON/string | No | - | Extra default HTTP headers for OpenAI-compatible embedding gateways. JSON object is recommended for multiple headers. |
 
 **Environment Variables Example:**
 ```env
@@ -510,6 +514,7 @@ EMBEDDING_API_KEY=your-openai-api-key
 EMBEDDING_MODEL=text-embedding-ada-002
 EMBEDDING_DIMS=1536
 OPEN_EMBEDDING_BASE_URL=https://api.openai.com/v1
+OPENAI_EMBEDDING_DEFAULT_HEADERS={"X-Custom-Header":"your-value"}
 ```
 
 **JSON Configuration Example:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ mcp = [
     "uvicorn>=0.27.1",
 ]
 seekdb = [
-    "pyseekdb>=1.3.0",
+    "pyobvector[pyseekdb]>=0.2.24,<0.3.0",
 ]
 extras = [
     "sentence-transformers>=5.0.0",
@@ -171,5 +171,6 @@ markers = [
     "integration: Integration tests",
     "e2e: End-to-end tests",
     "e2e_config: End-to-end tests requiring real configuration (not included in default test suite)",
+    "api: Tests requiring external API credentials",
     "slow: Slow running tests",
 ]

--- a/src/powermem/integrations/embeddings/config/providers.py
+++ b/src/powermem/integrations/embeddings/config/providers.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, Optional, Union
 
 import httpx
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator
 
 from powermem.integrations.embeddings.config.base import BaseEmbedderConfig
 from powermem.settings import settings_config
+from powermem.utils.headers import parse_default_headers
 
 
 class OpenAIEmbeddingConfig(BaseEmbedderConfig):
@@ -22,6 +23,15 @@ class OpenAIEmbeddingConfig(BaseEmbedderConfig):
             "OPEN_EMBEDDING_BASE_URL",
         ),
     )
+    default_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "default_headers",
+            "OPENAI_EMBEDDING_DEFAULT_HEADERS",
+            "EMBEDDING_DEFAULT_HEADERS",
+        ),
+        description="Extra default headers sent with OpenAI-compatible embedding requests",
+    )
     #: When False, omit the ``dimensions`` argument on ``embeddings.create`` (required for some
     #: OpenAI-compatible gateways that reject Matryoshka / output-dimension overrides).
     pass_dimensions: bool = Field(
@@ -31,6 +41,11 @@ class OpenAIEmbeddingConfig(BaseEmbedderConfig):
             "EMBEDDING_OPENAI_PASS_DIMENSIONS",
         ),
     )
+
+    @field_validator("default_headers", mode="before")
+    @classmethod
+    def _parse_default_headers(cls, value):
+        return parse_default_headers(value)
 
 
 class QwenEmbeddingConfig(BaseEmbedderConfig):

--- a/src/powermem/integrations/embeddings/openai.py
+++ b/src/powermem/integrations/embeddings/openai.py
@@ -29,7 +29,11 @@ class OpenAIEmbedding(EmbeddingBase):
                 DeprecationWarning,
             )
 
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        client_kwargs = {"api_key": api_key, "base_url": base_url}
+        default_headers = getattr(self.config, "default_headers", None)
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
+        self.client = OpenAI(**client_kwargs)
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """

--- a/src/powermem/integrations/llm/config/openai.py
+++ b/src/powermem/integrations/llm/config/openai.py
@@ -1,9 +1,10 @@
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator
 
 from powermem.integrations.llm.config.base import BaseLLMConfig
 from powermem.settings import settings_config
+from powermem.utils.headers import parse_default_headers
 
 
 class OpenAIConfig(BaseLLMConfig):
@@ -36,6 +37,16 @@ class OpenAIConfig(BaseLLMConfig):
             "OPENAI_LLM_BASE_URL",
         ),
         description="OpenAI API base URL"
+    )
+
+    default_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "default_headers",
+            "OPENAI_LLM_DEFAULT_HEADERS",
+            "LLM_DEFAULT_HEADERS",
+        ),
+        description="Extra default headers sent with OpenAI-compatible LLM requests",
     )
     
     models: Optional[List[str]] = Field(
@@ -73,3 +84,8 @@ class OpenAIConfig(BaseLLMConfig):
         exclude=True,
         description="Optional callback for monitoring LLM responses"
     )
+
+    @field_validator("default_headers", mode="before")
+    @classmethod
+    def _parse_default_headers(cls, value):
+        return parse_default_headers(value)

--- a/src/powermem/integrations/llm/openai.py
+++ b/src/powermem/integrations/llm/openai.py
@@ -51,6 +51,7 @@ class OpenAILLM(LLMBase):
                 enable_vision=config.enable_vision,
                 vision_details=config.vision_details,
                 http_client_proxies=config.http_client,
+                default_headers=getattr(config, "default_headers", None),
             )
 
         super().__init__(config)
@@ -58,18 +59,26 @@ class OpenAILLM(LLMBase):
         if not self.config.model:
             self.config.model = "gpt-4o-mini"
 
+        default_headers = getattr(self.config, "default_headers", None)
+
         if os.environ.get("OPENROUTER_API_KEY"):  # Use OpenRouter
-            self.client = OpenAI(
-                api_key=os.environ.get("OPENROUTER_API_KEY"),
-                base_url=getattr(self.config, "openrouter_base_url", None)
+            client_kwargs = {
+                "api_key": os.environ.get("OPENROUTER_API_KEY"),
+                "base_url": getattr(self.config, "openrouter_base_url", None)
                 or os.getenv("OPENROUTER_API_BASE")
                 or "https://openrouter.ai/api/v1",
-            )
+            }
+            if default_headers:
+                client_kwargs["default_headers"] = default_headers
+            self.client = OpenAI(**client_kwargs)
         else:
             api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
             base_url = getattr(self.config, "openai_base_url", None) or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
 
-            self.client = OpenAI(api_key=api_key, base_url=base_url)
+            client_kwargs = {"api_key": api_key, "base_url": base_url}
+            if default_headers:
+                client_kwargs["default_headers"] = default_headers
+            self.client = OpenAI(**client_kwargs)
 
     def _parse_response(self, response, tools):
         """

--- a/src/powermem/integrations/llm/openai_structured.py
+++ b/src/powermem/integrations/llm/openai_structured.py
@@ -17,7 +17,11 @@ class OpenAIStructuredLLM(LLMBase):
 
         api_key = self.config.api_key or os.getenv("OPENAI_API_KEY")
         base_url = getattr(self.config, "openai_base_url", None) or os.getenv("OPENAI_API_BASE") or "https://api.openai.com/v1"
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        client_kwargs = {"api_key": api_key, "base_url": base_url}
+        default_headers = getattr(self.config, "default_headers", None)
+        if default_headers:
+            client_kwargs["default_headers"] = default_headers
+        self.client = OpenAI(**client_kwargs)
 
     def generate_response(
             self,

--- a/src/powermem/utils/headers.py
+++ b/src/powermem/utils/headers.py
@@ -1,0 +1,44 @@
+import json
+import re
+from collections.abc import Mapping
+from typing import Dict, Optional
+
+
+def parse_default_headers(value) -> Optional[Dict[str, str]]:
+    """Parse provider default headers from a dict, JSON object, or `Name: value` list."""
+    if value is None:
+        return None
+
+    if isinstance(value, Mapping):
+        return {str(key): str(val) for key, val in value.items() if val is not None}
+
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError:
+            decoded = None
+        if isinstance(decoded, Mapping):
+            return parse_default_headers(decoded)
+        if decoded is not None:
+            raise ValueError("default_headers JSON value must be an object")
+
+        headers: Dict[str, str] = {}
+        for item in re.split(r"[\n;,]+", raw):
+            item = item.strip()
+            if not item:
+                continue
+            if ":" not in item:
+                raise ValueError("default_headers entries must use 'Header-Name: value'")
+            name, header_value = item.split(":", 1)
+            name = name.strip()
+            header_value = header_value.strip()
+            if not name:
+                raise ValueError("default_headers header names cannot be empty")
+            headers[name] = header_value
+        return headers or None
+
+    raise ValueError("default_headers must be a mapping or string")

--- a/tests/regression/test_scenario_6_sub_stores.py
+++ b/tests/regression/test_scenario_6_sub_stores.py
@@ -75,11 +75,11 @@ BASE_CONFIG: Dict[str, Any] = {
             "collection_name": "demo_memories",
             "embedding_model_dims": 768,
             "connection_args": {
-                "host": os.getenv("OCEANBASE_HOST", "6.12.235.2"),
+                "host": os.getenv("OCEANBASE_HOST", "127.0.0.1"),
                 "port": int(os.getenv("OCEANBASE_PORT", "10001")),
                 "user": os.getenv("OCEANBASE_USER", "root"),
                 "password": os.getenv("OCEANBASE_PASSWORD", ""),
-                "db_name": os.getenv("OCEANBASE_DB", "powermem"),
+                "db_name": os.getenv("OCEANBASE_DATABASE", "powermem"),
             },
         },
     },
@@ -333,4 +333,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/tests/regression/test_scenario_7_multimodal.py
+++ b/tests/regression/test_scenario_7_multimodal.py
@@ -80,7 +80,7 @@ custom_config = {
                 "port": int(os.getenv("OCEANBASE_PORT", "10001")),
                 "user": os.getenv("OCEANBASE_USER", "root"),
                 "password": os.getenv("OCEANBASE_PASSWORD", ""),
-                "db_name": os.getenv("OCEANBASE_DB", "powermem"),
+                "db_name": os.getenv("OCEANBASE_DATABASE", "powermem"),
             },
             "vidx_metric_type": "cosine",
             "index_type": "IVF_FLAT",

--- a/tests/unit/test_openai.py
+++ b/tests/unit/test_openai.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -15,7 +14,7 @@ def mock_openai_client():
         yield mock_client
 
 
-def test_openai_llm_base_url():
+def test_openai_llm_base_url(monkeypatch):
     # case1: default config: with openai official base url
     config = OpenAIConfig(model="gpt-4o", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
     llm = OpenAILLM(config)
@@ -24,7 +23,7 @@ def test_openai_llm_base_url():
 
     # case2: with env variable OPENAI_API_BASE
     provider_base_url = "https://api.provider.com/v1"
-    os.environ["OPENAI_BASE_URL"] = provider_base_url
+    monkeypatch.setenv("OPENAI_BASE_URL", provider_base_url)
     config = OpenAIConfig(model="gpt-4o", temperature=0.7, max_tokens=100, top_p=1.0, api_key="api_key")
     llm = OpenAILLM(config)
     # Note: openai client will parse the raw base_url into a URL object, which will have a trailing slash


### PR DESCRIPTION
## Summary

  Adds configurable default HTTP headers for OpenAI-compatible LLM and embedding providers, so deployments behind custom gateways can pass required headers
  such as `yourkey`.

  ## Changes

  - Added `default_headers` support for:
    - OpenAI LLM
    - OpenAI structured LLM
    - OpenAI embeddings
  - Added env config aliases:
    - `OPENAI_LLM_DEFAULT_HEADERS`
    - `LLM_DEFAULT_HEADERS`
    - `OPENAI_EMBEDDING_DEFAULT_HEADERS`
    - `EMBEDDING_DEFAULT_HEADERS`
  - Added shared header parsing utility supporting:
    - dict config
    - JSON object strings
    - `Header-Name: value` strings
  - Documented the new env options in `.env.example`, `.env.example.full`, and configuration docs.
  - Fixed `tests/unit/test_openai.py` to avoid leaking `OPENAI_BASE_URL` into later tests.

  ## Example

  ```env
  EMBEDDING_PROVIDER=openai
  EMBEDDING_API_KEY=your-ak
  EMBEDDING_MODEL=qwen3-embedding
  OPENAI_EMBEDDING_BASE_URL=http://ip/qwen3-embedding/v1
  OPENAI_EMBEDDING_DEFAULT_HEADERS={"key":"xxx-appid"}
