### PR TITLE
fix: apply access reinforcement to memory decay

### DIFF
--- a/src/powermem/intelligence/ebbinghaus_algorithm.py
+++ b/src/powermem/intelligence/ebbinghaus_algorithm.py
@@ -6,7 +6,7 @@ This module implements the Ebbinghaus forgetting curve for memory management.
 
 import logging
 import math
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional, List, Tuple
 from datetime import datetime, timedelta
 from powermem.utils.utils import get_current_datetime
 
@@ -371,8 +371,7 @@ class EbbinghausAlgorithm:
 
     def _resolve_decay_rate(self, memory: Dict[str, Any]) -> float:
         """Resolve the effective decay strength for a memory dict."""
-        meta = memory.get("metadata") or {}
-        intelligence = meta.get("intelligence") or memory.get("intelligence") or {}
+        meta, intelligence = self._resolve_metadata_sections(memory)
 
         memory_type = (
             memory.get("memory_type")
@@ -380,12 +379,13 @@ class EbbinghausAlgorithm:
             or intelligence.get("memory_type")
         )
         if memory_type:
-            return self._get_decay_rate_for_type(memory_type)
+            base_rate = self._get_decay_rate_for_type(memory_type)
+            return self._apply_reinforcement(memory, base_rate)
 
-        stored = (
-            memory.get("decay_rate")
-            or meta.get("decay_rate")
-            or intelligence.get("decay_rate")
+        stored = self._first_present(
+            memory.get("decay_rate"),
+            meta.get("decay_rate"),
+            intelligence.get("decay_rate"),
         )
         if stored is not None:
             try:
@@ -394,8 +394,67 @@ class EbbinghausAlgorithm:
                 logger.warning("Invalid stored decay_rate: %s", stored)
             else:
                 if rate > 0:
-                    return rate
-        return self.decay_rate
+                    return self._apply_reinforcement(memory, rate)
+        return self._apply_reinforcement(memory, self.decay_rate)
+
+    def _resolve_metadata_sections(
+        self, memory: Dict[str, Any]
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Return metadata and intelligence sections from supported layouts."""
+        meta = memory.get("metadata") or {}
+        intelligence = (
+            meta.get("intelligence")
+            or memory.get("intelligence")
+            or {}
+        )
+        return meta, intelligence
+
+    @staticmethod
+    def _first_present(*values: Any) -> Any:
+        """Return the first value that is not None."""
+        for value in values:
+            if value is not None:
+                return value
+        return None
+
+    def _apply_reinforcement(
+        self, memory: Dict[str, Any], base_rate: float
+    ) -> float:
+        """Increase decay strength with diminishing returns on access frequency."""
+        access_count = self._resolve_access_count(memory)
+        reinforcement_factor = self._resolve_reinforcement_factor(memory)
+        return base_rate * (1 + reinforcement_factor * math.log1p(access_count))
+
+    def _resolve_access_count(self, memory: Dict[str, Any]) -> int:
+        """Resolve access_count from top-level, metadata, or intelligence."""
+        meta, intelligence = self._resolve_metadata_sections(memory)
+        raw = self._first_present(
+            memory.get("access_count"),
+            meta.get("access_count"),
+            intelligence.get("access_count"),
+        )
+        try:
+            access_count = int(raw or 0)
+        except (TypeError, ValueError):
+            logger.warning("Invalid access_count for reinforcement: %s", raw)
+            return 0
+        return max(access_count, 0)
+
+    def _resolve_reinforcement_factor(self, memory: Dict[str, Any]) -> float:
+        """Resolve per-memory reinforcement factor with config fallback."""
+        meta, intelligence = self._resolve_metadata_sections(memory)
+        raw = self._first_present(
+            memory.get("reinforcement_factor"),
+            meta.get("reinforcement_factor"),
+            intelligence.get("reinforcement_factor"),
+            self.reinforcement_factor,
+        )
+        try:
+            factor = float(raw)
+        except (TypeError, ValueError):
+            logger.warning("Invalid reinforcement_factor: %s", raw)
+            return 0.0
+        return max(factor, 0.0)
     
     def _parse_datetime(self, value: Any) -> datetime:
         """Parse datetime from object or ISO string."""

--- a/tests/unit/intelligence/test_ebbinghaus_decay_rate.py
+++ b/tests/unit/intelligence/test_ebbinghaus_decay_rate.py
@@ -1,5 +1,6 @@
 """Unit tests for per-memory Ebbinghaus decay rates."""
 
+import math
 from datetime import timedelta
 
 import pytest
@@ -40,12 +41,12 @@ def test_should_forget_uses_memory_type_decay_rate(algo):
     working_memory = {
         "created_at": created_at,
         "memory_type": "working",
-        "access_count": 1,
+        "access_count": 0,
     }
     long_term_memory = {
         "created_at": created_at,
         "memory_type": "long_term",
-        "access_count": 1,
+        "access_count": 0,
     }
 
     assert algo.should_forget(working_memory) is True
@@ -89,6 +90,83 @@ def test_resolve_decay_rate_falls_back_to_stored_rate(algo):
     }
 
     assert algo._resolve_decay_rate(memory) == pytest.approx(0.17)
+
+
+def test_resolve_decay_rate_applies_access_reinforcement(algo):
+    memory = {
+        "memory_type": "working",
+        "access_count": 2,
+    }
+
+    assert algo._resolve_decay_rate(memory) == pytest.approx(
+        1.5 * (1 + 0.3 * math.log1p(2))
+    )
+
+
+def test_resolve_decay_rate_uses_stored_reinforcement_factor(algo):
+    memory = {
+        "metadata": {
+            "access_count": 3,
+            "intelligence": {
+                "memory_type": "working",
+                "reinforcement_factor": 0.5,
+            },
+        }
+    }
+
+    assert algo._resolve_decay_rate(memory) == pytest.approx(
+        1.5 * (1 + 0.5 * math.log1p(3))
+    )
+
+
+def test_reinforced_memory_decays_slower_in_search_results():
+    manager = IntelligentMemoryManager(
+        {"intelligent_memory": {"decay_rate": 1.5}}
+    )
+    created_at = get_current_datetime() - timedelta(hours=50)
+    results = [
+        {
+            "id": "unreinforced",
+            "content": "shared keyword",
+            "score": 0.8,
+            "created_at": created_at,
+            "memory_type": "working",
+            "access_count": 0,
+        },
+        {
+            "id": "reinforced",
+            "content": "shared keyword",
+            "score": 0.8,
+            "created_at": created_at,
+            "memory_type": "working",
+            "access_count": 2,
+        },
+    ]
+
+    processed = manager.process_search_results(results, "keyword")
+    by_id = {item["id"]: item for item in processed}
+
+    assert (
+        by_id["reinforced"]["decay_factor"]
+        > by_id["unreinforced"]["decay_factor"]
+    )
+    assert processed[0]["id"] == "reinforced"
+
+
+def test_access_reinforcement_can_prevent_forgetting(algo):
+    created_at = get_current_datetime() - timedelta(hours=50)
+    base_memory = {
+        "created_at": created_at,
+        "memory_type": "working",
+        "access_count": 0,
+    }
+    reinforced_memory = {
+        **base_memory,
+        "access_count": 2,
+    }
+
+    assert algo.should_forget(base_memory) is True
+    assert algo.should_forget(reinforced_memory) is False
 
 
 def test_promotion_changes_effective_rate(algo):


### PR DESCRIPTION
## Summary

Fixes #998 by applying `reinforcement_factor` and `access_count` when resolving the effective Ebbinghaus decay strength. Accessed memories now decay more slowly in both search ranking and forget checks, while unaccessed memories keep the previous behavior.

The effective decay strength now uses diminishing returns for access frequency:

```text
effective_decay_rate = base_decay_rate * (1 + reinforcement_factor * log1p(access_count))
```

This keeps the change scoped to existing fields and does not add schema changes, reset timestamps, or change lazy forgetting semantics.

## Tests

```bash
python -m pytest tests/unit/intelligence/test_ebbinghaus_decay_rate.py -q
# 23 passed

python -m pytest tests/unit/intelligence -q
# 46 passed

python -m compileall -q src/powermem/intelligence/ebbinghaus_algorithm.py tests/unit/intelligence/test_ebbinghaus_decay_rate.py

git diff --check
```