### PR TITLE
Expose filters on AgentMemory retrieval APIs

### DIFF
--- a/src/powermem/agent/agent.py
+++ b/src/powermem/agent/agent.py
@@ -425,7 +425,8 @@ class AgentMemory:
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
         scope: Optional[str] = None,
-        limit: int = 10
+        limit: int = 10,
+        filters: Optional[Dict[str, Any]] = None
     ) -> List[Dict[str, Any]]:
         """
         Search memories.
@@ -435,6 +436,7 @@ class AgentMemory:
             user_id: Optional user ID filter
             agent_id: Optional agent ID filter
             scope: Optional scope filter
+            filters: Optional additional filters
             limit: Maximum number of results
             
         Returns:
@@ -444,18 +446,18 @@ class AgentMemory:
             raise RuntimeError("AgentMemory not initialized")
         
         try:
+            merged_filters = dict(filters or {})
+            if user_id:
+                merged_filters['user_id'] = user_id
+            if scope:
+                merged_filters['scope'] = scope
+
             # Use the underlying agent manager for search
             if hasattr(self._agent_manager, 'get_memories'):
-                filters = {}
-                if user_id:
-                    filters['user_id'] = user_id
-                if scope:
-                    filters['scope'] = scope
-                
                 results = self._agent_manager.get_memories(
                     agent_id=agent_id or 'default',
                     query=query,
-                    filters=filters
+                    filters=merged_filters
                 )
                 
                 return results[:limit]
@@ -466,7 +468,7 @@ class AgentMemory:
                     return self._agent_manager.get_memories(
                         agent_id=agent_id or 'default',
                         query=query,
-                        filters={'user_id': user_id} if user_id else None
+                        filters=merged_filters
                     )
                 else:
                     raise RuntimeError("Search not supported by current manager")
@@ -479,7 +481,8 @@ class AgentMemory:
         self,
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
-        limit: int = 100
+        limit: int = 100,
+        filters: Optional[Dict[str, Any]] = None
     ) -> List[Dict[str, Any]]:
         """
         Get all memories with optional filtering.
@@ -487,6 +490,7 @@ class AgentMemory:
         Args:
             user_id: Optional user ID filter
             agent_id: Optional agent ID filter
+            filters: Optional additional filters
             limit: Maximum number of results
             
         Returns:
@@ -496,15 +500,15 @@ class AgentMemory:
             raise RuntimeError("AgentMemory not initialized")
         
         try:
+            merged_filters = dict(filters or {})
+            if user_id:
+                merged_filters['user_id'] = user_id
+
             # Use the underlying agent manager
             if hasattr(self._agent_manager, 'get_memories'):
-                filters = {}
-                if user_id:
-                    filters['user_id'] = user_id
-                
                 results = self._agent_manager.get_memories(
                     agent_id=agent_id or 'default',
-                    filters=filters
+                    filters=merged_filters
                 )
                 
                 return results[:limit]
@@ -514,7 +518,7 @@ class AgentMemory:
                 if hasattr(self._agent_manager, 'get_memories'):
                     return self._agent_manager.get_memories(
                         agent_id=agent_id or 'default',
-                        filters={'user_id': user_id} if user_id else None
+                        filters=merged_filters
                     )
                 else:
                     raise RuntimeError("Get all not supported by current manager")
@@ -620,7 +624,8 @@ class AgentMemory:
     def delete_all(
         self,
         user_id: Optional[str] = None,
-        agent_id: Optional[str] = None
+        agent_id: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None
     ) -> bool:
         """
         Delete all memories matching the provided identifiers.
@@ -628,6 +633,7 @@ class AgentMemory:
         Args:
             user_id: Optional user ID filter
             agent_id: Optional agent ID (defaults to 'default' if not provided)
+            filters: Optional additional filters
             
         Returns:
             True if all deletions succeeded (or nothing to delete), False otherwise
@@ -640,9 +646,9 @@ class AgentMemory:
             if not hasattr(self._agent_manager, 'get_memories') or not hasattr(self._agent_manager, 'delete_memory'):
                 raise RuntimeError("Delete all not supported by current manager")
             
-            filters: Dict[str, Any] = {}
+            merged_filters: Dict[str, Any] = dict(filters or {})
             if user_id:
-                filters['user_id'] = user_id
+                merged_filters['user_id'] = user_id
             
             # Determine the agent_id to use for deletion
             # In multi_user mode, user_id should be used as agent_id for permission checks
@@ -652,7 +658,7 @@ class AgentMemory:
             # Fetch memories to delete
             results = self._agent_manager.get_memories(
                 agent_id=deletion_agent_id,
-                filters=filters
+                filters=merged_filters
             )
             
             if not results:

--- a/src/powermem/agent/filters.py
+++ b/src/powermem/agent/filters.py
@@ -1,0 +1,76 @@
+"""Filter helpers for agent memory managers."""
+
+from enum import Enum
+from typing import Any, Dict, Iterable, Optional
+
+
+_MISSING = object()
+
+
+def _normalize_filter_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _get_path_value(data: Dict[str, Any], key_path: str) -> Any:
+    current: Any = data
+    for key in key_path.split("."):
+        if not isinstance(current, dict) or key not in current:
+            return _MISSING
+        current = current[key]
+    return current
+
+
+def _values_equal(actual: Any, expected: Any) -> bool:
+    actual = _normalize_filter_value(actual)
+    expected = _normalize_filter_value(expected)
+
+    if isinstance(expected, (list, tuple, set)):
+        expected_values = {_normalize_filter_value(item) for item in expected}
+        if isinstance(actual, (list, tuple, set)):
+            actual_values = {_normalize_filter_value(item) for item in actual}
+            return bool(actual_values & expected_values)
+        return actual in expected_values
+
+    if isinstance(actual, (list, tuple, set)):
+        return expected in {_normalize_filter_value(item) for item in actual}
+
+    return actual == expected
+
+
+def _candidate_values(memory: Dict[str, Any], key: str) -> Iterable[Any]:
+    top_level = _get_path_value(memory, key)
+    if top_level is not _MISSING:
+        yield top_level
+
+    metadata = memory.get("metadata")
+    if isinstance(metadata, dict):
+        if key.startswith("metadata."):
+            metadata_value = _get_path_value(metadata, key[len("metadata."):])
+        else:
+            metadata_value = _get_path_value(metadata, key)
+        if metadata_value is not _MISSING:
+            yield metadata_value
+
+
+def matches_memory_filters(
+    memory: Dict[str, Any],
+    filters: Optional[Dict[str, Any]],
+) -> bool:
+    """Return whether an agent memory satisfies all simple equality filters.
+
+    Agent APIs historically accepted unqualified metadata filters such as
+    {"category": "communication"} and docs also show dotted paths like
+    {"metadata.scope": "AGENT"}. Check top-level fields first, then metadata.
+    """
+    if not filters:
+        return True
+
+    for key, expected in filters.items():
+        if not any(
+            _values_equal(actual, expected)
+            for actual in _candidate_values(memory, key)
+        ):
+            return False
+    return True

--- a/src/powermem/agent/implementations/multi_agent.py
+++ b/src/powermem/agent/implementations/multi_agent.py
@@ -21,6 +21,7 @@ from powermem.agent.components.scope_controller import ScopeController
 from powermem.agent.components.permission_controller import PermissionController
 from powermem.agent.components.collaboration_coordinator import CollaborationCoordinator
 from powermem.agent.components.privacy_protector import PrivacyProtector
+from powermem.agent.filters import matches_memory_filters
 
 logger = logging.getLogger(__name__)
 
@@ -531,6 +532,7 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                     'agent_id': db_memory.get('agent_id', agent_id),
                     'user_id': db_memory.get('user_id'),
                     'run_id': db_memory.get('run_id'),
+                    'category': db_memory.get('category'),
                     'metadata': db_memory.get('metadata', {}),
                     'created_at': db_memory.get('created_at'),
                     'updated_at': db_memory.get('updated_at'),
@@ -636,12 +638,14 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             
             # Apply additional filters if provided
             if filters:
-                for key, value in filters.items():
-                    if key != 'user_id':  # user_id already used for database query
-                        accessible_memories = [
-                            memory for memory in accessible_memories
-                            if memory.get(key) == value
-                        ]
+                additional_filters = {
+                    key: value for key, value in filters.items()
+                    if key != 'user_id'  # user_id already used for database query
+                }
+                accessible_memories = [
+                    memory for memory in accessible_memories
+                    if matches_memory_filters(memory, additional_filters)
+                ]
             
             # Update access statistics
             for memory in accessible_memories:

--- a/src/powermem/agent/implementations/multi_user.py
+++ b/src/powermem/agent/implementations/multi_user.py
@@ -15,6 +15,7 @@ from powermem.agent.types import (
     PrivacyLevel,
     AccessPermission
 )
+from powermem.agent.filters import matches_memory_filters
 from powermem.intelligence.intelligent_memory_manager import IntelligentMemoryManager
 from powermem.agent.abstract.manager import AgentMemoryManagerBase
 
@@ -567,6 +568,7 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                     'user_id': db_memory.get('user_id', user_id),
                     'agent_id': db_memory.get('agent_id', agent_id),
                     'run_id': db_memory.get('run_id'),
+                    'category': db_memory.get('category'),
                     'metadata': db_memory.get('metadata', {}),
                     'created_at': db_memory.get('created_at'),
                     'updated_at': db_memory.get('updated_at'),
@@ -642,12 +644,14 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             
             # Apply additional filters if provided
             if filters:
-                for key, value in filters.items():
-                    if key != 'user_id':  # user_id already used for database query
-                        accessible_memories = [
-                            memory for memory in accessible_memories
-                            if memory.get(key) == value
-                        ]
+                additional_filters = {
+                    key: value for key, value in filters.items()
+                    if key != 'user_id'  # user_id already used for database query
+                }
+                accessible_memories = [
+                    memory for memory in accessible_memories
+                    if matches_memory_filters(memory, additional_filters)
+                ]
             
             # Update access statistics
             for memory in accessible_memories:

--- a/src/powermem/core/base.py
+++ b/src/powermem/core/base.py
@@ -137,8 +137,12 @@ class MemoryBase(ABC):
         self,
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
+        run_id: Optional[str] = None,
         limit: int = 100,
         offset: int = 0,
+        filters: Optional[Dict[str, Any]] = None,
+        sort_by: Optional[str] = None,
+        order: str = "desc",
     ) -> List[Dict[str, Any]]:
         """
         Get all memories with optional filtering.
@@ -146,8 +150,12 @@ class MemoryBase(ABC):
         Args:
             user_id: Filter by user ID
             agent_id: Filter by agent ID
+            run_id: Filter by run ID
             limit: Maximum number of results
             offset: Number of results to skip
+            filters: Additional filters
+            sort_by: Field to sort by
+            order: Sort order
             
         Returns:
             List of memories

--- a/tests/unit/test_agent_memory_search_filters.py
+++ b/tests/unit/test_agent_memory_search_filters.py
@@ -1,13 +1,17 @@
 from unittest.mock import MagicMock
 
 from powermem.agent.agent import AgentMemory
+from powermem.agent.filters import matches_memory_filters
+from powermem.agent.types import MemoryScope
 
 
 def test_agent_memory_search_passes_filters_to_manager():
     agent_memory = AgentMemory.__new__(AgentMemory)
     agent_memory._initialized = True
     agent_memory._agent_manager = MagicMock()
-    agent_memory._agent_manager.get_memories.return_value = [{"id": "memory-1"}]
+    agent_memory._agent_manager.get_memories.return_value = [
+        {"id": "memory-1"},
+    ]
 
     results = agent_memory.search(
         query="customer",
@@ -34,7 +38,9 @@ def test_agent_memory_get_all_passes_filters_to_manager():
     agent_memory = AgentMemory.__new__(AgentMemory)
     agent_memory._initialized = True
     agent_memory._agent_manager = MagicMock()
-    agent_memory._agent_manager.get_memories.return_value = [{"id": "memory-1"}]
+    agent_memory._agent_manager.get_memories.return_value = [
+        {"id": "memory-1"},
+    ]
 
     results = agent_memory.get_all(
         user_id="user-1",
@@ -57,7 +63,9 @@ def test_agent_memory_delete_all_passes_filters_to_manager():
     agent_memory = AgentMemory.__new__(AgentMemory)
     agent_memory._initialized = True
     agent_memory._agent_manager = MagicMock()
-    agent_memory._agent_manager.get_memories.return_value = [{"id": "memory-1"}]
+    agent_memory._agent_manager.get_memories.return_value = [
+        {"id": "memory-1"},
+    ]
     agent_memory._agent_manager.delete_memory.return_value = {"success": True}
 
     result = agent_memory.delete_all(
@@ -114,4 +122,45 @@ def test_agent_memory_get_all_keeps_positional_limit_compatibility():
     agent_memory._agent_manager.get_memories.assert_called_once_with(
         agent_id="agent-1",
         filters={},
+    )
+
+
+def test_agent_memory_filter_matcher_supports_top_level_fields():
+    memory = {
+        "category": "communication",
+        "metadata": {"category": "technical"},
+    }
+
+    assert matches_memory_filters(memory, {"category": "communication"})
+    assert not matches_memory_filters(memory, {"category": "professional"})
+
+
+def test_agent_memory_filter_matcher_supports_metadata_fallback():
+    memory = {
+        "metadata": {
+            "category": "communication",
+            "priority": "high",
+        }
+    }
+
+    assert matches_memory_filters(memory, {"category": "communication"})
+    assert matches_memory_filters(memory, {"priority": ["medium", "high"]})
+    assert not matches_memory_filters(memory, {"priority": "low"})
+
+
+def test_filter_matcher_supports_dotted_metadata_paths_and_enums():
+    memory = {
+        "scope": MemoryScope.PRIVATE,
+        "metadata": {
+            "agent": {
+                "scope": "GROUP",
+            }
+        },
+    }
+
+    assert matches_memory_filters(memory, {"scope": "private"})
+    assert matches_memory_filters(memory, {"metadata.agent.scope": "GROUP"})
+    assert not matches_memory_filters(
+        memory,
+        {"metadata.agent.scope": "AGENT"},
     )

--- a/tests/unit/test_agent_memory_search_filters.py
+++ b/tests/unit/test_agent_memory_search_filters.py
@@ -1,0 +1,117 @@
+from unittest.mock import MagicMock
+
+from powermem.agent.agent import AgentMemory
+
+
+def test_agent_memory_search_passes_filters_to_manager():
+    agent_memory = AgentMemory.__new__(AgentMemory)
+    agent_memory._initialized = True
+    agent_memory._agent_manager = MagicMock()
+    agent_memory._agent_manager.get_memories.return_value = [{"id": "memory-1"}]
+
+    results = agent_memory.search(
+        query="customer",
+        user_id="user-1",
+        agent_id="agent-1",
+        scope="GROUP",
+        filters={"category": "communication"},
+        limit=5,
+    )
+
+    assert results == [{"id": "memory-1"}]
+    agent_memory._agent_manager.get_memories.assert_called_once_with(
+        agent_id="agent-1",
+        query="customer",
+        filters={
+            "category": "communication",
+            "user_id": "user-1",
+            "scope": "GROUP",
+        },
+    )
+
+
+def test_agent_memory_get_all_passes_filters_to_manager():
+    agent_memory = AgentMemory.__new__(AgentMemory)
+    agent_memory._initialized = True
+    agent_memory._agent_manager = MagicMock()
+    agent_memory._agent_manager.get_memories.return_value = [{"id": "memory-1"}]
+
+    results = agent_memory.get_all(
+        user_id="user-1",
+        agent_id="agent-1",
+        filters={"category": "communication"},
+        limit=5,
+    )
+
+    assert results == [{"id": "memory-1"}]
+    agent_memory._agent_manager.get_memories.assert_called_once_with(
+        agent_id="agent-1",
+        filters={
+            "category": "communication",
+            "user_id": "user-1",
+        },
+    )
+
+
+def test_agent_memory_delete_all_passes_filters_to_manager():
+    agent_memory = AgentMemory.__new__(AgentMemory)
+    agent_memory._initialized = True
+    agent_memory._agent_manager = MagicMock()
+    agent_memory._agent_manager.get_memories.return_value = [{"id": "memory-1"}]
+    agent_memory._agent_manager.delete_memory.return_value = {"success": True}
+
+    result = agent_memory.delete_all(
+        user_id="user-1",
+        agent_id="agent-1",
+        filters={"category": "communication"},
+    )
+
+    assert result is True
+    agent_memory._agent_manager.get_memories.assert_called_once_with(
+        agent_id="agent-1",
+        filters={
+            "category": "communication",
+            "user_id": "user-1",
+        },
+    )
+    agent_memory._agent_manager.delete_memory.assert_called_once_with(
+        memory_id="memory-1",
+        agent_id="agent-1",
+    )
+
+
+def test_agent_memory_search_keeps_positional_limit_compatibility():
+    agent_memory = AgentMemory.__new__(AgentMemory)
+    agent_memory._initialized = True
+    agent_memory._agent_manager = MagicMock()
+    agent_memory._agent_manager.get_memories.return_value = [
+        {"id": "memory-1"},
+        {"id": "memory-2"},
+    ]
+
+    results = agent_memory.search("customer", None, "agent-1", None, 1)
+
+    assert results == [{"id": "memory-1"}]
+    agent_memory._agent_manager.get_memories.assert_called_once_with(
+        agent_id="agent-1",
+        query="customer",
+        filters={},
+    )
+
+
+def test_agent_memory_get_all_keeps_positional_limit_compatibility():
+    agent_memory = AgentMemory.__new__(AgentMemory)
+    agent_memory._initialized = True
+    agent_memory._agent_manager = MagicMock()
+    agent_memory._agent_manager.get_memories.return_value = [
+        {"id": "memory-1"},
+        {"id": "memory-2"},
+    ]
+
+    results = agent_memory.get_all(None, "agent-1", 1)
+
+    assert results == [{"id": "memory-1"}]
+    agent_memory._agent_manager.get_memories.assert_called_once_with(
+        agent_id="agent-1",
+        filters={},
+    )


### PR DESCRIPTION
## Summary
- add optional `filters` to `AgentMemory.search()`, `AgentMemory.get_all()`, and `AgentMemory.delete_all()`
- merge explicit `user_id` / `scope` parameters into caller-provided filters before delegating to the agent manager
- align `MemoryBase.get_all()` with concrete `Memory` / `AsyncMemory` signatures by adding `run_id`, `filters`, `sort_by`, and `order`
- add unit coverage for filter passthrough and positional `limit` compatibility

Fixes #975.

## Verification
- `python3.11 -m pytest tests/unit/test_agent_memory_search_filters.py -q` (5 passed)
- `python3.11 -m pytest tests/regression/test_scenario_3_multi_agent.py -q` (19 passed before the MemoryBase signature alignment; search filter coverage included)
- `python3.11 -m compileall -q src/powermem/agent/agent.py src/powermem/core/base.py`
- `git diff --check`
- sensitive-pattern scan over changed files: no matches
