### PR TITLE
fix(ci): isolate regression embedding dimensions

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -145,13 +145,18 @@ jobs:
           set_env_var OCEANBASE_USER root
           set_env_var OCEANBASE_PASSWORD ""
           set_env_var OCEANBASE_DATABASE powermem
-          set_env_var OCEANBASE_COLLECTION memories
+          set_env_var OCEANBASE_COLLECTION memories_1536
           set_env_var DATABASE_PROVIDER oceanbase
           set_env_var LLM_PROVIDER siliconflow
           set_env_var LLM_MODEL THUDM/GLM-4-9B-0414
           set_env_var SILICONFLOW_LLM_BASE_URL https://api.siliconflow.cn/v1
+          set_env_var EMBEDDING_PROVIDER qwen
+          set_env_var EMBEDDING_MODEL text-embedding-v4
+          set_env_var EMBEDDING_DIMS 1536
+          set_env_var QWEN_EMBEDDING_BASE_URL https://dashscope.aliyuncs.com/api/v1
           set_env_var GRAPH_STORE_PORT 10001
           set_env_var GRAPH_STORE_PASSWORD ""
+          set_env_var OCEANBASE_EMBEDDING_MODEL_DIMS 1536
           set_env_var LLM_API_KEY "${SILICONFLOW_CN_API_KEY}"
           set_env_var EMBEDDING_API_KEY "${QWEN_API_KEY}"
           set_env_var POWERMEM_SERVER_API_KEYS key1,key2,key3
@@ -294,13 +299,18 @@ jobs:
           set_env_var OCEANBASE_USER root
           set_env_var OCEANBASE_PASSWORD ""
           set_env_var OCEANBASE_DATABASE powermem
-          set_env_var OCEANBASE_COLLECTION memories
+          set_env_var OCEANBASE_COLLECTION memories_1536
           set_env_var DATABASE_PROVIDER oceanbase
           set_env_var LLM_PROVIDER siliconflow
           set_env_var LLM_MODEL THUDM/GLM-4-9B-0414
           set_env_var SILICONFLOW_LLM_BASE_URL https://api.siliconflow.cn/v1
+          set_env_var EMBEDDING_PROVIDER qwen
+          set_env_var EMBEDDING_MODEL text-embedding-v4
+          set_env_var EMBEDDING_DIMS 1536
+          set_env_var QWEN_EMBEDDING_BASE_URL https://dashscope.aliyuncs.com/api/v1
           set_env_var GRAPH_STORE_PORT 10001
           set_env_var GRAPH_STORE_PASSWORD ""
+          set_env_var OCEANBASE_EMBEDDING_MODEL_DIMS 1536
           set_env_var LLM_API_KEY "${SILICONFLOW_CN_API_KEY}"
           set_env_var EMBEDDING_API_KEY "${QWEN_API_KEY}"
           set_env_var POWERMEM_SERVER_API_KEYS key1,key2,key3

--- a/tests/regression/test_scenario_7_multimodal.py
+++ b/tests/regression/test_scenario_7_multimodal.py
@@ -74,7 +74,7 @@ custom_config = {
     "vector_store": {
         "provider": "oceanbase",
         "config": {
-            "collection_name": "memories",  # Changed to avoid dimension mismatch
+            "collection_name": os.getenv("OCEANBASE_COLLECTION", "memories_1536"),
             "connection_args": {
                 "host": os.getenv("OCEANBASE_HOST", "127.0.0.1"),
                 "port": int(os.getenv("OCEANBASE_PORT", "10001")),

--- a/tests/regression/test_scenario_9_default_embedding_384.py
+++ b/tests/regression/test_scenario_9_default_embedding_384.py
@@ -1,0 +1,112 @@
+"""Regression coverage for the built-in 384-dim default embedder.
+
+The main regression workflow pins Qwen text-embedding-v4 (1536 dims). This file
+keeps explicit coverage for the zero-config local embedder on its own OceanBase
+collection so table dimensions cannot conflict with the 1536-dim path.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from dotenv import load_dotenv
+from powermem import create_memory
+
+
+env_path = os.path.join(os.path.dirname(__file__), "..", "..", ".env")
+if os.path.exists(env_path):
+    print("Found .env file")
+    load_dotenv(env_path, override=True)
+
+
+USER_ID = "scenario9_default_embedder_user"
+COLLECTION_NAME = "memories_384"
+
+
+def _results(result: Any) -> List[Dict[str, Any]]:
+    if isinstance(result, dict) and isinstance(result.get("results"), list):
+        return result["results"]
+    return []
+
+
+def _memory_text(entry: Dict[str, Any]) -> str:
+    return (
+        entry.get("memory")
+        or entry.get("content")
+        or entry.get("text")
+        or entry.get("data")
+        or ""
+    )
+
+
+def _default_embedding_config() -> Dict[str, Any]:
+    return {
+        "llm": {
+            "provider": os.getenv("LLM_PROVIDER", "siliconflow"),
+            "config": {
+                "model": os.getenv("LLM_MODEL", "THUDM/GLM-4-9B-0414"),
+                "api_key": os.getenv("LLM_API_KEY"),
+                "openai_base_url": os.getenv("SILICONFLOW_LLM_BASE_URL"),
+            },
+        },
+        "vector_store": {
+            "provider": "oceanbase",
+            "config": {
+                "collection_name": COLLECTION_NAME,
+                "connection_args": {
+                    "host": os.getenv("OCEANBASE_HOST", "127.0.0.1"),
+                    "port": int(os.getenv("OCEANBASE_PORT", "10001")),
+                    "user": os.getenv("OCEANBASE_USER", "root"),
+                    "password": os.getenv("OCEANBASE_PASSWORD", ""),
+                    "db_name": os.getenv("OCEANBASE_DATABASE", "powermem"),
+                },
+                "embedding_model_dims": 384,
+                "vidx_metric_type": "cosine",
+                "index_type": "HNSW",
+                "primary_field": "id",
+                "vector_field": "embedding",
+                "text_field": "document",
+                "metadata_field": "metadata",
+                "vidx_name": "memories_384_vidx",
+            },
+        },
+        "embedder": {
+            "provider": "default",
+            "config": {
+                "model": "all-MiniLM-L6-v2",
+                "embedding_dims": 384,
+            },
+        },
+    }
+
+
+def test_default_embedder_384_add_and_search() -> None:
+    memory = create_memory(config=_default_embedding_config())
+    try:
+        memory.delete_all(user_id=USER_ID)
+    except Exception:
+        pass
+
+    try:
+        result = memory.add(
+            "User likes local 384 dimension embeddings",
+            user_id=USER_ID,
+            metadata={"scenario": "default_embedding_384"},
+            infer=False,
+        )
+        assert _results(result), "simple add should return one stored memory"
+
+        search_result = memory.search(
+            "local embeddings",
+            user_id=USER_ID,
+            limit=5,
+        )
+        matches = _results(search_result)
+        assert matches, "search should return the memory stored with the 384-dim embedder"
+        assert any("384 dimension" in _memory_text(item) for item in matches)
+    finally:
+        try:
+            memory.delete_all(user_id=USER_ID)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

  Fix regression CI embedding dimension conflicts after the default embedder changed to the local 384-dim `all-MiniLM-L6-v2`.

  ## Changes

  - Pin the main regression workflow to Qwen `text-embedding-v4` with 1536 dimensions.
  - Move the main regression OceanBase collection to `memories_1536`.
  - Make the multimodal scenario use `OCEANBASE_COLLECTION` instead of hardcoding `memories`.
  - Add a dedicated 384-dim regression scenario using the built-in default embedder on `memories_384`.

  ## Why

  Regression tests previously shared the same OceanBase collection name, `memories`.

  After the zero-config default embedder change, regular scenarios created a 384-dim `memories` table, while multimodal tests still expected 1536 dimensions.
  OceanBase correctly rejected the mismatch.

  This separates the 1536-dim and 384-dim paths so both are covered without table schema conflicts.

  ## Testing

  - `python -m py_compile tests/regression/test_scenario_7_multimodal.py tests/regression/test_scenario_9_default_embedding_384.py`
  - `pytest tests/unit/test_pyseekdb_default_embeddings.py -q`
  - `pytest tests/regression/test_scenario_9_default_embedding_384.py -q`
  - `pytest tests/regression/test_scenario_7_multimodal.py --collect-only -q`