### PR TITLE
Fix agent memory sharing permissions

### DIFF
--- a/src/powermem/agent/agent.py
+++ b/src/powermem/agent/agent.py
@@ -247,7 +247,7 @@ class AgentMemory:
             'default_collaboration_level': default_collaboration_level,
             'default_access_permission': default_access_permission,
             'default_permissions': {
-                'owner': ['read', 'write', 'delete', 'admin'],
+                'owner': ['read', 'write', 'delete', 'share', 'admin'],
                 'collaborator': ['read', 'write'],
                 'viewer': ['read']
             },
@@ -306,7 +306,7 @@ class AgentMemory:
             'cross_user_sharing': True,
             'privacy_protection': True,
             'default_permissions': {
-                'owner': ['read', 'write', 'delete', 'admin'],
+                'owner': ['read', 'write', 'delete', 'share', 'admin'],
                 'collaborator': ['read', 'write'],
                 'viewer': ['read']
             },

--- a/src/powermem/agent/implementations/hybrid.py
+++ b/src/powermem/agent/implementations/hybrid.py
@@ -90,7 +90,7 @@ class HybridMemoryManager(AgentMemoryManagerBase):
             multi_agent_config.agent_memory._data['multi_agent_config'] = {
                 'enabled': True,
                 'default_permissions': {
-                    'owner': ['read', 'write', 'delete', 'admin'],
+                    'owner': ['read', 'write', 'delete', 'share', 'admin'],
                     'collaborator': ['read', 'write'],
                     'viewer': ['read']
                 },
@@ -124,7 +124,7 @@ class HybridMemoryManager(AgentMemoryManagerBase):
                 'cross_user_sharing': True,
                 'privacy_protection': True,
                 'default_permissions': {
-                    'owner': ['read', 'write', 'delete', 'admin'],
+                    'owner': ['read', 'write', 'delete', 'share', 'admin'],
                     'collaborator': ['read', 'write'],
                     'viewer': ['read']
                 },

--- a/src/powermem/agent/implementations/multi_agent.py
+++ b/src/powermem/agent/implementations/multi_agent.py
@@ -546,7 +546,7 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                 try:
                     scope = MemoryScope(scope_str) if isinstance(scope_str, str) else scope_str
                 except (ValueError, TypeError):
-                    scope = MemoryScope.AGENT  # Default scope
+                    scope = MemoryScope.AGENT_GROUP  # Backward-compatible "agent" scope
                 
                 try:
                     memory_type = MemoryType(memory_type_str) if isinstance(memory_type_str, str) else memory_type_str
@@ -1121,7 +1121,7 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             # Set default permissions if not provided
             if permissions is None:
                 permissions = {
-                    'owner': ['read', 'write', 'delete', 'admin'],
+                    'owner': ['read', 'write', 'delete', 'share', 'admin'],
                     'collaborator': ['read', 'write'],
                     'viewer': ['read']
                 }

--- a/src/powermem/agent/types.py
+++ b/src/powermem/agent/types.py
@@ -26,6 +26,7 @@ class AccessPermission(Enum):
     READ = "read"
     WRITE = "write"
     DELETE = "delete"
+    SHARE = "share"
     ADMIN = "admin"
 
 
@@ -49,5 +50,4 @@ class CollaborationStatus(Enum):
 class CollaborationLevel(Enum):
     ISOLATED = "isolated"
     COLLABORATIVE = "collaborative"
-
 

--- a/tests/unit/test_issue_925_agent_memory_share.py
+++ b/tests/unit/test_issue_925_agent_memory_share.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+from powermem.agent.implementations.multi_agent import MultiAgentMemoryManager
+from powermem.agent.types import AccessPermission, MemoryScope, MemoryType
+
+
+def test_multi_agent_loads_legacy_agent_scope_as_agent_group():
+    manager = MultiAgentMemoryManager.__new__(MultiAgentMemoryManager)
+    manager.config = {}
+    manager.multi_agent_config = SimpleNamespace(
+        default_permissions={"owner": ["read", "write", "delete", "share", "admin"]}
+    )
+    manager.scope_memories = {
+        scope: {memory_type: {} for memory_type in MemoryType} for scope in MemoryScope
+    }
+    manager.scope_controller = SimpleNamespace(
+        scope_storage={
+            scope: {memory_type: {} for memory_type in MemoryType}
+            for scope in MemoryScope
+        },
+        check_scope_access=lambda agent_id, memory_id: True,
+    )
+    manager.permission_controller = SimpleNamespace(
+        memory_permissions={},
+        check_permission=lambda agent_id, memory_id, permission: True,
+    )
+    manager._memory_instance = SimpleNamespace(
+        get_all=lambda **kwargs: {
+            "results": [
+                {
+                    "id": "memory-1",
+                    "memory": "legacy scope memory",
+                    "agent_id": "agent-1",
+                    "metadata": {"scope": "agent", "memory_type": "working"},
+                }
+            ]
+        }
+    )
+
+    memories = manager.get_memories("agent-1")
+
+    assert memories[0]["scope"] == MemoryScope.AGENT_GROUP
+    assert (
+        AccessPermission.SHARE
+        in manager.permission_controller.memory_permissions["memory-1"]["agent-1"]
+    )


### PR DESCRIPTION
## Summary
- add the missing `share` access permission used by agent memory sharing
- include `share` in default owner permissions for multi-agent, multi-user, and hybrid modes
- map legacy metadata scope `agent` to `AGENT_GROUP` instead of referencing the non-existent `MemoryScope.AGENT`
- add regression coverage for loading legacy agent-scope memories and granting share permissions

Fixes #925.

## Verification
- `python3.11 -m pytest tests/unit/test_issue_925_agent_memory_share.py tests/regression/test_scenario_3_multi_agent.py -q` (20 passed)
- `python3.11 -m compileall -q src/powermem/agent`
- `git diff --check`
- sensitive-pattern scan over changed agent/test files: no matches
