### PR TITLE
fix(intelligence): soft mark forgotten memories

### DIFF
--- a/src/powermem/core/async_memory.py
+++ b/src/powermem/core/async_memory.py
@@ -41,6 +41,13 @@ from ..prompts.intelligent_memory_prompts import (
 logger = logging.getLogger(__name__)
 
 
+def _forget_marker_updates() -> Dict[str, Any]:
+    return {
+        "should_forget": True,
+        "marked_for_forgetting_at": get_current_datetime().isoformat(),
+    }
+
+
 def _auto_convert_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """
     Convert legacy powermem config to format for compatibility.
@@ -1073,9 +1080,16 @@ class AsyncMemory(MemoryBase):
                         await self.storage.update_memory_async(mem_id, {**upd}, user_id, agent_id)
                     except Exception:
                         continue
+                # The plugin's "deletes" are memories that should be
+                # forgotten by marking, not physically removed from storage.
                 for mem_id in deletes:
                     try:
-                        await self.storage.delete_memory_async(mem_id, user_id, agent_id)
+                        await self.storage.update_memory_async(
+                            mem_id,
+                            _forget_marker_updates(),
+                            user_id,
+                            agent_id,
+                        )
                     except Exception:
                         continue
             
@@ -1171,8 +1185,9 @@ class AsyncMemory(MemoryBase):
                     updates, delete_flag = self._intelligence_plugin.on_get(result)
                     try:
                         if delete_flag:
-                            await self.storage.delete_memory_async(memory_id, user_id, agent_id)
-                            return None
+                            if updates is None:
+                                updates = {}
+                            updates.update(_forget_marker_updates())
                         if updates:
                             await self.storage.update_memory_async(memory_id, {**updates}, user_id, agent_id)
                     except Exception:

--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -52,6 +52,13 @@ logger = logging.getLogger(__name__)
 _BACKGROUND_EXECUTOR = ThreadPoolExecutor(max_workers=3)
 
 
+def _forget_marker_updates() -> Dict[str, Any]:
+    return {
+        "should_forget": True,
+        "marked_for_forgetting_at": get_current_datetime().isoformat(),
+    }
+
+
 def _auto_convert_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """
     Convert legacy powermem config to format for compatibility.
@@ -1279,12 +1286,21 @@ class Memory(MemoryBase):
                             _BACKGROUND_EXECUTOR.submit(self.storage.update_memory, mem_id, {**upd}, user_id, agent_id)
                     logger.info(f"Submitted {len(updates)} update operations to background executor")
                 if deletes:
+                    # The plugin's "deletes" are memories that should be
+                    # forgotten by marking, not physically removed from storage.
                     for mem_id in deletes:
+                        forget_updates = _forget_marker_updates()
                         if _is_embedded_store:
-                            self.storage.delete_memory(mem_id, user_id, agent_id)
+                            self.storage.update_memory(mem_id, forget_updates, user_id, agent_id)
                         else:
-                            _BACKGROUND_EXECUTOR.submit(self.storage.delete_memory, mem_id, user_id, agent_id)
-                    logger.info(f"Submitted {len(deletes)} delete operations to background executor")
+                            _BACKGROUND_EXECUTOR.submit(
+                                self.storage.update_memory,
+                                mem_id,
+                                forget_updates,
+                                user_id,
+                                agent_id,
+                            )
+                    logger.info(f"Submitted {len(deletes)} forget marker update operations")
             
             # Transform results to match benchmark expected format
             # Benchmark expects: {"results": [{"memory": ..., "metadata": {...}, "score": ...}], "relations": [...]}
@@ -1416,8 +1432,7 @@ class Memory(MemoryBase):
                             
                             if updates is None:
                                 updates = {}
-                            updates["should_forget"] = True
-                            updates["marked_for_forgetting_at"] = get_current_datetime().isoformat()
+                            updates.update(_forget_marker_updates())
                         
                         if updates:
                             self.storage.update_memory(memory_id, {**updates}, user_id, agent_id)

--- a/tests/unit/test_intelligence_forget_soft_mark.py
+++ b/tests/unit/test_intelligence_forget_soft_mark.py
@@ -1,0 +1,113 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from powermem.core.async_memory import AsyncMemory
+from powermem.core.memory import Memory
+
+
+def _enabled_plugin(updates=None, forget_ids=None, get_result=(None, True)):
+    plugin = SimpleNamespace(enabled=True)
+    plugin.on_search = MagicMock(return_value=(updates or [], forget_ids or []))
+    plugin.on_get = MagicMock(return_value=get_result)
+    return plugin
+
+
+def _embedding_service():
+    service = MagicMock()
+    service.embed.return_value = [0.1, 0.2, 0.3]
+    return service
+
+
+def test_memory_search_marks_forgotten_memories_without_deleting():
+    memory = object.__new__(Memory)
+    memory._get_embedding_service = MagicMock(return_value=_embedding_service())
+    memory.intelligence = SimpleNamespace(enabled=False)
+    memory._intelligence_plugin = _enabled_plugin(forget_ids=["memory-1"])
+    memory.audit = MagicMock()
+    memory.telemetry = MagicMock()
+    memory.enable_graph = False
+
+    storage = MagicMock()
+    storage.search_memories.return_value = [
+        {"id": "memory-1", "memory": "stale memory", "metadata": {}, "score": 0.9}
+    ]
+    storage.vector_store = SimpleNamespace(connection_args={})
+    memory.storage = storage
+
+    result = memory.search("stale", user_id="user-1", agent_id="agent-1")
+
+    assert result["results"][0]["id"] == "memory-1"
+    storage.delete_memory.assert_not_called()
+    storage.update_memory.assert_called_once()
+    mem_id, updates, user_id, agent_id = storage.update_memory.call_args.args
+    assert mem_id == "memory-1"
+    assert user_id == "user-1"
+    assert agent_id == "agent-1"
+    assert updates["should_forget"] is True
+    assert "marked_for_forgetting_at" in updates
+
+
+def test_async_memory_search_marks_forgotten_memories_without_deleting():
+    async def run_test():
+        memory = object.__new__(AsyncMemory)
+        memory._get_embedding_service = MagicMock(return_value=_embedding_service())
+        memory.intelligence = SimpleNamespace(enabled=False)
+        memory._intelligence_plugin = _enabled_plugin(forget_ids=["memory-1"])
+        memory.audit = SimpleNamespace(log_event_async=AsyncMock())
+        memory.telemetry = MagicMock()
+        memory.enable_graph = False
+
+        storage = SimpleNamespace(
+            search_memories_async=AsyncMock(
+                return_value=[
+                    {"id": "memory-1", "memory": "stale memory", "metadata": {}, "score": 0.9}
+                ]
+            ),
+            update_memory_async=AsyncMock(),
+            delete_memory_async=AsyncMock(),
+        )
+        memory.storage = storage
+
+        result = await memory.search("stale", user_id="user-1", agent_id="agent-1")
+
+        assert result["results"][0]["id"] == "memory-1"
+        storage.delete_memory_async.assert_not_called()
+        storage.update_memory_async.assert_awaited_once()
+        mem_id, updates, user_id, agent_id = storage.update_memory_async.call_args.args
+        assert mem_id == "memory-1"
+        assert user_id == "user-1"
+        assert agent_id == "agent-1"
+        assert updates["should_forget"] is True
+        assert "marked_for_forgetting_at" in updates
+
+    asyncio.run(run_test())
+
+
+def test_async_memory_get_marks_forgotten_memory_without_deleting():
+    async def run_test():
+        memory = object.__new__(AsyncMemory)
+        memory._intelligence_plugin = _enabled_plugin()
+        memory.audit = SimpleNamespace(log_event_async=AsyncMock())
+
+        stored = {"id": "memory-1", "memory": "stale memory"}
+        storage = SimpleNamespace(
+            get_memory_async=AsyncMock(return_value=stored),
+            update_memory_async=AsyncMock(),
+            delete_memory_async=AsyncMock(),
+        )
+        memory.storage = storage
+
+        result = await memory.get("memory-1", user_id="user-1", agent_id="agent-1")
+
+        assert result == stored
+        storage.delete_memory_async.assert_not_called()
+        storage.update_memory_async.assert_awaited_once()
+        mem_id, updates, user_id, agent_id = storage.update_memory_async.call_args.args
+        assert mem_id == "memory-1"
+        assert user_id == "user-1"
+        assert agent_id == "agent-1"
+        assert updates["should_forget"] is True
+        assert "marked_for_forgetting_at" in updates
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary

This PR completes the intelligent-forgetting soft-mark behavior introduced for Memory.get() in #282.

When EbbinghausIntelligencePlugin returns delete_flag=True, memories should be marked as forgotten instead of being physically removed from storage. The sync Memory.get() path already does this, but Memory.search(), AsyncMemory.get(), and AsyncMemory.search() still called delete_memory / delete_memory_async.

## Changes

- Add a forget-marker payload helper for sync and async memory modules.
- Update Memory.search() to call update_memory() with should_forget and marked_for_forgetting_at instead of deleting.
- Update AsyncMemory.search() to call update_memory_async() instead of deleting.
- Update AsyncMemory.get() to soft mark and return the current result, matching Memory.get() behavior.
- Add regression tests covering sync search, async search, and async get soft-mark behavior.

## Test plan

- [x] pytest tests/unit/test_intelligence_forget_soft_mark.py -v
- [x] pytest tests/unit/intelligence -v
- [x] pytest tests/unit/test_memory.py -v
- [x] git diff --check