### PR TITLE
fix(llm): wire base_url into AnthropicLLM and ZaiLLM clients

### DIFF
--- a/src/powermem/integrations/llm/anthropic.py
+++ b/src/powermem/integrations/llm/anthropic.py
@@ -38,7 +38,8 @@ class AnthropicLLM(LLMBase):
             self.config.model = "claude-3-5-sonnet-20240620"
 
         api_key = self.config.api_key or os.getenv("ANTHROPIC_API_KEY")
-        self.client = anthropic.Anthropic(api_key=api_key)
+        base_url = getattr(self.config, "anthropic_base_url", None) or os.getenv("ANTHROPIC_BASE_URL")
+        self.client = anthropic.Anthropic(api_key=api_key, base_url=base_url)
 
     def generate_response(
             self,

--- a/src/powermem/integrations/llm/zai.py
+++ b/src/powermem/integrations/llm/zai.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
-from zai import ZhipuAiClient
+from openai import OpenAI
 
 from powermem.integrations.llm import LLMBase
 from powermem.integrations.llm.config.base import BaseLLMConfig
@@ -53,9 +53,9 @@ class ZaiLLM(LLMBase):
 
         # Get API key from config or environment
         api_key = self.config.api_key or os.getenv("ZAI_API_KEY")
+        base_url = getattr(self.config, "zai_base_url", None) or os.getenv("ZAI_BASE_URL")
 
-        # Initialize Zhipu AI client
-        self.client = ZhipuAiClient(api_key=api_key)
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
 
     def _parse_response(self, response, tools):
         """

--- a/tests/unit/test_anthropic.py
+++ b/tests/unit/test_anthropic.py
@@ -1,0 +1,29 @@
+import pytest
+
+pytest.importorskip("anthropic")
+
+from powermem.integrations.llm.config.anthropic import AnthropicConfig
+from powermem.integrations.llm.anthropic import AnthropicLLM
+
+
+def test_anthropic_llm_base_url(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    # case 1: config field takes precedence
+    config_url = "https://via-config.example.com"
+    llm = AnthropicLLM(AnthropicConfig(api_key="fake", anthropic_base_url=config_url))
+    assert str(llm.client.base_url) == config_url
+
+    # case 2: ANTHROPIC_LLM_BASE_URL env var (PowerMem convention, read by AnthropicConfig)
+    env_url = "https://via-llm-base-url.example.com"
+    monkeypatch.setenv("ANTHROPIC_LLM_BASE_URL", env_url)
+    llm = AnthropicLLM(AnthropicConfig(api_key="fake"))
+    assert str(llm.client.base_url) == env_url
+    monkeypatch.delenv("ANTHROPIC_LLM_BASE_URL")
+
+    # case 3: ANTHROPIC_BASE_URL env var (Claude Code convention, fallback in anthropic.py)
+    compat_url = "https://via-anthropic-base-url.example.com"
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", compat_url)
+    llm = AnthropicLLM(AnthropicConfig(api_key="fake"))
+    assert str(llm.client.base_url) == compat_url

--- a/tests/unit/test_zai.py
+++ b/tests/unit/test_zai.py
@@ -1,0 +1,126 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from powermem.integrations.llm.config.zai import ZaiConfig
+from powermem.integrations.llm.zai import ZaiLLM
+
+
+@pytest.fixture
+def mock_openai_client():
+    with patch("powermem.integrations.llm.zai.OpenAI") as mock_openai:
+        mock_client = Mock()
+        mock_openai.return_value = mock_client
+        yield mock_client
+
+
+def test_zai_llm_base_url(monkeypatch):
+    monkeypatch.delenv("ZAI_BASE_URL", raising=False)
+
+    # case 1: default base_url from ZaiConfig
+    default_url = "https://open.bigmodel.cn/api/paas/v4/"
+    llm = ZaiLLM(ZaiConfig(api_key="fake"))
+    assert str(llm.client.base_url) == default_url
+
+    # case 2: ZAI_BASE_URL env var (read by ZaiConfig via AliasChoices)
+    env_url = "https://via-env.example.com/v1"
+    monkeypatch.setenv("ZAI_BASE_URL", env_url)
+    llm = ZaiLLM(ZaiConfig(api_key="fake"))
+    assert str(llm.client.base_url) == env_url + "/"
+    monkeypatch.delenv("ZAI_BASE_URL")
+
+    # case 3: config field zai_base_url
+    config_url = "https://via-config.example.com/v1"
+    llm = ZaiLLM(ZaiConfig(api_key="fake", zai_base_url=config_url))
+    assert str(llm.client.base_url) == config_url + "/"
+
+
+def test_generate_response_without_tools(mock_openai_client):
+    config = ZaiConfig(model="glm-4.7", temperature=0.7, max_tokens=100, top_p=1.0, api_key="fake")
+    llm = ZaiLLM(config)
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello!"},
+    ]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="Hi there!", tool_calls=None))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+
+    mock_openai_client.chat.completions.create.assert_called_once()
+    assert response == "Hi there!"
+
+
+def test_generate_response_with_tools(mock_openai_client):
+    config = ZaiConfig(model="glm-4.7", api_key="fake")
+    llm = ZaiLLM(config)
+    messages = [{"role": "user", "content": "Add a memory."}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add_memory",
+                "description": "Add a memory",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"data": {"type": "string"}},
+                    "required": ["data"],
+                },
+            },
+        }
+    ]
+
+    mock_tool_call = Mock()
+    mock_tool_call.function.name = "add_memory"
+    mock_tool_call.function.arguments = '{"data": "test memory"}'
+
+    mock_message = Mock()
+    mock_message.content = "Done."
+    mock_message.tool_calls = [mock_tool_call]
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages, tools=tools)
+
+    assert response["content"] == "Done."
+    assert len(response["tool_calls"]) == 1
+    assert response["tool_calls"][0]["name"] == "add_memory"
+    assert response["tool_calls"][0]["arguments"] == {"data": "test memory"}
+
+
+def test_response_callback_invocation(mock_openai_client):
+    mock_callback = Mock()
+    config = ZaiConfig(model="glm-4.7", api_key="fake", response_callback=mock_callback)
+    llm = ZaiLLM(config)
+    messages = [{"role": "user", "content": "Test"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="OK", tool_calls=None))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    llm.generate_response(messages)
+
+    mock_callback.assert_called_once()
+    args = mock_callback.call_args[0]
+    assert args[0] is llm
+    assert args[1] == mock_response
+    assert "messages" in args[2]
+
+
+def test_callback_exception_does_not_propagate(mock_openai_client):
+    def faulty_callback(*args):
+        raise ValueError("boom")
+
+    config = ZaiConfig(model="glm-4.7", api_key="fake", response_callback=faulty_callback)
+    llm = ZaiLLM(config)
+    messages = [{"role": "user", "content": "Test"}]
+
+    mock_response = Mock()
+    mock_response.choices = [Mock(message=Mock(content="OK", tool_calls=None))]
+    mock_openai_client.chat.completions.create.return_value = mock_response
+
+    response = llm.generate_response(messages)
+    assert response == "OK"


### PR DESCRIPTION
## Summary

- `AnthropicConfig` already declares `anthropic_base_url` (env: `ANTHROPIC_LLM_BASE_URL`) but
  `AnthropicLLM.__init__` never forwarded it to the `anthropic.Anthropic()` constructor — the field
  was silently ignored.
- Added a secondary fallback to `ANTHROPIC_BASE_URL` so users whose Claude Code sets that variable
  automatically get the correct endpoint without extra `.env` config.
- `ZaiConfig` already declares `zai_base_url` (env: `ZAI_BASE_URL`, default
  `https://open.bigmodel.cn/api/paas/v4/`) but `ZaiLLM.__init__` never forwarded it either.
- Replaced the `ZhipuAiClient` (from the `zai` SDK) with `openai.OpenAI` since Zhipu AI exposes
  an OpenAI-compatible endpoint — `base_url` is then passed directly, and a separate SDK
  dependency is removed with no behaviour change.
- Added unit tests for both providers following the pattern of `tests/unit/test_openai.py`.

## Motivation

Users pointing `AnthropicLLM` or `ZaiLLM` at a private proxy or a regional mirror had no
working way to redirect requests even though the config fields existed:

| Provider | Config field | Env var | Effect before this fix |
|---|---|---|---|
| Anthropic | `anthropic_base_url` | `ANTHROPIC_LLM_BASE_URL` | Declared but never read — every request went to `api.anthropic.com` |
| Anthropic | — | `ANTHROPIC_BASE_URL` | Not read at all — Claude Code users needed manual workaround |
| ZAI | `zai_base_url` | `ZAI_BASE_URL` | Declared but never read — always hit the hardcoded Zhipu default |

## Changes

| File | What changed |
|---|---|
| `src/powermem/integrations/llm/anthropic.py` | Read `anthropic_base_url` from config and `ANTHROPIC_BASE_URL` from env; pass `base_url` to `anthropic.Anthropic()` |
| `src/powermem/integrations/llm/zai.py` | Replace `ZhipuAiClient` with `openai.OpenAI`; read `zai_base_url` from config and pass as `base_url` |
| `tests/unit/test_anthropic.py` | New — covers config field, `ANTHROPIC_LLM_BASE_URL`, and `ANTHROPIC_BASE_URL` |
| `tests/unit/test_zai.py` | New — covers default URL, config field, `ZAI_BASE_URL`, `generate_response`, callback |

## Test plan

- [x] `pytest tests/unit/test_anthropic.py tests/unit/test_zai.py` — 6 passed
- [x] Real ZAI API call with `zai_base_url` explicitly set — response returned correctly
- [x] Real ZAI API call with default `zai_base_url` — response returned correctly
- [x] `AnthropicLLM` with `anthropic_base_url` config field — `client.base_url` matches
- [x] `AnthropicLLM` with `ANTHROPIC_BASE_URL` env var — `client.base_url` matches