### PR TITLE
fix: restore usable lint gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: help install install-dev test test-unit test-integration test-e2e test-coverage test-fast test-slow lint format clean build build-package build-check build-dashboard build-claude-hook package-claude-plugin publish-pypi publish-testpypi install-build-tools upload docs bump-version server-start server-stop server-restart server-status server-logs server-dashboard-start docker-build docker-run docker-up docker-down docker-logs docker-stop docker-restart docker-clean docker-ps
+PYTHON ?= python3
+
+.PHONY: help install install-dev test test-unit test-integration test-e2e test-coverage test-fast test-slow check-python lint lint-pylint format-check format type-check clean build build-package build-check build-dashboard build-claude-hook package-claude-plugin publish-pypi publish-testpypi install-build-tools upload docs bump-version server-start server-stop server-restart server-status server-logs server-dashboard-start docker-build docker-run docker-up docker-down docker-logs docker-stop docker-restart docker-clean docker-ps
 
 help: ## Show help information
 	@echo "powermem Project Build Tools"
@@ -59,20 +61,25 @@ test-marker: ## Run tests with specific marker (usage: make test-marker MARKER=u
 	pytest -m $(MARKER) -v
 
 # Code quality
-lint: ## Run linting checks
-	flake8 src tests
-	pylint src/powermem || true
+check-python: ## Verify Python version
+	@$(PYTHON) -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 'Python >=3.11 required. Use PYTHON=python3.11 make lint or activate a Python 3.11+ environment.')"
 
-format-check: ## Check code formatting
-	black --check src tests
-	isort --check-only src tests
+lint: check-python ## Run linting checks
+	$(PYTHON) -m flake8 src tests
 
-format: ## Format code
-	black src tests
-	isort src tests
+lint-pylint: check-python ## Run optional pylint checks
+	$(PYTHON) -m pylint src/powermem
 
-type-check: ## Run type checking with mypy
-	mypy src/powermem
+format-check: check-python ## Check code formatting
+	$(PYTHON) -m black --check src tests
+	$(PYTHON) -m isort --check-only src tests
+
+format: check-python ## Format code
+	$(PYTHON) -m black src tests
+	$(PYTHON) -m isort src tests
+
+type-check: check-python ## Run type checking with mypy
+	$(PYTHON) -m mypy src/powermem
 
 # Cleanup
 clean: ## Clean build files

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,18 @@ egg_base = .
 [build_system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[flake8]
+max-line-length = 88
+select =
+    E9,
+    F6,
+    F7,
+    F82
+extend-ignore =
+    E203
+exclude =
+    .git,
+    .venv,
+    build,
+    dist

--- a/src/powermem/agent/agent.py
+++ b/src/powermem/agent/agent.py
@@ -271,8 +271,7 @@ class AgentMemory:
                 'max_collaborators': 5,
                 'collaboration_timeout': 3600,
                 'default_collaboration_level': default_collaboration_level.lower()
-            },
-            'default_scope': default_scope.lower()
+            }
         }
     
     def _get_default_multi_user_config(self) -> Dict[str, Any]:

--- a/src/script/scripts/migrate_sparse_vector.py
+++ b/src/script/scripts/migrate_sparse_vector.py
@@ -17,11 +17,14 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, Optional, Any, Dict
+from typing import TYPE_CHECKING, List, Optional, Any, Dict
 
 from sqlalchemy import text
 
 from powermem.utils import OceanBaseUtil
+
+if TYPE_CHECKING:
+    from powermem import Memory
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/test_basic_usage_e2e.py
+++ b/tests/e2e/test_basic_usage_e2e.py
@@ -9,7 +9,7 @@ Run with: pytest -m e2e_config tests/e2e/test_basic_usage_e2e.py
 import os
 import pytest
 from dotenv import load_dotenv
-from powermem import Memory, auto_config
+from powermem import auto_config, create_memory
 
 
 @pytest.fixture(scope="module")
@@ -122,4 +122,3 @@ class TestBasicUsageE2E:
         
         # Cleanup
         memory.delete_all(user_id=user_id)
-


### PR DESCRIPTION
## Summary

- add a Python >= 3.11 guard and route lint/format/type-check commands through the selected `PYTHON` interpreter
- configure flake8 as a high-signal initial lint gate for syntax/pyflakes errors instead of failing on the existing formatting backlog
- fix the current `F601`/`F821` issues that block that gate
- move pylint to an explicit `make lint-pylint` target so default lint output stays focused

## Notes

This intentionally does not reformat the entire repository. The existing `E501`/`W293`/style backlog should be handled in follow-up mechanical PRs so this change stays reviewable.

`make lint` now runs the flake8 gate only. `make lint-pylint` remains available for maintainers who want to run the broader optional pylint check.

Closes #275

## Verification

```bash
PYTHON=python3.11 make lint
python3.11 -m flake8 src tests --count --select=F601,F821,E999
git diff --check HEAD
```

`make lint` now passes in a Python 3.11+ environment without emitting the historical pylint backlog by default.