### PR TITLE
Make soft-forgotten memories rank lower

### DIFF
--- a/src/powermem/__init__.py
+++ b/src/powermem/__init__.py
@@ -178,6 +178,7 @@ def from_config(config: Any = None, **kwargs):
                  - initial_retention (float): Initial retention strength for new memories (default: 1.0)
                  - decay_rate (float): Rate at which memories decay over time (default: 0.1)
                  - reinforcement_factor (float): Factor by which memories are reinforced when accessed (default: 0.3)
+                 - forgotten_score_multiplier (float): Multiplier for memories marked should_forget in search ranking (default: 0.1)
                  - working_threshold (float): Threshold for working memory classification (default: 0.3)
                  - short_term_threshold (float): Threshold for short-term memory classification (default: 0.6)
                  - long_term_threshold (float): Threshold for long-term memory classification (default: 0.8)

--- a/src/powermem/config_loader.py
+++ b/src/powermem/config_loader.py
@@ -299,6 +299,7 @@ class IntelligentMemorySettings(_BasePowermemSettings):
         }
     )
     reinforcement_factor: float = Field(default=0.3)
+    forgotten_score_multiplier: float = Field(default=0.1)
     working_threshold: float = Field(default=0.3)
     short_term_threshold: float = Field(default=0.6)
     long_term_threshold: float = Field(default=0.8)

--- a/src/powermem/configs.py
+++ b/src/powermem/configs.py
@@ -55,6 +55,13 @@ class IntelligentMemoryConfig(BaseModel):
         default=0.3,
         description="Factor by which memories are reinforced when accessed"
     )
+    forgotten_score_multiplier: float = Field(
+        default=0.1,
+        description=(
+            "Multiplier applied to search ranking scores for memories "
+            "marked should_forget"
+        )
+    )
     working_threshold: float = Field(
         default=0.3,
         description="Threshold for working memory classification"

--- a/src/powermem/intelligence/ebbinghaus_algorithm.py
+++ b/src/powermem/intelligence/ebbinghaus_algorithm.py
@@ -183,7 +183,11 @@ class EbbinghausAlgorithm:
             Relevance score between 0 and 1
         """
         try:
-            content = memory.get("content", "").lower()
+            content = (
+                memory.get("content")
+                or memory.get("memory")
+                or ""
+            ).lower()
             query_lower = query.lower()
             
             # Simple keyword matching

--- a/src/powermem/intelligence/intelligent_memory_manager.py
+++ b/src/powermem/intelligence/intelligent_memory_manager.py
@@ -49,6 +49,9 @@ class IntelligentMemoryManager:
             self.config.get("llm", {})
         )
         self.ebbinghaus_algorithm = EbbinghausAlgorithm(self.intelligent_config)
+        self.forgotten_score_multiplier = self._load_forgotten_score_multiplier(
+            self.intelligent_config.get("forgotten_score_multiplier", 0.1)
+        )
         
         # Initialize LLM for importance evaluation
         self._initialize_llm()
@@ -187,9 +190,19 @@ class IntelligentMemoryManager:
                 
                 # Update result with processed information
                 processed_result = result.copy()
+                forgotten_score_multiplier = (
+                    self.forgotten_score_multiplier
+                    if self._is_marked_forgetting(result)
+                    else 1.0
+                )
                 processed_result["relevance_score"] = relevance_score
                 processed_result["decay_factor"] = decay_factor
-                processed_result["final_score"] = relevance_score * decay_factor
+                processed_result["forgotten_score_multiplier"] = (
+                    forgotten_score_multiplier
+                )
+                processed_result["final_score"] = (
+                    relevance_score * decay_factor * forgotten_score_multiplier
+                )
                 
                 processed_results.append(processed_result)
             
@@ -203,6 +216,34 @@ class IntelligentMemoryManager:
         except Exception as e:
             logger.error(f"Failed to process search results: {e}")
             return results
+
+    def _is_marked_forgetting(self, memory: Dict[str, Any]) -> bool:
+        value = memory.get("should_forget")
+        metadata = memory.get("metadata") or {}
+        if value is None:
+            value = metadata.get("should_forget")
+        if value is None:
+            management = metadata.get("memory_management") or {}
+            value = management.get("should_forget")
+        return self._coerce_bool(value)
+
+    @staticmethod
+    def _coerce_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() == "true"
+        return False
+
+    @staticmethod
+    def _load_forgotten_score_multiplier(value: Any) -> float:
+        try:
+            multiplier = float(value)
+        except (TypeError, ValueError):
+            return 0.1
+        if multiplier < 0:
+            return 0.1
+        return min(multiplier, 1.0)
     
     async def process_search_results_async(
         self,

--- a/tests/unit/intelligence/test_ebbinghaus_decay_rate.py
+++ b/tests/unit/intelligence/test_ebbinghaus_decay_rate.py
@@ -138,3 +138,106 @@ def test_search_results_use_type_specific_decay_rate():
 
     assert by_id["working"]["decay_factor"] < by_id["long"]["decay_factor"]
     assert processed[0]["id"] == "long"
+
+
+def test_search_results_demote_memories_marked_for_forgetting():
+    manager = IntelligentMemoryManager(
+        {
+            "intelligent_memory": {
+                "decay_rate": 0.1,
+                "forgotten_score_multiplier": 0.1,
+            }
+        }
+    )
+    created_at = get_current_datetime()
+    results = [
+        {
+            "id": "active",
+            "content": "shared keyword",
+            "created_at": created_at,
+        },
+        {
+            "id": "forgotten",
+            "content": "shared keyword extra",
+            "created_at": created_at,
+            "should_forget": True,
+        },
+    ]
+
+    processed = manager.process_search_results(results, "keyword")
+    by_id = {item["id"]: item for item in processed}
+
+    assert by_id["forgotten"]["forgotten_score_multiplier"] == pytest.approx(
+        0.1
+    )
+    assert by_id["forgotten"]["final_score"] < by_id["active"]["final_score"]
+    assert processed[0]["id"] == "active"
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        {"should_forget": True},
+        {"metadata": {"should_forget": True}},
+        {"metadata": {"should_forget": "true"}},
+        {"metadata": {"memory_management": {"should_forget": True}}},
+    ],
+)
+def test_search_results_read_forget_marker_from_supported_locations(marker):
+    manager = IntelligentMemoryManager(
+        {
+            "intelligent_memory": {
+                "decay_rate": 0.1,
+                "forgotten_score_multiplier": 0.2,
+            }
+        }
+    )
+    result = {
+        "id": "forgotten",
+        "content": "keyword",
+        "created_at": get_current_datetime(),
+        **marker,
+    }
+
+    processed = manager.process_search_results([result], "keyword")
+
+    assert processed[0]["forgotten_score_multiplier"] == pytest.approx(0.2)
+
+
+def test_search_results_do_not_demote_unmarked_memories():
+    manager = IntelligentMemoryManager({"intelligent_memory": {"decay_rate": 0.1}})
+    result = {
+        "id": "active",
+        "content": "keyword",
+        "created_at": get_current_datetime(),
+        "metadata": {"should_forget": False},
+    }
+
+    processed = manager.process_search_results([result], "keyword")
+
+    assert processed[0]["forgotten_score_multiplier"] == pytest.approx(1.0)
+    assert processed[0]["final_score"] == pytest.approx(
+        processed[0]["relevance_score"] * processed[0]["decay_factor"]
+    )
+
+
+def test_search_results_calculate_relevance_from_storage_memory_field():
+    manager = IntelligentMemoryManager({"intelligent_memory": {"decay_rate": 0.1}})
+    result = {
+        "id": "storage-result",
+        "memory": "keyword from storage adapter",
+        "created_at": get_current_datetime(),
+    }
+
+    processed = manager.process_search_results([result], "keyword")
+
+    assert processed[0]["relevance_score"] == pytest.approx(1.0)
+    assert processed[0]["final_score"] > 0
+
+
+def test_forgotten_score_multiplier_does_not_boost_scores():
+    manager = IntelligentMemoryManager(
+        {"intelligent_memory": {"forgotten_score_multiplier": 2.0}}
+    )
+
+    assert manager.forgotten_score_multiplier == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- apply a configurable demotion multiplier to search results marked with `should_forget`
- read soft-forget markers from top-level, metadata, and memory_management metadata
- make relevance calculation work with storage results that expose content as `memory`

## Scope
This keeps the existing search/get lifecycle behavior intact. It only makes the soft-forget marker introduced by #984 affect search ranking.

## Tests
- `python -m pytest tests/unit/intelligence tests/unit/test_intelligence_forget_soft_mark.py`