### PR TITLE
fix(skill-store): fix broken embed calls and dedup threshold

### DIFF
--- a/src/powermem/configs.py
+++ b/src/powermem/configs.py
@@ -230,7 +230,7 @@ class SkillStoreConfig(BaseModel):
     """Configuration for skill sub-store."""
     enabled: bool = Field(default=False, description="Enable skill storage")
     collection_name: Optional[str] = Field(default=None, description="Table name; auto-generated if None")
-    similarity_threshold: float = Field(default=0.75, description="Dedup similarity threshold")
+    similarity_threshold: float = Field(default=0.03, description="Dedup RRF score threshold")
     index_type: Optional[str] = Field(default=None, description="Vector index type (hnsw, ivf, etc.). Falls back to vector_store.config.index_type if not set")
 
 

--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -2562,14 +2562,14 @@ class Memory(MemoryBase):
             if not safe:
                 return {"title": title, "action": "blocked", "reason": reason}
 
-        title_emb = title_embedding if title_embedding is not None else self._embed(title)
-        desc_emb = description_embedding if description_embedding is not None else self._embed(description)
+        title_emb = title_embedding if title_embedding is not None else self.embedding.embed(title)
+        desc_emb = description_embedding if description_embedding is not None else self.embedding.embed(description)
 
         similar = self.skill_store.search(
             query_embedding=title_emb, query_text=title,
             limit=1, user_id=user_id, agent_id=agent_id,
         )
-        threshold = (self.config.get("skill_store") or {}).get("similarity_threshold", 0.75) if isinstance(self.config.get("skill_store"), dict) else 0.75
+        threshold = (self.config.get("skill_store") or {}).get("similarity_threshold", 0.03) if isinstance(self.config.get("skill_store"), dict) else 0.03
 
         if similar and similar[0].get("score", 0) > threshold:
             existing = similar[0]
@@ -2583,8 +2583,8 @@ class Memory(MemoryBase):
                 merged_desc = merge_result.get("description") or description
                 merged_proc = merge_result.get("procedure") or procedure
                 merged_tags = list(set((tags or []) + (existing.get("tags") or [])))
-                merged_title_emb = self._embed(merged_title)
-                merged_desc_emb = self._embed(merged_desc)
+                merged_title_emb = self.embedding.embed(merged_title)
+                merged_desc_emb = self.embedding.embed(merged_desc)
                 self.skill_store.update(
                     existing["id"], merged_title, merged_desc,
                     tags=merged_tags, procedure_data=merged_proc,
@@ -2606,7 +2606,7 @@ class Memory(MemoryBase):
         """Search skills by embedding + fulltext."""
         if not self.skill_store:
             return []
-        query_emb = self._embed(query)
+        query_emb = self.embedding.embed(query)
         return self.skill_store.search(
             query_embedding=query_emb, query_text=query,
             limit=limit, user_id=user_id, agent_id=agent_id,


### PR DESCRIPTION
## Summary

The skill distillation storage pipeline (`add_skill()`, `search_skills()`) was non-functional due to two compounding bugs:

- `self._embed()` was never defined on Memory — all calls raised `AttributeError` at runtime. Replaced with `self.embedding.embed()` at 5 call sites.
- Dedup `similarity_threshold` defaulted to 0.75, but the skill store's RRF fusion score maxes out at `4*(1/60) = 0.0667`. The dedup condition could never trigger, making the merge path dead code. Changed default to 0.03.

## Details

**Bug 1: `_embed` undefined**
```python
# Before (crashes):
title_emb = self._embed(title)        # AttributeError

# After (works):
title_emb = self.embedding.embed(title)  # uses the initialized embedder
```

**Bug 2: threshold/score-space mismatch**
```
Max RRF score: 4 * 1/(60+0) = 0.0667
Old threshold: 0.75  →  0.0667 > 0.75 = False (always)
New threshold: 0.03  →  0.0667 > 0.03 = True  (when 2+ lanes match)
```

## Test plan

- [x] Verified `self.embedding` is unconditionally set in `__init__` (line 268)
- [x] Verified `embed()` signature is compatible across all 16 embedder implementations
- [x] Verified no remaining `self._embed(` calls in codebase
- [x] Verified no test mocks `_embed` (no breakage)
- [x] No existing tests assert on old threshold value 0.75
- [ ] CI tests pass
- Note: `add_skill()` and `search_skills()` have no dedicated test coverage (pre-existing gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)