### PR TITLE
fix(cli): keep config show section headers for empty optional groups

### DIFF
--- a/src/powermem/cli/commands/config.py
+++ b/src/powermem/cli/commands/config.py
@@ -733,7 +733,7 @@ def _config_from_env_file(
 
     result = {}
     for section_key, _ in _ENV_SECTION_PREFIXES:
-        if sections[section_key]:
+        if section_filter is None or sections[section_key]:
             result[section_key] = sections[section_key]
     if section_filter is not None:
         result = {section_filter: result.get(section_filter, {})}

--- a/tests/unit/test_cli_config_show.py
+++ b/tests/unit/test_cli_config_show.py
@@ -1,0 +1,32 @@
+from powermem.cli.commands.config import _config_from_env_file
+from powermem.cli.utils.output import format_output
+
+
+def test_config_show_all_keeps_empty_optional_sections(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "DATABASE_PROVIDER=oceanbase",
+                "OCEANBASE_HOST=127.0.0.1",
+                "LLM_PROVIDER=siliconflow",
+                "LLM_MODEL=test-llm",
+                "EMBEDDING_PROVIDER=qwen",
+                "EMBEDDING_MODEL=text-embedding-v4",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = _config_from_env_file(str(env_file), section_filter=None)
+    output = format_output(config, "config")
+
+    assert "[AGENT (Optional)]" in output
+    assert "[INTELLIGENT MEMORY (Optional)]" in output
+    assert "[PERFORMANCE (Optional)]" in output
+    assert "[SECURITY (Optional)]" in output
+    assert "[TELEMETRY (Optional)]" in output
+    assert "[AUDIT (Optional)]" in output
+    assert "[LOGGING (Optional)]" in output
+    assert "[SPARSE EMBEDDING (Optional)]" in output
+    assert "[QUERY REWRITE (Optional)]" in output


### PR DESCRIPTION
## Summary

- keep all known config sections present for `pmem config show` / `--section all`, even when optional groups have no values in `.env`
- preserve filtered behavior for explicit section requests like `--section llm`
- add unit coverage for empty optional section headers

## Root cause

`test2 (3.11)` failed in `tests/regression/test_powermem_cli.py::TestConfigShow` because `_config_from_env_file()` filtered out empty optional sections. The table formatter only renders sections present in the config dict, so headers such as `AGENT`, `INTELLIGENT MEMORY`, `PERFORMANCE`, `SECURITY`, `TELEMETRY`, `AUDIT`, `LOGGING`, `SPARSE EMBEDDING`, and `QUERY REWRITE` were missing when CI `.env` did not define those optional keys.

## Verification

- `python3.11 -m pytest tests/unit/test_cli_config_show.py -q`
- `python3.11 -m pytest tests/regression/test_powermem_cli.py::TestConfigShow::test_config_show_basic tests/regression/test_powermem_cli.py::TestConfigShow::test_config_show_section_all -q`
- `python3.11 -m py_compile src/powermem/cli/commands/config.py tests/unit/test_cli_config_show.py`
- `git diff --check`
