### PR TITLE
fix(intelligence): expose final search score after ranking

### DIFF
--- a/src/powermem/intelligence/intelligent_memory_manager.py
+++ b/src/powermem/intelligence/intelligent_memory_manager.py
@@ -188,13 +188,18 @@ class IntelligentMemoryManager:
                     decay_rate=decay_rate,
                 )
                 
-                # Update result with processed information
+                # Update result with processed information. Keep the storage
+                # score for diagnostics, but expose the final score because
+                # it is the value used for user-visible ranking.
                 processed_result = result.copy()
+                original_score = processed_result.get("score")
                 forgotten_score_multiplier = (
                     self.forgotten_score_multiplier
                     if self._is_marked_forgetting(result)
                     else 1.0
                 )
+                if original_score is not None:
+                    processed_result["original_score"] = original_score
                 processed_result["relevance_score"] = relevance_score
                 processed_result["decay_factor"] = decay_factor
                 processed_result["forgotten_score_multiplier"] = (
@@ -203,6 +208,7 @@ class IntelligentMemoryManager:
                 processed_result["final_score"] = (
                     relevance_score * decay_factor * forgotten_score_multiplier
                 )
+                processed_result["score"] = processed_result["final_score"]
                 
                 processed_results.append(processed_result)
             

--- a/tests/unit/intelligence/test_ebbinghaus_decay_rate.py
+++ b/tests/unit/intelligence/test_ebbinghaus_decay_rate.py
@@ -171,7 +171,45 @@ def test_search_results_demote_memories_marked_for_forgetting():
         0.1
     )
     assert by_id["forgotten"]["final_score"] < by_id["active"]["final_score"]
+    assert by_id["forgotten"]["score"] == pytest.approx(
+        by_id["forgotten"]["final_score"]
+    )
     assert processed[0]["id"] == "active"
+
+
+def test_search_results_expose_scores_in_ranking_order():
+    manager = IntelligentMemoryManager(
+        {
+            "intelligent_memory": {
+                "decay_rate": 0.1,
+                "forgotten_score_multiplier": 0.1,
+            }
+        }
+    )
+    created_at = get_current_datetime()
+    results = [
+        {
+            "id": "forgotten",
+            "content": "shared keyword",
+            "created_at": created_at,
+            "score": 0.9,
+            "should_forget": True,
+        },
+        {
+            "id": "active",
+            "content": "shared keyword",
+            "created_at": created_at,
+            "score": 0.2,
+        },
+    ]
+
+    processed = manager.process_search_results(results, "keyword")
+    scores = [item["score"] for item in processed]
+
+    assert processed[0]["id"] == "active"
+    assert scores == sorted(scores, reverse=True)
+    assert processed[1]["id"] == "forgotten"
+    assert processed[1]["original_score"] == pytest.approx(0.9)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- expose the intelligence `final_score` as the returned search `score` after intelligent ranking
- keep the pre-intelligence storage score as `original_score` for diagnostics
- add a regression unit test that verifies returned scores remain in ranking order when soft-forgotten memories are demoted

## Why
Regression run https://github.com/oceanbase/powermem/actions/runs/27140841569/job/80105314588 failed because search results were sorted by the intelligence `final_score`, but the API response still exposed the original storage `score`. That made user-visible scores appear out of descending order even though the internal ranking had changed.

## Validation
- python3.11 -m pytest tests/unit/intelligence/test_ebbinghaus_decay_rate.py -q
- python3 -m py_compile src/powermem/intelligence/intelligent_memory_manager.py tests/unit/intelligence/test_ebbinghaus_decay_rate.py

Note: `python3 -m pytest ...` in the local Python 3.8 environment fails during collection because `pyobvector` is not installed; Python 3.11 test execution passed.
