### PR TITLE
Fix Node 20 CI deprecation and VS Code extension cache path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ on:
           - '3.11'
           - '3.12'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-dashboard:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,23 +19,20 @@ on:
           - '3.11'
           - '3.12'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build-dashboard:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
@@ -46,7 +43,7 @@ jobs:
           pnpm build
 
       - name: Upload dashboard dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dashboard-dist
           path: dashboard/dist/
@@ -61,10 +58,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download dashboard artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dashboard-dist
           path: dashboard-dist
@@ -75,7 +72,7 @@ jobs:
           cp -r dashboard-dist/* src/server/dashboard/
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -126,14 +123,14 @@ jobs:
           ls -lh packages/powermem-mcp/dist/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-python-${{ matrix.python-version }}
           path: dist/*
           retention-days: 30
 
       - name: Upload MCP wrapper build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-mcp-python-${{ matrix.python-version }}
           path: packages/powermem-mcp/dist/*
@@ -146,7 +143,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist-all
 
@@ -162,7 +159,7 @@ jobs:
           ls -1 dist/ | wc -l
 
       - name: Upload combined artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-packages
           path: dist/*
@@ -178,13 +175,13 @@ jobs:
 
     steps:
       - name: Download combined artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-packages
           path: dist
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           draft: false

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -8,21 +8,18 @@ on:
   pull_request:
     branches: [main, develop]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Get SDK version
         id: sdk-version
@@ -58,14 +55,14 @@ jobs:
 
       - name: Log in to Docker hub (for tag push only)
         if: steps.should-push.outputs.should-push == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image (for tags)
         if: steps.should-push.outputs.should-push == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -135,7 +132,7 @@ jobs:
 
       - name: Upload Docker image artifacts (for PR and branches)
         if: steps.should-push.outputs.should-push != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: powermem-server-docker-images
           path: docker-images/*.tar

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -15,6 +15,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Deploy frontend
         run: bash scripts/deploy-frontend.sh
       - name: Setup Pages

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -15,9 +15,6 @@ permissions:
   pages: write
   id-token: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -33,20 +30,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Deploy frontend
         run: bash scripts/deploy-frontend.sh
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload entire repository
           path: 'docs/website/build'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/export_docker_image.yml
+++ b/.github/workflows/export_docker_image.yml
@@ -35,6 +35,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   export-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/export_docker_image.yml
+++ b/.github/workflows/export_docker_image.yml
@@ -35,9 +35,6 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   export-docker-image:
     runs-on: ubuntu-latest
@@ -106,15 +103,15 @@ jobs:
           echo "Resolved platform: ${PLATFORM}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.resolve-ref.outputs.checkout_ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build image and save as tar
         shell: bash
@@ -172,7 +169,7 @@ jobs:
           EOF
 
       - name: Upload docker image package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: powermem-server-image-${{ steps.resolve-build.outputs.image_tag }}
           path: docker-images/*

--- a/.github/workflows/ob441-reg.yml
+++ b/.github/workflows/ob441-reg.yml
@@ -12,6 +12,9 @@ on:
         required: false
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   regression:
     runs-on: ubuntu-latest

--- a/.github/workflows/ob441-reg.yml
+++ b/.github/workflows/ob441-reg.yml
@@ -12,9 +12,6 @@ on:
         required: false
         type: string
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   regression:
     runs-on: ubuntu-latest
@@ -27,7 +24,7 @@ jobs:
       - name: Get PR SHA (if PR number provided)
         if: github.event.inputs.pr_number != ''
         id: get_pr_sha
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -41,13 +38,13 @@ jobs:
             core.setOutput('sha', pr.head.sha);
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.pr_number != '' && steps.get_pr_sha.outputs.sha || github.event.inputs.ref || github.ref }}
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -58,7 +55,7 @@ jobs:
           pip install --upgrade setuptools wheel
 
       - name: Cache pip dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}

--- a/.github/workflows/plugins-build.yml
+++ b/.github/workflows/plugins-build.yml
@@ -22,7 +22,6 @@ on:
         type: boolean
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: '24'
   GO_VERSION: '1.22.x'
 
@@ -36,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -59,7 +58,7 @@ jobs:
         id: vsce
 
       - name: Upload VS Code extension (.vsix)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: powermem-vscode-vsix
           path: apps/vscode-extension/*.vsix
@@ -71,10 +70,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -82,7 +81,7 @@ jobs:
         run: bash apps/claude-code-plugin/scripts/package-plugin.sh
 
       - name: Upload Claude Code plugin (zip)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: powermem-claude-code-plugin-zip
           path: apps/claude-code-plugin/dist/powermem-claude-code-plugin-*.zip
@@ -98,13 +97,13 @@ jobs:
 
     steps:
       - name: Download VS Code extension
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: powermem-vscode-vsix
           path: vsix
 
       - name: Download Claude Code plugin
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: powermem-claude-code-plugin-zip
           path: zip
@@ -119,7 +118,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('plugins-{0}', steps.ver.outputs.version) }}
           name: Plugins ${{ steps.ver.outputs.version }}

--- a/.github/workflows/plugins-build.yml
+++ b/.github/workflows/plugins-build.yml
@@ -22,7 +22,7 @@ on:
         type: boolean
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '24'
   GO_VERSION: '1.22.x'
 
 jobs:
@@ -42,10 +42,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: apps/vscode-extension/package-lock.json
+          cache-dependency-path: apps/vscode-extension/package.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Compile
         run: npm run compile
@@ -137,4 +137,3 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/plugins-build.yml
+++ b/.github/workflows/plugins-build.yml
@@ -22,6 +22,7 @@ on:
         type: boolean
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: '24'
   GO_VERSION: '1.22.x'
 

--- a/.github/workflows/plugins-publish-vscode.yml
+++ b/.github/workflows/plugins-publish-vscode.yml
@@ -20,6 +20,9 @@ on:
         default: false
         type: boolean
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   publish:
     name: Publish to Marketplace(s)

--- a/.github/workflows/plugins-publish-vscode.yml
+++ b/.github/workflows/plugins-publish-vscode.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
-          cache-dependency-path: apps/vscode-extension/package-lock.json
+          cache-dependency-path: apps/vscode-extension/package.json
 
       - name: Build .vsix
         run: |
           cd apps/vscode-extension
-          npm ci
+          npm install
           npm run compile
           npx @vscode/vsce package --no-dependencies --no-rewrite-relative-links
           mkdir -p ../.vsix

--- a/.github/workflows/plugins-publish-vscode.yml
+++ b/.github/workflows/plugins-publish-vscode.yml
@@ -20,9 +20,6 @@ on:
         default: false
         type: boolean
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   publish:
     name: Publish to Marketplace(s)
@@ -32,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,25 +16,22 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   release-build:
     if: startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'v') && !startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'plugins-')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
@@ -46,7 +43,7 @@ jobs:
           # static files: ./dashboard/dist
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -71,13 +68,13 @@ jobs:
           python -m build -o ../../dist-mcp
 
       - name: Upload powermem dists
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dists
           path: dist/
 
       - name: Upload powermem-mcp dists
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-mcp-dists
           path: dist-mcp/
@@ -92,7 +89,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-dists
           path: dist/
@@ -112,7 +109,7 @@ jobs:
 
     steps:
       - name: Retrieve powermem-mcp release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-mcp-dists
           path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release-build:
     if: startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'v') && !startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'plugins-')

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -28,9 +28,6 @@ on:
   schedule:
     - cron: '0 16 * * *'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   test1:
     runs-on: ubuntu-latest
@@ -50,7 +47,7 @@ jobs:
       - name: Get PR SHA (if PR number provided)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != ''
         id: get_pr_sha
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -64,7 +61,7 @@ jobs:
             core.setOutput('sha', pr.head.sha);
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         # For pull_request_target, checkout the PR branch
         # For workflow_dispatch, checkout the PR SHA (if PR number provided), or specified ref, or default branch
         # For push, checkout the pushed branch
@@ -73,7 +70,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -84,7 +81,7 @@ jobs:
           pip install --upgrade setuptools wheel
 
       - name: Cache pip dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -175,7 +172,7 @@ jobs:
           pytest tests/regression/test_scenario*.py -vs --junitxml=report/test1.xml
       - name: Upload JUnit report
         if: always() && (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junit-test1
           path: report/
@@ -204,7 +201,7 @@ jobs:
       - name: Get PR SHA (if PR number provided)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != ''
         id: get_pr_sha
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -218,7 +215,7 @@ jobs:
             core.setOutput('sha', pr.head.sha);
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         # For pull_request_target, checkout the PR branch
         # For workflow_dispatch, checkout the PR SHA (if PR number provided), or specified ref, or default branch
         # For push, checkout the pushed branch
@@ -227,7 +224,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -238,7 +235,7 @@ jobs:
           pip install --upgrade setuptools wheel
 
       - name: Cache pip dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -329,7 +326,7 @@ jobs:
           pytest tests/regression/ --ignore-glob='*test_scenario*.py' -vs --junitxml=report/test2.xml
       - name: Upload JUnit report
         if: always() && (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junit-test2
           path: report/
@@ -347,7 +344,7 @@ jobs:
     if: always() && (needs.test1.result == 'success' || needs.test1.result == 'failure') && (needs.test2.result == 'success' || needs.test2.result == 'failure')
     steps:
       - name: Download JUnit artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: junit-*
       - name: Collect JUnit reports
@@ -364,7 +361,7 @@ jobs:
           fi
           ls -la all-reports/
       - name: Publish Test Report Summary
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         if: always()
         with:
           report_paths: 'all-reports/*.xml'

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -28,6 +28,9 @@ on:
   schedule:
     - cron: '0 16 * * *'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test1:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-project-milestones.yml
+++ b/.github/workflows/sync-project-milestones.yml
@@ -19,6 +19,9 @@ permissions:
   # Note: This requires enabling "Read and write permissions" in repository settings or using a Personal Access Token
   # The GITHUB_TOKEN needs project write permissions for organization projects
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   get-project-id:
     if: github.repository == 'oceanbase/powermem'
@@ -399,4 +402,3 @@ jobs:
             console.log(`New PRs added to project: ${addedPRs}`);
             console.log(`Total items processed: ${totalIssues + totalPRs}`);
             console.log(`Total items added: ${addedIssues + addedPRs}`);
-

--- a/.github/workflows/sync-project-milestones.yml
+++ b/.github/workflows/sync-project-milestones.yml
@@ -19,9 +19,6 @@ permissions:
   # Note: This requires enabling "Read and write permissions" in repository settings or using a Personal Access Token
   # The GITHUB_TOKEN needs project write permissions for organization projects
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   get-project-id:
     if: github.repository == 'oceanbase/powermem'
@@ -31,7 +28,7 @@ jobs:
     steps:
       - name: Get Project ID
         id: get_project
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.PROJECT_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -212,7 +209,7 @@ jobs:
     
     steps:
       - name: Add Issue to Project
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.PROJECT_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -256,7 +253,7 @@ jobs:
     
     steps:
       - name: Sync Historical Issues and PRs with Milestones
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.PROJECT_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: docs/website/package-lock.json
 
@@ -39,4 +39,3 @@ jobs:
           du -sh docs/website/build
           echo "Number of files:"
           find docs/website/build -type f | wc -l
-

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -7,19 +7,16 @@ on:
     # Trigger on all branches
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   test-frontend:
     runs-on: ubuntu-latest
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -7,6 +7,9 @@ on:
     # Trigger on all branches
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test-frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,6 @@ on:
       - '../../benchmark/locomo/requirements.txt'
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -34,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -48,7 +45,7 @@ jobs:
           pip install --upgrade setuptools wheel
 
       - name: Cache pip dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -72,10 +69,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ on:
       - '../../benchmark/locomo/requirements.txt'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -13,9 +13,6 @@ on:
   pull_request_review_comment:
     types: [created, edited]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   translate:
     permissions:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -13,6 +13,9 @@ on:
   pull_request_review_comment:
     types: [created, edited]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   translate:
     permissions:


### PR DESCRIPTION
## Summary

- move frontend/plugin workflows from Node 20 to Node 24
- fix VS Code extension setup-node cache path after package-lock.json removal
- switch VS Code extension workflow installs from npm ci to npm install because no lockfile is present

## Issue

### Problem

The plugin build workflow fails before dependency installation in the VS Code extension job:

- Run: https://github.com/oceanbase/powermem/actions/runs/27251626154/job/80477175828
- Failing step: Setup Node.js
- Error: Some specified paths were not resolved, unable to cache dependencies.

The immediate cause is that the workflow still uses apps/vscode-extension/package-lock.json as the npm cache dependency path, but that lockfile no longer exists. The next step would also fail because it runs npm ci, which requires a lockfile.

The same workflows also still pin Node 20. GitHub Actions now warns that Node.js 20 actions are deprecated and will be forced to Node 24 by default, so this should be cleaned up in the same pass.

### Expected

Frontend and plugin workflows should run on Node 24 and should not reference missing lockfiles.

## Validation

- parsed all .github/workflows/*.yml with PyYAML
- git diff --check
- verified no workflow references node-version: 20 or NODE_VERSION: 20
