### PR TITLE
Fix PyPI publish trigger for tag releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,3 +163,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  dispatch-pypi-publish:
+    runs-on: ubuntu-latest
+    # Releases created with GITHUB_TOKEN do not emit a release.published event
+    # that starts another workflow. workflow_dispatch is the supported exception,
+    # and keeps PyPI trusted publishing bound to publish.yml.
+    if: startsWith(github.ref, 'refs/tags/v') && !startsWith(github.ref, 'refs/tags/plugins-')
+    needs: build-and-release
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Dispatch PyPI publish workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh workflow run publish.yml --ref "$RELEASE_TAG" -f release_tag="$RELEASE_TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,16 +6,24 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Version tag to publish, for example v1.1.2'
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   release-build:
-    if: startsWith(github.event.release.tag_name, 'v') && !startsWith(github.event.release.tag_name, 'plugins-')
+    if: startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'v') && !startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'plugins-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -58,7 +66,7 @@ jobs:
           path: dist/
 
   pypi-publish:
-    if: startsWith(github.event.release.tag_name, 'v') && !startsWith(github.event.release.tag_name, 'plugins-')
+    if: startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'v') && !startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'plugins-')
     runs-on: ubuntu-latest
     needs:
       - release-build
@@ -74,3 +82,5 @@ jobs:
 
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
## Summary

- dispatch publish.yml from the tag release workflow after GitHub Release creation
- keep PyPI trusted publishing bound to publish.yml
- add workflow_dispatch support to publish.yml for manual backfills
- use skip-existing for idempotent PyPI backfill runs

## Validation

- parsed build.yml and publish.yml with PyYAML
- git diff --check
