### PR TITLE
chore: bump version to 1.1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ build: ## Build package (legacy, use build-package)
 	$(MAKE) build-package
 
 check-package-versions: ## Verify powermem and powermem-mcp versions are aligned
-	python scripts/check_package_versions.py
+	python3 scripts/check_package_versions.py
 
 build-package: clean check-package-versions ## Build distribution packages (wheel and sdist)
 	@echo "Building distribution packages..."

--- a/packages/powermem-mcp/pyproject.toml
+++ b/packages/powermem-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powermem-mcp"
-version = "1.1.2"
+version = "1.1.3"
 description = "PowerMem MCP server - thin wrapper that installs powermem[mcp,seekdb] and exposes the powermem-mcp command."
 readme = "README.md"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "powermem[mcp,seekdb]==1.1.2",
+    "powermem[mcp,seekdb]==1.1.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powermem"
-version = "1.1.2"
+version = "1.1.3"
 description = "Intelligent Memory System - Persistent memory layer for LLM applications"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/powermem/core/audit.py
+++ b/src/powermem/core/audit.py
@@ -106,7 +106,7 @@ class AuditLogger:
                 "user_id": user_id,
                 "agent_id": agent_id,
                 "details": details,
-                "version": "1.1.2",
+                "version": "1.1.3",
             }
             
             # Log to file

--- a/src/powermem/core/telemetry.py
+++ b/src/powermem/core/telemetry.py
@@ -82,7 +82,7 @@ class TelemetryManager:
                 "user_id": user_id,
                 "agent_id": agent_id,
                 "timestamp": get_current_datetime().isoformat(),
-                "version": "1.1.2",
+                "version": "1.1.3",
             }
             
             self.events.append(event)
@@ -182,7 +182,7 @@ class TelemetryManager:
                 "properties": properties,
                 "user_id": user_id,
                 "timestamp": get_current_datetime().isoformat(),
-                "version": "1.1.2",
+                "version": "1.1.3",
             }
             
             self.events.append(event)

--- a/src/powermem/version.py
+++ b/src/powermem/version.py
@@ -2,11 +2,12 @@
 Version information management
 """
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __version_info__ = tuple(map(int, __version__.split(".")))
 
 # Version history
 VERSION_HISTORY = {
+    "1.1.3": "2026-06-08 - Version 1.1.3 release",
     "1.1.2": "2026-06-07 - Version 1.1.2 release",
     "1.1.0": "2026-04-02 - Version 1.1.0 release",
     "1.0.0": "2026-03-16 - Version 1.0.0 release",


### PR DESCRIPTION
## Summary
- bump powermem from 1.1.2 to 1.1.3
- bump powermem-mcp to 1.1.3 and pin it to powermem[mcp,seekdb]==1.1.3
- add 1.1.3 to VERSION_HISTORY
- use python3 for the package-version consistency check so make bump-version works on hosts where python is Python 2

## Validation
- make bump-version VERSION=1.1.3
- make check-package-versions
- python3 scripts/check_package_versions.py
- git diff --check
- python3.11 -m build --wheel --outdir /tmp/powermem-root-dist .
- python3.11 -m build --wheel --outdir /tmp/powermem-mcp-dist packages/powermem-mcp
- inspected wheel metadata: powermem==1.1.3 and powermem-mcp Requires-Dist: powermem[mcp,seekdb]==1.1.3
