### PR TITLE
fix: scope graph entities by user

### DIFF
--- a/src/powermem/storage/oceanbase/oceanbase_graph.py
+++ b/src/powermem/storage/oceanbase/oceanbase_graph.py
@@ -294,11 +294,35 @@ class MemoryGraph(GraphStoreBase):
             - graph_relationships: Stores relationships between entities
         """
 
-        if not self.client.check_table_exists(constants.TABLE_ENTITIES):
+        entities_exists = self.client.check_table_exists(constants.TABLE_ENTITIES)
+        if entities_exists:
+            has_user_id = self._entities_table_has_user_id()
+            if has_user_id is None:
+                raise RuntimeError(
+                    f"Unable to inspect {constants.TABLE_ENTITIES} schema before graph migration"
+                )
+            needs_entity_migration = not has_user_id
+        else:
+            needs_entity_migration = False
+
+        if needs_entity_migration:
+            logger.warning(
+                "%s table does not include user_id. Recreating graph tables to enforce user isolation.",
+                constants.TABLE_ENTITIES,
+            )
+            if self.client.check_table_exists(constants.TABLE_RELATIONSHIPS):
+                self.client.drop_table_if_exist(constants.TABLE_RELATIONSHIPS)
+                logger.info("Dropped %s table for graph entity user_id migration", constants.TABLE_RELATIONSHIPS)
+            self.client.drop_table_if_exist(constants.TABLE_ENTITIES)
+            logger.info("Dropped %s table for graph entity user_id migration", constants.TABLE_ENTITIES)
+            entities_exists = False
+
+        if not entities_exists:
             # Define columns for entities table
             cols = [
                 Column("id", BigInteger, primary_key=True, autoincrement=False),
                 Column("name", String(255), nullable=False),
+                Column("user_id", String(128), nullable=False),
                 Column("entity_type", String(64)),
                 Column("embedding", VECTOR(self.embedding_dims)),
                 Column("created_at", TIMESTAMP, server_default=text("CURRENT_TIMESTAMP")),
@@ -306,7 +330,7 @@ class MemoryGraph(GraphStoreBase):
             ]
             # Define regular indexes
             indexes = [
-                Index("idx_name", "name"),
+                Index("idx_user_name", "user_id", "name"),
             ]
 
             # Map index_type string to VecIndexType enum
@@ -376,6 +400,15 @@ class MemoryGraph(GraphStoreBase):
             logger.info("%s table created successfully", constants.TABLE_RELATIONSHIPS)
         else:
             logger.info("%s table already exists", constants.TABLE_RELATIONSHIPS)
+
+    def _entities_table_has_user_id(self) -> Optional[bool]:
+        """Return whether the existing graph entity table is user-scoped."""
+        try:
+            table = Table(constants.TABLE_ENTITIES, self.metadata, autoload_with=self.engine)
+            return "user_id" in table.c
+        except Exception as exc:
+            logger.warning("Unable to inspect %s schema: %s", constants.TABLE_ENTITIES, exc)
+            return None
 
     def _get_existing_vector_dimension_for_entities(self) -> Optional[int]:
         """Get the dimension of the existing vector field in entities table.
@@ -1061,23 +1094,29 @@ class MemoryGraph(GraphStoreBase):
             destination = item["destination"]
             relationship = item["relationship"]
 
-            # First, find the source and destination entities by name
+            # First, find the source and destination entities by name for this user.
             source_entities = self.client.get(
                 table_name=constants.TABLE_ENTITIES,
                 ids=None,
                 output_column_name=["id", "name"],
-                where_clause=[text(f"name = :source_name").bindparams(
-                    bindparam("source_name", source)
-                )]
+                where_clause=[
+                    text("name = :source_name AND user_id = :user_id").bindparams(
+                        bindparam("source_name", source),
+                        bindparam("user_id", filters["user_id"]),
+                    )
+                ]
             )
 
             dest_entities = self.client.get(
                 table_name=constants.TABLE_ENTITIES,
                 ids=None,
                 output_column_name=["id", "name"],
-                where_clause=[text(f"name = :dest_name").bindparams(
-                    bindparam("dest_name", destination)
-                )]
+                where_clause=[
+                    text("name = :dest_name AND user_id = :user_id").bindparams(
+                        bindparam("dest_name", destination),
+                        bindparam("user_id", filters["user_id"]),
+                    )
+                ]
             )
 
             # Get entity IDs
@@ -1237,6 +1276,10 @@ class MemoryGraph(GraphStoreBase):
         vec_str = "[" + ",".join([str(np.float32(v)) for v in embedding]) + "]"
         distance_expr = l2_distance(table.c.embedding, vec_str)
         where_clause = [distance_expr < threshold]
+        user_id = filters.get("user_id") if filters else None
+        if user_id is None:
+            raise ValueError("user_id is required for graph entity search")
+        where_clause.append(table.c.user_id == user_id)
 
         results = self.client.ann_search(
             table_name=constants.TABLE_ENTITIES,
@@ -1288,6 +1331,7 @@ class MemoryGraph(GraphStoreBase):
         record = {
             "id": entity_id,
             "name": name,
+            "user_id": filters["user_id"],
             "entity_type": entity_type,
             "embedding": embedding,
             "created_at": current_time,

--- a/tests/unit/test_oceanbase_graph.py
+++ b/tests/unit/test_oceanbase_graph.py
@@ -102,6 +102,29 @@ class TestOceanBaseGraph(unittest.TestCase):
         self.assertEqual(self.memory_graph.max_hops, 3)
         self.assertEqual(self.memory_graph.client, self.mock_client)
 
+    def test_entities_table_schema_is_user_scoped(self):
+        """Test graph entity table schema includes user isolation."""
+        first_call = self.mock_client.create_table_with_index_params.call_args_list[0]
+        kwargs = first_call.kwargs
+
+        self.assertEqual(kwargs["table_name"], constants.TABLE_ENTITIES)
+        self.assertIn("user_id", [column.name for column in kwargs["columns"]])
+        self.assertIn("idx_user_name", [index.name for index in kwargs["indexes"]])
+
+    def test_recreates_legacy_entities_table_without_user_id(self):
+        """Test legacy unscoped graph tables are recreated for user isolation."""
+        self.mock_client.reset_mock()
+        self.mock_client.check_table_exists.side_effect = [True, True, False]
+        self.memory_graph._entities_table_has_user_id = MagicMock(return_value=False)
+
+        self.memory_graph._create_tables()
+
+        self.mock_client.drop_table_if_exist.assert_any_call(constants.TABLE_RELATIONSHIPS)
+        self.mock_client.drop_table_if_exist.assert_any_call(constants.TABLE_ENTITIES)
+        create_calls = self.mock_client.create_table_with_index_params.call_args_list
+        self.assertEqual(create_calls[0].kwargs["table_name"], constants.TABLE_ENTITIES)
+        self.assertEqual(create_calls[1].kwargs["table_name"], constants.TABLE_RELATIONSHIPS)
+
     def test_init_without_embedding_dims(self):
         """Test initialization fails without embedding_model_dims."""
         # Create a mock config without embedding_model_dims
@@ -362,6 +385,8 @@ class TestOceanBaseGraph(unittest.TestCase):
 
             # Verify the method calls
             self.mock_client.ann_search.assert_called_once()
+            where_clause = self.mock_client.ann_search.call_args.kwargs["where_clause"]
+            self.assertEqual(len(where_clause), 2)
 
             # Check the result
             self.assertEqual(len(result), 2)
@@ -448,10 +473,36 @@ class TestOceanBaseGraph(unittest.TestCase):
 
         # Verify the method calls
         self.mock_client.upsert.assert_called_once()
+        inserted_record = self.mock_client.upsert.call_args.kwargs["data"][0]
+        self.assertEqual(inserted_record["user_id"], self.user_id)
 
         # Check the result is a Snowflake ID (int)
         self.assertIsInstance(result, int)
         self.assertGreater(result, 0)  # Snowflake ID should be positive
+
+    def test_delete_entities_scopes_entity_name_lookup_by_user(self):
+        """Test relationship deletion looks up entities only for the current user."""
+        to_be_deleted = [{
+            "source": "alice",
+            "relationship": "knows",
+            "destination": "bob",
+        }]
+        source_result = MagicMock()
+        source_result.fetchall.return_value = [(641905209349505024, "alice")]
+        dest_result = MagicMock()
+        dest_result.fetchall.return_value = [(641905209349505025, "bob")]
+        delete_result = MagicMock()
+        delete_result.rowcount = 1
+        self.mock_client.get.side_effect = [source_result, dest_result]
+        self.mock_client.delete.return_value = delete_result
+
+        result = self.memory_graph._delete_entities(to_be_deleted, self.test_filters)
+
+        self.assertEqual(result, [{"deleted_count": 1}])
+        source_where = self.mock_client.get.call_args_list[0].kwargs["where_clause"][0]
+        dest_where = self.mock_client.get.call_args_list[1].kwargs["where_clause"][0]
+        self.assertIn("user_id = :user_id", str(source_where))
+        self.assertIn("user_id = :user_id", str(dest_where))
 
     def test_create_or_update_relationship_new(self):
         """Test the _create_or_update_relationship method for new relationship."""


### PR DESCRIPTION
## Summary

Closes #1002.

This PR scopes OceanBase graph entities by `user_id` so graph entity deduplication and seed discovery no longer reuse nodes across users.

Changes:
- adds `user_id` to `graph_entities` and indexes `(user_id, name)`
- writes `user_id` when creating graph entities
- filters graph entity vector search by `user_id`
- filters entity name lookups used by relationship deletion by `user_id`
- recreates legacy unscoped graph tables when an existing `graph_entities` table lacks `user_id`
- avoids dropping tables if schema inspection fails; startup raises instead
- adds unit coverage for schema creation, legacy migration, entity creation, search scoping, and deletion lookup scoping

## Validation

- `python -m pytest tests/unit/test_oceanbase_graph.py -q`
- `python -m pytest tests/unit -q`
- `python -m flake8 src/powermem/storage/oceanbase/oceanbase_graph.py tests/unit/test_oceanbase_graph.py --select=F601,F821,E999`
- `git diff --check`