### PR TITLE
fix(intelligence): preserve on_get metadata merges on search path

### DIFF
--- a/src/powermem/intelligence/plugin.py
+++ b/src/powermem/intelligence/plugin.py
@@ -233,20 +233,22 @@ class EbbinghausIntelligencePlugin(IntelligentMemoryPlugin):
             Enhanced updates for search context
         """
         try:
-            # Add search-specific metadata
-            search_metadata = memory.get("metadata", {})
-            search_metadata["last_searched_at"] = get_current_datetime()
-            search_metadata["search_count"] = search_metadata.get("search_count", 0) + 1
-            
-            # Update base updates with search metadata
             enhanced_updates = base_updates.copy()
-            enhanced_updates["metadata"] = search_metadata
+            base_metadata = dict(base_updates.get("metadata") or {})
+            base_metadata["last_searched_at"] = get_current_datetime()
+            base_metadata["search_count"] = base_metadata.get("search_count", 0) + 1
+            enhanced_updates["metadata"] = base_metadata
             
             # Add search relevance score if not present
             if "search_relevance_score" not in memory:
                 # Simple relevance calculation based on access patterns
-                access_count = memory.get("access_count", 0)
-                importance_score = memory.get("importance_score", 0.5)
+                access_count = enhanced_updates.get(
+                    "access_count",
+                    base_metadata.get("access_count", memory.get("access_count", 0)),
+                )
+                importance_score = base_metadata.get(
+                    "importance_score", memory.get("importance_score", 0.5)
+                )
                 search_relevance = min(1.0, (access_count * 0.1) + (importance_score * 0.5))
                 enhanced_updates["search_relevance_score"] = search_relevance
             

--- a/tests/unit/intelligence/test_ebbinghaus_search_metadata.py
+++ b/tests/unit/intelligence/test_ebbinghaus_search_metadata.py
@@ -1,0 +1,107 @@
+"""Unit tests for Ebbinghaus search metadata updates."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from powermem.intelligence.plugin import EbbinghausIntelligencePlugin
+
+
+def make_enabled_plugin() -> EbbinghausIntelligencePlugin:
+    plugin = object.__new__(EbbinghausIntelligencePlugin)
+    plugin.config = {"enabled": True}
+    plugin._importance = None
+    plugin._algo = MagicMock()
+    return plugin
+
+
+def test_enhance_for_search_preserves_on_get_metadata_updates():
+    plugin = make_enabled_plugin()
+    original_metadata = {
+        "access_count": 4,
+        "memory_type": "working",
+        "importance_score": 0.9,
+        "search_count": 2,
+    }
+    memory = {
+        "id": "memory-1",
+        "metadata": original_metadata,
+        "access_count": 4,
+        "importance_score": 0.1,
+    }
+    base_updates = {
+        "access_count": 5,
+        "metadata": {
+            "access_count": 5,
+            "memory_type": "short_term",
+            "importance_score": 0.9,
+            "archived": True,
+            "intelligence": {"refreshed": True},
+            "search_count": 2,
+        },
+    }
+
+    enhanced = plugin._enhance_for_search(memory, base_updates)
+    metadata = enhanced["metadata"]
+
+    assert metadata["access_count"] == 5
+    assert metadata["memory_type"] == "short_term"
+    assert metadata["archived"] is True
+    assert metadata["intelligence"] == {"refreshed": True}
+    assert metadata["search_count"] == 3
+    assert "last_searched_at" in metadata
+    assert enhanced["search_relevance_score"] == pytest.approx(0.95)
+
+
+def test_enhance_for_search_does_not_mutate_input_metadata():
+    plugin = make_enabled_plugin()
+    original_metadata = {"access_count": 4, "search_count": 2}
+    base_metadata = {"access_count": 5, "search_count": 2}
+
+    plugin._enhance_for_search(
+        {"id": "memory-1", "metadata": original_metadata},
+        {"access_count": 5, "metadata": base_metadata},
+    )
+
+    assert original_metadata == {"access_count": 4, "search_count": 2}
+    assert base_metadata == {"access_count": 5, "search_count": 2}
+
+
+def test_on_search_keeps_lifecycle_metadata_and_adds_search_metadata():
+    plugin = make_enabled_plugin()
+    plugin._algo.should_forget.return_value = False
+    plugin._algo.should_promote.return_value = True
+    plugin._algo.should_archive.return_value = True
+    plugin._algo.process_memory_metadata.return_value = {
+        "intelligence": {"refreshed": True}
+    }
+    memory = {
+        "id": "memory-1",
+        "memory": "User prefers concise updates",
+        "metadata": {
+            "access_count": 4,
+            "memory_type": "working",
+            "importance_score": 0.9,
+            "search_count": 7,
+            "custom": "kept",
+        },
+    }
+
+    updates, deletes = plugin.on_search([memory])
+
+    assert deletes == []
+    assert len(updates) == 1
+    mem_id, update = updates[0]
+    metadata = update["metadata"]
+    assert mem_id == "memory-1"
+    assert update["access_count"] == 5
+    assert update["memory_type"] == "short_term"
+    assert "last_reprocessed_at" in update
+    assert metadata["access_count"] == 5
+    assert metadata["memory_type"] == "short_term"
+    assert metadata["archived"] is True
+    assert metadata["intelligence"] == {"refreshed": True}
+    assert metadata["custom"] == "kept"
+    assert metadata["search_count"] == 8
+    assert "last_searched_at" in metadata
+    assert update["search_relevance_score"] == pytest.approx(0.95)


### PR DESCRIPTION
Fixes #980

## Summary

This PR fixes the search-path metadata overwrite described in #980.

On the search path, `EbbinghausIntelligencePlugin.on_search()` delegates lifecycle work to `on_get()` for each hit, then calls `_enhance_for_search()` to add search-tracking fields. Before this change, `_enhance_for_search()` replaced `base_updates["metadata"]` with the original search-hit metadata snapshot. As a result, lifecycle updates computed by `on_get()` — such as `access_count`, `memory_type` promotion, `archived`, and `intelligence` reprocessing — were not persisted when memories were accessed only through `search()`.

The fix makes `_enhance_for_search()` build on `base_updates["metadata"]` and only overlay search-specific deltas (`last_searched_at`, `search_count`). `search_relevance_score` now prefers the post-`on_get` access count.

## Changes

- Updated `EbbinghausIntelligencePlugin._enhance_for_search()` to copy `base_updates["metadata"]` instead of `memory["metadata"]`.
- Added search counters on top of the merged metadata without discarding `on_get()` side effects.
- Updated `search_relevance_score` to use the incremented `access_count` from `base_updates` when available.
- Added regression tests in `tests/unit/intelligence/test_ebbinghaus_search_metadata.py`.

## Test plan

- [x] `pytest tests/unit/intelligence/test_ebbinghaus_search_metadata.py -v` (3 passed)
- [x] `pytest tests/unit/intelligence -v` (32 passed)
