### PR TITLE
chore: add powermem-mcp release flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,10 @@ jobs:
         run: |
           pip install build twine
 
+      - name: Check Python package versions
+        run: |
+          python scripts/check_package_versions.py
+
       - name: Clean previous builds
         run: |
           rm -rf dist/ build/ *.egg-info/
@@ -98,15 +102,38 @@ jobs:
         run: |
           python -m twine check dist/*
 
+      - name: Clean previous MCP wrapper builds
+        run: |
+          rm -rf packages/powermem-mcp/dist/ packages/powermem-mcp/build/
+          rm -rf packages/powermem-mcp/*.egg-info/ packages/powermem-mcp/src/*.egg-info/
+
+      - name: Build MCP wrapper package
+        run: |
+          cd packages/powermem-mcp
+          python -m build
+
+      - name: Check MCP wrapper package
+        run: |
+          cd packages/powermem-mcp
+          python -m twine check dist/*
+
       - name: List built files
         run: |
           ls -lh dist/
+          ls -lh packages/powermem-mcp/dist/
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dist-python-${{ matrix.python-version }}
           path: dist/*
+          retention-days: 30
+
+      - name: Upload MCP wrapper build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-mcp-python-${{ matrix.python-version }}
+          path: packages/powermem-mcp/dist/*
           retention-days: 30
 
   combine-artifacts:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,17 +55,31 @@ jobs:
           mkdir -p src/server/dashboard
           cp -r dashboard/dist/* src/server/dashboard/
 
+          python scripts/check_package_versions.py
+
           rm -rf dist
           mkdir -p dist
           python -m build -o dist
 
-      - name: Upload dists
+          rm -rf dist-mcp packages/powermem-mcp/dist packages/powermem-mcp/build
+          rm -rf packages/powermem-mcp/*.egg-info packages/powermem-mcp/src/*.egg-info
+          mkdir -p dist-mcp
+          cd packages/powermem-mcp
+          python -m build -o ../../dist-mcp
+
+      - name: Upload powermem dists
         uses: actions/upload-artifact@v4
         with:
           name: release-dists
           path: dist/
 
-  pypi-publish:
+      - name: Upload powermem-mcp dists
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-mcp-dists
+          path: dist-mcp/
+
+  pypi-publish-powermem:
     if: startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'v') && !startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'plugins-')
     runs-on: ubuntu-latest
     needs:
@@ -81,6 +95,26 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+  pypi-publish-powermem-mcp:
+    if: startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'v') && !startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'plugins-')
+    runs-on: ubuntu-latest
+    needs:
+      - pypi-publish-powermem
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Retrieve powermem-mcp release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-mcp-dists
+          path: dist/
+
+      - name: Publish powermem-mcp distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev test test-unit test-integration test-e2e test-coverage test-fast test-slow lint format clean build build-package build-check build-dashboard build-claude-hook package-claude-plugin publish-pypi publish-testpypi install-build-tools upload docs bump-version server-start server-stop server-restart server-status server-logs server-dashboard-start docker-build docker-run docker-up docker-down docker-logs docker-stop docker-restart docker-clean docker-ps
+.PHONY: help install install-dev test test-unit test-integration test-e2e test-coverage test-fast test-slow lint format clean build build-package build-check build-mcp-package build-mcp-check build-all-python-packages build-dashboard build-claude-hook package-claude-plugin publish-pypi publish-mcp-pypi publish-all-pypi publish-testpypi install-build-tools upload docs bump-version check-package-versions server-start server-stop server-restart server-status server-logs server-dashboard-start docker-build docker-run docker-up docker-down docker-logs docker-stop docker-restart docker-clean docker-ps
 
 help: ## Show help information
 	@echo "powermem Project Build Tools"
@@ -98,7 +98,10 @@ build: ## Build package (legacy, use build-package)
 	@echo "Use 'make build-package' instead"
 	$(MAKE) build-package
 
-build-package: clean ## Build distribution packages (wheel and sdist)
+check-package-versions: ## Verify powermem and powermem-mcp versions are aligned
+	python scripts/check_package_versions.py
+
+build-package: clean check-package-versions ## Build distribution packages (wheel and sdist)
 	@echo "Building distribution packages..."
 	python -m build
 	@echo "Build complete! Distribution files are in dist/"
@@ -108,6 +111,23 @@ build-check: build-package ## Check the built package
 	@echo "Checking built package..."
 	python -m twine check dist/*
 	@echo "Package check passed!"
+
+build-mcp-package: check-package-versions ## Build powermem-mcp wrapper package
+	@echo "Building powermem-mcp wrapper package..."
+	rm -rf packages/powermem-mcp/dist/
+	rm -rf packages/powermem-mcp/build/
+	rm -rf packages/powermem-mcp/*.egg-info/
+	rm -rf packages/powermem-mcp/src/*.egg-info/
+	cd packages/powermem-mcp && python -m build
+	@echo "Build complete! Distribution files are in packages/powermem-mcp/dist/"
+	@ls -lh packages/powermem-mcp/dist/
+
+build-mcp-check: build-mcp-package ## Check the powermem-mcp wrapper package
+	@echo "Checking powermem-mcp wrapper package..."
+	cd packages/powermem-mcp && python -m twine check dist/*
+	@echo "powermem-mcp package check passed!"
+
+build-all-python-packages: build-check build-mcp-check ## Build and check powermem plus powermem-mcp
 
 build-dashboard: ## Build dashboard frontend and inject into src/server/dashboard (for local dev; then use make server-start-reload)
 	@echo "Building dashboard..."
@@ -149,6 +169,21 @@ publish-pypi: build-check ## Publish to PyPI (requires credentials)
 	python -m twine upload dist/*
 	@echo "Upload complete!"
 	@echo "Package available at: https://pypi.org/project/powermem/"
+
+publish-mcp-pypi: build-mcp-check ## Publish powermem-mcp to PyPI (requires credentials)
+	@echo "Publishing powermem-mcp to PyPI..."
+	@echo "Make sure the matching powermem version is already available on PyPI."
+	@read -p "Continue with upload to PyPI? (y/N) " -n 1 -r; \
+	echo; \
+	if [[ ! $$REPLY =~ ^[Yy]$$ ]]; then \
+		echo "Upload cancelled."; \
+		exit 1; \
+	fi
+	cd packages/powermem-mcp && python -m twine upload dist/*
+	@echo "Upload complete!"
+	@echo "Package available at: https://pypi.org/project/powermem-mcp/"
+
+publish-all-pypi: publish-pypi publish-mcp-pypi ## Publish powermem first, then powermem-mcp
 
 publish-testpypi: build-check ## Publish to TestPyPI (for testing)
 	@echo "Publishing to TestPyPI..."
@@ -194,6 +229,10 @@ bump-version: ## Bump version number (usage: make bump-version VERSION=0.2.0)
 	@$(SED_INPLACE) -E 's/"version": "[0-9]+\.[0-9]+\.[0-9]+"/"version": "$(VERSION)"/g' src/powermem/core/telemetry.py
 	@# Update src/powermem/core/audit.py (match any x.y.z)
 	@$(SED_INPLACE) -E 's/"version": "[0-9]+\.[0-9]+\.[0-9]+"/"version": "$(VERSION)"/g' src/powermem/core/audit.py
+	@# Update powermem-mcp wrapper package version and dependency pin
+	@$(SED_INPLACE) 's/^version = ".*"/version = "$(VERSION)"/' packages/powermem-mcp/pyproject.toml
+	@$(SED_INPLACE) -E 's/powermem\[mcp,seekdb\]==[0-9]+\.[0-9]+\.[0-9]+/powermem[mcp,seekdb]==$(VERSION)/' packages/powermem-mcp/pyproject.toml
+	@$(MAKE) check-package-versions
 	@echo "✓ Version updated to $(VERSION) in all files (excluding examples/)"
 	@echo ""
 	@echo "Updated files:"
@@ -201,6 +240,7 @@ bump-version: ## Bump version number (usage: make bump-version VERSION=0.2.0)
 	@echo "  - src/powermem/version.py"
 	@echo "  - src/powermem/core/telemetry.py"
 	@echo "  - src/powermem/core/audit.py"
+	@echo "  - packages/powermem-mcp/pyproject.toml"
 	@echo ""
 	@echo "Note: Don't forget to update VERSION_HISTORY in src/powermem/version.py manually!"
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,21 @@ pip install "powermem[mcp,seekdb]"
 pip install "powermem[cli,server,mcp,seekdb]"
 ```
 
+For zero-install MCP clients such as Cursor, Codex, Claude Desktop, Cline, or
+Goose, use the wrapper package:
+
+```bash
+uvx powermem-mcp
+```
+
+The `powermem-mcp` wrapper is version-locked to the main `powermem` release and
+installs `powermem[mcp,seekdb]` for the same version. If `uv` has cached an older
+tool environment, refresh it explicitly:
+
+```bash
+uvx --refresh --upgrade powermem-mcp
+```
+
 ### SDK
 
 Run from a directory that contains your configured `.env`:

--- a/packages/powermem-mcp/README.md
+++ b/packages/powermem-mcp/README.md
@@ -1,0 +1,36 @@
+# powermem-mcp
+
+Thin wrapper package for launching the PowerMem MCP server with `uvx`.
+
+This package intentionally uses the same version as the main
+[`powermem`](https://pypi.org/project/powermem/) package. For example,
+`powermem-mcp==1.1.3` depends on `powermem[mcp,seekdb]==1.1.3`.
+
+Use this package when an MCP client needs a zero-install command such as:
+
+```bash
+uvx powermem-mcp
+```
+
+## Usage
+
+```bash
+uvx powermem-mcp                  # streamable HTTP on :8848
+uvx powermem-mcp stdio            # stdio
+uvx powermem-mcp streamable-http 9000
+uvx powermem-mcp sse 8848
+```
+
+If `uv` has cached an older tool environment, refresh explicitly:
+
+```bash
+uvx --refresh --upgrade powermem-mcp
+```
+
+## Development
+
+Do not publish this package with a version that differs from the root
+`powermem` package. The release flow should publish `powermem` first, then this
+wrapper package for the same version.
+
+See the [main repository](https://github.com/oceanbase/powermem) for full documentation.

--- a/packages/powermem-mcp/pyproject.toml
+++ b/packages/powermem-mcp/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "powermem-mcp"
+version = "1.1.2"
+description = "PowerMem MCP server - thin wrapper that installs powermem[mcp,seekdb] and exposes the powermem-mcp command."
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    {name = "powermem Team", email = "open_oceanbase@oceanbase.com"}
+]
+requires-python = ">=3.11"
+dependencies = [
+    "powermem[mcp,seekdb]==1.1.2",
+]
+
+[project.urls]
+Homepage = "https://github.com/oceanbase/powermem"
+Repository = "https://github.com/oceanbase/powermem.git"
+
+[project.scripts]
+powermem-mcp = "powermem.mcp.server:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/scripts/check_package_versions.py
+++ b/scripts/check_package_versions.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Check that powermem and powermem-mcp are released as one version pair."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROOT_PYPROJECT = ROOT / "pyproject.toml"
+MCP_PYPROJECT = ROOT / "packages" / "powermem-mcp" / "pyproject.toml"
+
+
+def read_project_version(path: Path) -> str:
+    match = re.search(r'^version = "([^"]+)"', path.read_text(), re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"Could not find project version in {path}")
+    return match.group(1)
+
+
+def main() -> int:
+    root_version = read_project_version(ROOT_PYPROJECT)
+    mcp_text = MCP_PYPROJECT.read_text()
+    mcp_version = read_project_version(MCP_PYPROJECT)
+    expected_dependency = f"powermem[mcp,seekdb]=={root_version}"
+
+    errors: list[str] = []
+    if mcp_version != root_version:
+        errors.append(
+            f"powermem-mcp version {mcp_version} does not match powermem {root_version}"
+        )
+    if expected_dependency not in mcp_text:
+        errors.append(
+            "powermem-mcp dependency must be pinned to "
+            f"{expected_dependency!r}"
+        )
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Package versions aligned: powermem == powermem-mcp == {root_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the powermem-mcp wrapper package for uvx-based MCP launches
- keep powermem-mcp version-locked to the root powermem package
- extend Makefile bump/build/publish targets and CI release workflow to publish powermem first, then powermem-mcp
- document uvx powermem-mcp usage and cache refresh behavior

## Validation
- python3 scripts/check_package_versions.py
- git diff --check
- python3.11 -m build --wheel --outdir /tmp/powermem-mcp-dist packages/powermem-mcp
- inspected wheel metadata: Requires-Dist: powermem[mcp,seekdb]==1.1.2