### PR TITLE
fix: clean up graph search tools and results

### DIFF
--- a/src/powermem/prompts/graph/graph_tools_prompts.py
+++ b/src/powermem/prompts/graph/graph_tools_prompts.py
@@ -313,7 +313,7 @@ NOOP_STRUCT_TOOL = {
 RELATIONS_STRUCT_TOOL = {
     "type": "function",
     "function": {
-        "name": "establish_relations",
+        "name": "establish_relationships",
         "description": "Establish relationships among the entities based on the provided text.",
         "strict": True,
         "parameters": {

--- a/src/powermem/storage/oceanbase/oceanbase_graph.py
+++ b/src/powermem/storage/oceanbase/oceanbase_graph.py
@@ -503,9 +503,10 @@ class MemoryGraph(GraphStoreBase):
             if idx < len(search_output):
                 item = search_output[idx]
                 search_results.append({
-                    "source": item["source"], 
-                    "relationship": item["relationship"], 
-                    "destination": item["destination"]
+                    "source": item["source"],
+                    "relationship": item["relationship"],
+                    "destination": item["destination"],
+                    "score": float(scores[idx]),
                 })
 
         logger.info("Returned %d search results (from %d candidates)", len(search_results), len(search_output))
@@ -652,9 +653,16 @@ class MemoryGraph(GraphStoreBase):
         Returns:
             Dictionary mapping entity names to entity types.
         """
-        _tools = [self.graph_tools_prompts.get_extract_entities_tool()]
         if constants.is_structured_llm_provider(self.llm_provider):
-            _tools = [self.graph_tools_prompts.get_extract_entities_tool(structured=True)]
+            _tools = [
+                self.graph_tools_prompts.get_extract_entities_tool(structured=True),
+                self.graph_tools_prompts.get_noop_tool(structured=True),
+            ]
+        else:
+            _tools = [
+                self.graph_tools_prompts.get_extract_entities_tool(),
+                self.graph_tools_prompts.get_noop_tool(),
+            ]
 
         search_results = self.llm.generate_response(
             messages=[
@@ -736,9 +744,16 @@ class MemoryGraph(GraphStoreBase):
                 },
             ]
 
-        _tools = [self.graph_tools_prompts.get_relations_tool()]
         if constants.is_structured_llm_provider(self.llm_provider):
-            _tools = [self.graph_tools_prompts.get_relations_tool(structured=True)]
+            _tools = [
+                self.graph_tools_prompts.get_relations_tool(structured=True),
+                self.graph_tools_prompts.get_noop_tool(structured=True),
+            ]
+        else:
+            _tools = [
+                self.graph_tools_prompts.get_relations_tool(),
+                self.graph_tools_prompts.get_noop_tool(),
+            ]
 
         extracted_entities = self.llm.generate_response(
             messages=messages,
@@ -781,6 +796,7 @@ class MemoryGraph(GraphStoreBase):
             List of dictionaries containing source, relationship, destination and their IDs.
         """
         result_relations = []
+        seen_relations = set()
 
         for node in node_list:
             n_embedding = self.embedding_model.embed(node)
@@ -798,7 +814,16 @@ class MemoryGraph(GraphStoreBase):
 
             # Use multi-hop search with early stopping
             multi_hop_results = self._multi_hop_search(entity_ids, filters, limit)
-            result_relations.extend(multi_hop_results)
+            for relation in multi_hop_results:
+                relation_key = (
+                    relation.get("source"),
+                    relation.get("relationship"),
+                    relation.get("destination"),
+                )
+                if relation_key in seen_relations:
+                    continue
+                seen_relations.add(relation_key)
+                result_relations.append(relation)
 
         return result_relations
 

--- a/tests/unit/test_oceanbase_graph.py
+++ b/tests/unit/test_oceanbase_graph.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch, Mock
 import pytest
 import uuid
+from powermem.prompts.graph.graph_tools_prompts import GraphToolsPrompts
 from powermem.storage.oceanbase.oceanbase_graph import MemoryGraph
 from powermem.storage.oceanbase import constants
 
@@ -186,6 +187,16 @@ class TestOceanBaseGraph(unittest.TestCase):
         result = self.memory_graph._coerce_tool_response_to_dict(response_invalid)
         self.assertEqual(result, {})
 
+    def test_structured_relations_tool_name_matches_regular_tool(self):
+        """Test structured relation extraction uses the expected tool name."""
+        prompts = GraphToolsPrompts()
+
+        regular_name = prompts.get_relations_tool()["function"]["name"]
+        structured_name = prompts.get_relations_tool(structured=True)["function"]["name"]
+
+        self.assertEqual(regular_name, "establish_relationships")
+        self.assertEqual(structured_name, regular_name)
+
     def test_add_method(self):
         """Test the add method with mocked components."""
         # Mock the necessary methods that add() calls
@@ -248,6 +259,7 @@ class TestOceanBaseGraph(unittest.TestCase):
             self.assertEqual(result[0]["source"], "alice")
             self.assertEqual(result[0]["relationship"], "knows")
             self.assertEqual(result[0]["destination"], "bob")
+            self.assertEqual(result[0]["score"], 0.8)
 
     def test_search_method_empty_results(self):
         """Test the search method with empty results."""
@@ -260,6 +272,69 @@ class TestOceanBaseGraph(unittest.TestCase):
 
         # Check the result
         self.assertEqual(result, [])
+
+    def test_search_graph_db_deduplicates_relations_across_seed_nodes(self):
+        """Test graph search removes duplicate triples from overlapping seeds."""
+        self.mock_embedding_model.embed.side_effect = [[0.1], [0.2]]
+        self.memory_graph._search_node = MagicMock(side_effect=[
+            [{"id": "entity1"}],
+            [{"id": "entity2"}],
+        ])
+        duplicate_relation = {
+            "source": "alice",
+            "relationship": "knows",
+            "destination": "bob",
+        }
+        self.memory_graph._multi_hop_search = MagicMock(side_effect=[
+            [duplicate_relation],
+            [dict(duplicate_relation)],
+        ])
+
+        result = self.memory_graph._search_graph_db(
+            node_list=["alice", "bob"],
+            filters=self.test_filters,
+        )
+
+        self.assertEqual(result, [duplicate_relation])
+
+    def test_retrieve_nodes_includes_noop_tool(self):
+        """Test entity extraction provides noop as an opt-out tool."""
+        extract_tool = {"function": {"name": "extract_entities"}}
+        noop_tool = {"function": {"name": "noop"}}
+        self.mock_graph_tools_prompts.get_extract_entities_tool.return_value = extract_tool
+        self.mock_graph_tools_prompts.get_noop_tool.return_value = noop_tool
+        self.mock_llm.generate_response.return_value = {"tool_calls": []}
+
+        self.memory_graph._retrieve_nodes_from_data("No memory here", self.test_filters)
+
+        self.mock_graph_tools_prompts.get_extract_entities_tool.assert_called_once_with(structured=True)
+        self.mock_graph_tools_prompts.get_noop_tool.assert_called_once_with(structured=True)
+        self.assertEqual(
+            self.mock_llm.generate_response.call_args.kwargs["tools"],
+            [extract_tool, noop_tool],
+        )
+
+    def test_establish_relations_includes_noop_tool(self):
+        """Test relation extraction provides noop as an opt-out tool."""
+        relations_tool = {"function": {"name": "establish_relationships"}}
+        noop_tool = {"function": {"name": "noop"}}
+        self.mock_graph_tools_prompts.get_relations_tool.return_value = relations_tool
+        self.mock_graph_tools_prompts.get_noop_tool.return_value = noop_tool
+        self.mock_llm.generate_response.return_value = {"tool_calls": []}
+
+        result = self.memory_graph._establish_nodes_relations_from_data(
+            "Alice knows Bob",
+            self.test_filters,
+            {"alice": "person", "bob": "person"},
+        )
+
+        self.assertEqual(result, [])
+        self.mock_graph_tools_prompts.get_relations_tool.assert_called_once_with(structured=True)
+        self.mock_graph_tools_prompts.get_noop_tool.assert_called_once_with(structured=True)
+        self.assertEqual(
+            self.mock_llm.generate_response.call_args.kwargs["tools"],
+            [relations_tool, noop_tool],
+        )
 
     def test_get_all_method(self):
         """Test the get_all method."""


### PR DESCRIPTION
## Summary

Closes #1004.

This PR fixes the graph search/tool issues reported in #1004.

Changes:
- aligns the structured relations tool name with the regular `establish_relationships` tool name
- passes `noop` alongside entity extraction and relation extraction tools so the LLM can opt out
- deduplicates graph search triples across overlapping seed-node traversals
- includes the BM25 rerank score in returned graph search results
- adds unit coverage for the tool name, noop tools, duplicate removal, and score exposure

## Validation

- `python -m pytest tests/unit/test_oceanbase_graph.py -q`
- `python -m pytest tests/unit -q`
- `python -m flake8 src/powermem/storage/oceanbase/oceanbase_graph.py src/powermem/prompts/graph/graph_tools_prompts.py tests/unit/test_oceanbase_graph.py --select=F601,F821,E999`
- `git diff --check`