### PR TITLE
fix: make lint usable for critical checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: help install install-dev test test-unit test-integration test-e2e test-coverage test-fast test-slow lint format clean build build-package build-check build-mcp-package build-mcp-check build-all-python-packages build-dashboard build-claude-hook package-claude-plugin publish-pypi publish-mcp-pypi publish-all-pypi publish-testpypi install-build-tools upload docs bump-version check-package-versions server-start server-stop server-restart server-status server-logs server-dashboard-start docker-build docker-run docker-up docker-down docker-logs docker-stop docker-restart docker-clean docker-ps
+.PHONY: help install install-dev test test-unit test-integration test-e2e test-coverage test-fast test-slow check-python-version lint lint-full lint-pylint format clean build build-package build-check build-mcp-package build-mcp-check build-all-python-packages build-dashboard build-claude-hook package-claude-plugin publish-pypi publish-mcp-pypi publish-all-pypi publish-testpypi install-build-tools upload docs bump-version check-package-versions server-start server-stop server-restart server-status server-logs server-dashboard-start docker-build docker-run docker-up docker-down docker-logs docker-stop docker-restart docker-clean docker-ps
+
+PYTHON ?= python3
 
 help: ## Show help information
 	@echo "powermem Project Build Tools"
@@ -59,9 +61,17 @@ test-marker: ## Run tests with specific marker (usage: make test-marker MARKER=u
 	pytest -m $(MARKER) -v
 
 # Code quality
-lint: ## Run linting checks
-	flake8 src tests
-	pylint src/powermem || true
+check-python-version: ## Check Python version compatibility
+	@$(PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else "Python >= 3.11 is required; set PYTHON to a compatible interpreter.")'
+
+lint: check-python-version ## Run high-signal linting checks
+	$(PYTHON) -m flake8 src tests --select=F601,F821,E999
+
+lint-full: check-python-version ## Run full flake8 report
+	$(PYTHON) -m flake8 src tests
+
+lint-pylint: check-python-version ## Run optional pylint checks
+	$(PYTHON) -m pylint src/powermem || true
 
 format-check: ## Check code formatting
 	black --check src tests

--- a/src/powermem/agent/agent.py
+++ b/src/powermem/agent/agent.py
@@ -242,7 +242,7 @@ class AgentMemory:
         
         return {
             'enabled': enabled,
-            'default_scope': default_scope,
+            'default_scope': default_scope.lower(),
             'default_privacy_level': default_privacy_level,
             'default_collaboration_level': default_collaboration_level,
             'default_access_permission': default_access_permission,
@@ -271,8 +271,7 @@ class AgentMemory:
                 'max_collaborators': 5,
                 'collaboration_timeout': 3600,
                 'default_collaboration_level': default_collaboration_level.lower()
-            },
-            'default_scope': default_scope.lower()
+            }
         }
     
     def _get_default_multi_user_config(self) -> Dict[str, Any]:

--- a/src/script/scripts/migrate_sparse_vector.py
+++ b/src/script/scripts/migrate_sparse_vector.py
@@ -17,11 +17,14 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, Optional, Any, Dict
+from typing import TYPE_CHECKING, List, Optional, Any, Dict
 
 from sqlalchemy import text
 
 from powermem.utils import OceanBaseUtil
+
+if TYPE_CHECKING:
+    from powermem import Memory
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/test_basic_usage_e2e.py
+++ b/tests/e2e/test_basic_usage_e2e.py
@@ -9,7 +9,7 @@ Run with: pytest -m e2e_config tests/e2e/test_basic_usage_e2e.py
 import os
 import pytest
 from dotenv import load_dotenv
-from powermem import Memory, auto_config
+from powermem import auto_config, create_memory
 
 
 @pytest.fixture(scope="module")
@@ -122,4 +122,3 @@ class TestBasicUsageE2E:
         
         # Cleanup
         memory.delete_all(user_id=user_id)
-


### PR DESCRIPTION
## Summary

Closes #275.

This PR makes the default `make lint` target usable as a high-signal regression gate instead of reporting the full historical style backlog.

Changes:
- adds an explicit Python >= 3.11 guard through the configurable `PYTHON` make variable
- changes default `make lint` to check critical flake8 errors only: duplicate dict keys, undefined names, and syntax errors
- moves the full flake8 report to `make lint-full`
- keeps pylint available as optional `make lint-pylint`, so the default target no longer depends on a tool that is not installed by the current dev extras
- fixes the currently reported critical lint failures

## Validation

- `PYTHON=<python3.11> make lint`
- `PYTHON=python3 make lint` verifies the version guard reports a clear Python >= 3.11 requirement when the default interpreter is too old
- `git diff --check`