### PR TITLE
Fix quoted OceanBase password handling

### DIFF
--- a/src/powermem/storage/config/base.py
+++ b/src/powermem/storage/config/base.py
@@ -2,6 +2,7 @@ from typing import Any, ClassVar, Dict, Optional, Union
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings
 from powermem.settings import settings_config
+from powermem.utils.strings import strip_wrapping_quotes
 
 
 class BaseVectorStoreConfig(BaseSettings):
@@ -161,11 +162,7 @@ class BaseGraphStoreConfig(BaseVectorStoreConfig):
     @field_validator("password", mode="before")
     @classmethod
     def _strip_wrapping_quotes_from_password(cls, value: Any) -> Any:
-        if isinstance(value, str) and len(value) >= 2:
-            stripped = value.strip()
-            if stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
-                return stripped[1:-1]
-        return value
+        return strip_wrapping_quotes(value)
     
     db_name: str = Field(
         default="test",

--- a/src/powermem/storage/config/base.py
+++ b/src/powermem/storage/config/base.py
@@ -157,6 +157,15 @@ class BaseGraphStoreConfig(BaseVectorStoreConfig):
         ),
         description="Database password"
     )
+
+    @field_validator("password", mode="before")
+    @classmethod
+    def _strip_wrapping_quotes_from_password(cls, value: Any) -> Any:
+        if isinstance(value, str) and len(value) >= 2:
+            stripped = value.strip()
+            if stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+                return stripped[1:-1]
+        return value
     
     db_name: str = Field(
         default="test",

--- a/src/powermem/storage/config/oceanbase.py
+++ b/src/powermem/storage/config/oceanbase.py
@@ -80,6 +80,15 @@ class OceanBaseConfig(BaseVectorStoreConfig):
         ),
         description="OceanBase password"
     )
+
+    @field_validator("password", mode="before")
+    @classmethod
+    def _strip_wrapping_quotes_from_password(cls, value: Any) -> Any:
+        if isinstance(value, str) and len(value) >= 2:
+            stripped = value.strip()
+            if stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+                return stripped[1:-1]
+        return value
     
     db_name: str = Field(
         default="test",

--- a/src/powermem/storage/config/oceanbase.py
+++ b/src/powermem/storage/config/oceanbase.py
@@ -4,6 +4,7 @@ from pydantic import AliasChoices, Field, field_validator, model_validator
 from powermem.settings import settings_config
 
 from powermem.storage.config.base import BaseVectorStoreConfig, BaseGraphStoreConfig
+from powermem.utils.strings import strip_wrapping_quotes
 
 
 class OceanBaseConfig(BaseVectorStoreConfig):
@@ -84,11 +85,7 @@ class OceanBaseConfig(BaseVectorStoreConfig):
     @field_validator("password", mode="before")
     @classmethod
     def _strip_wrapping_quotes_from_password(cls, value: Any) -> Any:
-        if isinstance(value, str) and len(value) >= 2:
-            stripped = value.strip()
-            if stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
-                return stripped[1:-1]
-        return value
+        return strip_wrapping_quotes(value)
     
     db_name: str = Field(
         default="test",

--- a/src/powermem/storage/oceanbase/oceanbase.py
+++ b/src/powermem/storage/oceanbase/oceanbase.py
@@ -40,6 +40,15 @@ from .models import create_memory_model
 
 logger = logging.getLogger(__name__)
 
+
+def _strip_wrapping_quotes(value: Any) -> Any:
+    if isinstance(value, str) and len(value) >= 2:
+        stripped = value.strip()
+        if stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+            return stripped[1:-1]
+    return value
+
+
 class OceanBaseVectorStore(VectorStoreBase):
     """OceanBase vector store implementation"""
 
@@ -139,7 +148,7 @@ class OceanBaseVectorStore(VectorStoreBase):
             "host": host or connection_args.get("host", constants.DEFAULT_OCEANBASE_CONNECTION["host"]),
             "port": port or connection_args.get("port", constants.DEFAULT_OCEANBASE_CONNECTION["port"]),
             "user": user or connection_args.get("user", constants.DEFAULT_OCEANBASE_CONNECTION["user"]),
-            "password": password or connection_args.get("password", constants.DEFAULT_OCEANBASE_CONNECTION["password"]),
+            "password": _strip_wrapping_quotes(password or connection_args.get("password", constants.DEFAULT_OCEANBASE_CONNECTION["password"])),
             "db_name": db_name or connection_args.get("db_name", constants.DEFAULT_OCEANBASE_CONNECTION["db_name"]),
             "ob_path": ob_path or connection_args.get("ob_path", constants.DEFAULT_OCEANBASE_CONNECTION["ob_path"]),
             "pool_recycle": pool_recycle,

--- a/src/powermem/storage/oceanbase/oceanbase.py
+++ b/src/powermem/storage/oceanbase/oceanbase.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 from powermem.storage.base import VectorStoreBase, OutputData
 from powermem.utils.utils import serialize_datetime, generate_snowflake_id
 from powermem.utils.oceanbase_util import OceanBaseUtil
+from powermem.utils.strings import strip_wrapping_quotes
 
 try:
     from pyobvector import (
@@ -39,14 +40,6 @@ from powermem.storage.oceanbase import constants
 from .models import create_memory_model
 
 logger = logging.getLogger(__name__)
-
-
-def _strip_wrapping_quotes(value: Any) -> Any:
-    if isinstance(value, str) and len(value) >= 2:
-        stripped = value.strip()
-        if stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
-            return stripped[1:-1]
-    return value
 
 
 class OceanBaseVectorStore(VectorStoreBase):
@@ -148,7 +141,9 @@ class OceanBaseVectorStore(VectorStoreBase):
             "host": host or connection_args.get("host", constants.DEFAULT_OCEANBASE_CONNECTION["host"]),
             "port": port or connection_args.get("port", constants.DEFAULT_OCEANBASE_CONNECTION["port"]),
             "user": user or connection_args.get("user", constants.DEFAULT_OCEANBASE_CONNECTION["user"]),
-            "password": _strip_wrapping_quotes(password or connection_args.get("password", constants.DEFAULT_OCEANBASE_CONNECTION["password"])),
+            "password": strip_wrapping_quotes(
+                password or connection_args.get("password", constants.DEFAULT_OCEANBASE_CONNECTION["password"])
+            ),
             "db_name": db_name or connection_args.get("db_name", constants.DEFAULT_OCEANBASE_CONNECTION["db_name"]),
             "ob_path": ob_path or connection_args.get("ob_path", constants.DEFAULT_OCEANBASE_CONNECTION["ob_path"]),
             "pool_recycle": pool_recycle,

--- a/src/powermem/utils/strings.py
+++ b/src/powermem/utils/strings.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+def strip_wrapping_quotes(value: Any) -> Any:
+    """Strip one matching quote pair preserved by env/config loaders.
+
+    This keeps compatibility with Docker-style env files that pass quoted
+    values through literally. Passwords that intentionally start and end with
+    the same quote character should be configured without wrapper syntax.
+    """
+    if not isinstance(value, str):
+        return value
+
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        return stripped[1:-1]
+    return value

--- a/tests/unit/test_issue_921_oceanbase_password.py
+++ b/tests/unit/test_issue_921_oceanbase_password.py
@@ -32,6 +32,7 @@ import powermem.config_loader as config_loader
 import powermem.settings as settings
 from powermem.config_loader import load_config_from_env
 from powermem.storage.oceanbase.oceanbase import OceanBaseVectorStore
+from powermem.utils.strings import strip_wrapping_quotes
 
 
 def _disable_env_file(monkeypatch):
@@ -65,3 +66,11 @@ def test_oceanbase_vector_store_strips_wrapping_quotes_from_connection_args(monk
     )
 
     assert store.connection_args["password"] == "powermem"
+
+
+def test_strip_wrapping_quotes_uses_trimmed_length_for_detection():
+    assert strip_wrapping_quotes(" ' ") == " ' "
+
+
+def test_strip_wrapping_quotes_documents_literal_quote_tradeoff():
+    assert strip_wrapping_quotes("'quoted-password'") == "quoted-password"

--- a/tests/unit/test_issue_921_oceanbase_password.py
+++ b/tests/unit/test_issue_921_oceanbase_password.py
@@ -1,0 +1,67 @@
+import sys
+from unittest.mock import MagicMock
+
+if "pyobvector" not in sys.modules:
+    sys.modules["pyobvector"] = MagicMock()
+    sys.modules["pyobvector"].ObVecClient = MagicMock()
+    sys.modules["pyobvector"].VECTOR = MagicMock()
+    sys.modules["pyobvector"].SPARSE_VECTOR = MagicMock()
+    sys.modules["pyobvector"].cosine_distance = MagicMock()
+    sys.modules["pyobvector"].inner_product = MagicMock()
+    sys.modules["pyobvector"].l2_distance = MagicMock()
+    sys.modules["pyobvector"].VecIndexType = MagicMock(
+        HNSW="HNSW",
+        HNSW_SQ="HNSW_SQ",
+        IVFFLAT="IVFFLAT",
+        IVFSQ="IVFSQ",
+        IVFPQ="IVFPQ",
+    )
+    sys.modules["pyobvector"].FtsIndexParam = MagicMock()
+    sys.modules["pyobvector"].FtsParser = MagicMock()
+    sys.modules["pyobvector.client"] = MagicMock()
+    sys.modules["pyobvector.client.index_param"] = MagicMock()
+    sys.modules["pyobvector.client.index_param"].IndexParams = MagicMock()
+    sys.modules["pyobvector.client.fts_index_param"] = MagicMock()
+    sys.modules["pyobvector.client.fts_index_param"].FtsIndexParam = MagicMock()
+    sys.modules["pyobvector.client.partitions"] = MagicMock()
+    sys.modules["pyobvector.client.partitions"].ObPartition = MagicMock()
+    sys.modules["pyobvector.schema"] = MagicMock()
+    sys.modules["pyobvector.schema"].ReplaceStmt = MagicMock()
+
+import powermem.config_loader as config_loader
+import powermem.settings as settings
+from powermem.config_loader import load_config_from_env
+from powermem.storage.oceanbase.oceanbase import OceanBaseVectorStore
+
+
+def _disable_env_file(monkeypatch):
+    monkeypatch.setattr(config_loader, "_DEFAULT_ENV_FILE", None, raising=False)
+    monkeypatch.setattr(settings, "_DEFAULT_ENV_FILE", None, raising=False)
+
+
+def test_oceanbase_password_strips_wrapping_quotes_from_env(monkeypatch):
+    _disable_env_file(monkeypatch)
+    monkeypatch.setenv("DATABASE_PROVIDER", "oceanbase")
+    monkeypatch.setenv("OCEANBASE_PASSWORD", "'powermem'")
+
+    config = load_config_from_env()
+
+    vector_config = config["vector_store"]["config"]
+    assert vector_config["password"] == "powermem"
+    assert vector_config["connection_args"]["password"] == "powermem"
+
+
+def test_oceanbase_vector_store_strips_wrapping_quotes_from_connection_args(monkeypatch):
+    monkeypatch.setattr(
+        OceanBaseVectorStore,
+        "_create_client",
+        lambda self, **kwargs: setattr(self, "obvector", MagicMock()),
+    )
+    monkeypatch.setattr(OceanBaseVectorStore, "_create_col", lambda self: None)
+
+    store = OceanBaseVectorStore(
+        collection_name="memories",
+        connection_args={"password": '"powermem"'},
+    )
+
+    assert store.connection_args["password"] == "powermem"


### PR DESCRIPTION
## Summary
- strip matching single or double wrapping quotes from OceanBase and graph-store passwords loaded from environment settings
- apply the same normalization when OceanBaseVectorStore is built directly from connection_args
- consolidate quote-stripping into a shared helper and document the compatibility assumption
- add regression coverage for docker-style quoted OCEANBASE_PASSWORD values

Fixes #921.

## Verification
- `python3.11 -m pytest tests/unit/test_config_loader.py tests/unit/test_oceanbase.py tests/unit/test_issue_921_oceanbase_password.py -q`
- `python3.11 -m compileall -q src/powermem/storage/config/oceanbase.py src/powermem/storage/config/base.py src/powermem/storage/oceanbase/oceanbase.py src/powermem/utils/strings.py tests/unit/test_issue_921_oceanbase_password.py`
- `git diff --check`
- sensitive-pattern scan over changed storage/test files: no matches
