### PR TITLE
fix(ci): keep optional dependencies from breaking regression server

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e ".[dev,test,seekdb]"
+          pip install -e ".[dev,test,server,seekdb]"
 
       - name: Deploy SeekDB (OceanBase)
         run: |
@@ -244,7 +244,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e ".[dev,test,seekdb]"
+          pip install -e ".[dev,test,server,seekdb]"
 
       - name: Deploy SeekDB (OceanBase)
         run: |

--- a/src/powermem/integrations/embeddings/ollama.py
+++ b/src/powermem/integrations/embeddings/ollama.py
@@ -1,5 +1,3 @@
-import subprocess
-import sys
 from typing import Literal, Optional
 
 from powermem.integrations.embeddings.base import EmbeddingBase
@@ -7,22 +5,21 @@ from powermem.integrations.embeddings.config.base import BaseEmbedderConfig
 
 try:
     from ollama import Client
-except ImportError:
-    user_input = input("The 'ollama' library is required. Install it now? [y/N]: ")
-    if user_input.lower() == "y":
-        try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "ollama"])
-            from ollama import Client
-        except subprocess.CalledProcessError:
-            print("Failed to install 'ollama'. Please install it manually using 'pip install ollama'.")
-            sys.exit(1)
-    else:
-        print("The required 'ollama' library is not installed.")
-        sys.exit(1)
+except ImportError as exc:
+    Client = None
+    _OLLAMA_IMPORT_ERROR = exc
+else:
+    _OLLAMA_IMPORT_ERROR = None
 
 
 class OllamaEmbedding(EmbeddingBase):
     def __init__(self, config: Optional[BaseEmbedderConfig] = None):
+        if Client is None:
+            raise ImportError(
+                "The 'ollama' library is required. "
+                "Please install it using 'pip install ollama'."
+            ) from _OLLAMA_IMPORT_ERROR
+
         super().__init__(config)
 
         self.config.model = self.config.model or "nomic-embed-text"

--- a/src/powermem/mcp/server.py
+++ b/src/powermem/mcp/server.py
@@ -14,21 +14,19 @@ Provides 13 tools for memory and user profile management:
 Requires: pip install 'powermem[mcp]'
 """
 
-import sys as _sys
-
-
 def _require_mcp_deps() -> None:
     missing = []
+    import_error = None
     try:
         import fastmcp  # noqa: F401
-    except ImportError:
+    except ImportError as exc:
         missing.append("fastmcp")
+        import_error = exc
     if missing:
-        _sys.stderr.write(
-            f"Missing dependencies: {', '.join(missing)}.\n"
-            "Run: pip install 'powermem[mcp]'\n"
-        )
-        _sys.exit(1)
+        raise ImportError(
+            f"Missing dependencies: {', '.join(missing)}. "
+            "Run: pip install 'powermem[mcp]'"
+        ) from import_error
 
 
 _require_mcp_deps()

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -21,6 +21,7 @@ from .middleware.auth import verify_api_key
 
 import os
 import logging
+from importlib.util import find_spec
 
 # Setup logging
 setup_logging()
@@ -33,6 +34,10 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 def _load_mcp_asgi_app():
     """Return streamable HTTP MCP ASGI app when powermem[mcp] is installed."""
+    if find_spec("fastmcp") is None:
+        logger.warning("MCP extras not installed; /mcp endpoint disabled")
+        return None
+
     try:
         from powermem.mcp.server import mcp
 

--- a/tests/unit/server/test_main_mcp_optional.py
+++ b/tests/unit/server/test_main_mcp_optional.py
@@ -1,0 +1,20 @@
+import builtins
+
+
+def test_load_mcp_asgi_app_skips_mcp_import_when_fastmcp_missing(monkeypatch):
+    from server import main
+
+    monkeypatch.setattr(
+        main, "find_spec", lambda name: None if name == "fastmcp" else object()
+    )
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "powermem.mcp.server":
+            raise AssertionError("MCP server should not be imported without fastmcp")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    assert main._load_mcp_asgi_app() is None

--- a/tests/unit/server/test_main_mcp_optional.py
+++ b/tests/unit/server/test_main_mcp_optional.py
@@ -1,7 +1,11 @@
 import builtins
 
+import pytest
+
 
 def test_load_mcp_asgi_app_skips_mcp_import_when_fastmcp_missing(monkeypatch):
+    pytest.importorskip("fastapi", exc_type=ImportError)
+
     from server import main
 
     monkeypatch.setattr(

--- a/tests/unit/test_optional_dependency_imports.py
+++ b/tests/unit/test_optional_dependency_imports.py
@@ -1,0 +1,58 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+from powermem.integrations.embeddings.config.base import BaseEmbedderConfig
+
+
+def _restore_module(module_name, saved_module):
+    if saved_module is None:
+        sys.modules.pop(module_name, None)
+    else:
+        sys.modules[module_name] = saved_module
+
+
+def test_mcp_missing_fastmcp_raises_import_error_not_system_exit(monkeypatch):
+    module_name = "powermem.mcp.server"
+    saved_module = sys.modules.pop(module_name, None)
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "fastmcp" or name.startswith("fastmcp."):
+            raise ImportError("fastmcp unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    try:
+        with pytest.raises(ImportError, match="powermem\\[mcp\\]"):
+            importlib.import_module(module_name)
+    finally:
+        _restore_module(module_name, saved_module)
+
+
+def test_ollama_embedding_missing_dependency_imports_without_prompt(monkeypatch):
+    module_name = "powermem.integrations.embeddings.ollama"
+    saved_module = sys.modules.pop(module_name, None)
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "ollama" or name.startswith("ollama."):
+            raise ImportError("ollama unavailable")
+        return real_import(name, *args, **kwargs)
+
+    def fail_input(*args, **kwargs):
+        raise AssertionError("missing optional dependency should not prompt on import")
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+    monkeypatch.setattr(builtins, "input", fail_input)
+
+    try:
+        module = importlib.import_module(module_name)
+        config = BaseEmbedderConfig(model="nomic-embed-text", embedding_dims=512)
+        with pytest.raises(ImportError, match="ollama"):
+            module.OllamaEmbedding(config)
+    finally:
+        _restore_module(module_name, saved_module)


### PR DESCRIPTION
## Summary

- install the `server` extra in regression jobs because `test2` starts the API/dashboard server
- keep the API server from importing MCP when `fastmcp` is not installed
- make optional dependency failures raise `ImportError` instead of exiting or prompting at import time
- add unit coverage for missing MCP/Ollama optional dependencies

## Verification

- `python3.11 -m pytest tests/unit/test_optional_dependency_imports.py tests/unit/server/test_main_mcp_optional.py tests/unit/server/test_settings.py tests/unit/test_ollama_embeddings.py tests/unit/test_qwen_embeddings.py -q`
- `python3.11 -m py_compile src/powermem/mcp/server.py src/powermem/integrations/embeddings/ollama.py tests/unit/test_optional_dependency_imports.py`
- `git diff --check`
- local API server health check with temporary sqlite config against `/api/v1/system/health`
