### PR TITLE
docs: add AgentScope MCP integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ PowerMem ships first-party plugins and setup guides for the most common AI clien
 |-----------------|---------|
 | Python SDK | `pip install powermem`, see [Quick start](#quick-start-python-sdk) |
 | LangChain / LangGraph | `pip install powermem`, see [LangChain guide](docs/integrations/langchain.md) |
-| AgentScope | Register `powermem-mcp` tools in an AgentScope `Toolkit`, see [AgentScope guide](docs/integrations/agentscope.md) |
+| AgentScope | Connect to `powermem-mcp` with AgentScope's MCP client, see [AgentScope guide](docs/integrations/agentscope.md) |
 | Go apps | [SDKs](#sdks) |
 | Java apps | [SDKs](#sdks) |
 | TypeScript apps | [SDKs](#sdks) |
@@ -184,9 +184,9 @@ Full framework guide: [LangChain and LangGraph integration](docs/integrations/la
 
 ### AgentScope
 
-PowerMem works with AgentScope through MCP. Start `powermem-mcp`, then register
-the PowerMem MCP client into an AgentScope `Toolkit` so AgentScope agents can use
-`add_memory`, `search_memories`, and the other memory tools.
+PowerMem works with AgentScope through MCP. Start `powermem-mcp`, then connect
+to it with AgentScope's MCP client so AgentScope workflows can use `add_memory`,
+`search_memories`, and the other memory tools.
 
 Full framework guide: [AgentScope integration](docs/integrations/agentscope.md).
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ PowerMem ships first-party plugins and setup guides for the most common AI clien
 |-----------------|---------|
 | Python SDK | `pip install powermem`, see [Quick start](#quick-start-python-sdk) |
 | LangChain / LangGraph | `pip install powermem`, see [LangChain guide](docs/integrations/langchain.md) |
+| AgentScope | Register `powermem-mcp` tools in an AgentScope `Toolkit`, see [AgentScope guide](docs/integrations/agentscope.md) |
 | Go apps | [SDKs](#sdks) |
 | Java apps | [SDKs](#sdks) |
 | TypeScript apps | [SDKs](#sdks) |
@@ -180,6 +181,14 @@ End-to-end runnable demos:
 - [LangGraph customer service bot](examples/langgraph/README.md)
 
 Full framework guide: [LangChain and LangGraph integration](docs/integrations/langchain.md).
+
+### AgentScope
+
+PowerMem works with AgentScope through MCP. Start `powermem-mcp`, then register
+the PowerMem MCP client into an AgentScope `Toolkit` so AgentScope agents can use
+`add_memory`, `search_memories`, and the other memory tools.
+
+Full framework guide: [AgentScope integration](docs/integrations/agentscope.md).
 
 ### SDKs
 

--- a/docs/integrations/agentscope.md
+++ b/docs/integrations/agentscope.md
@@ -1,0 +1,142 @@
+# AgentScope
+
+Use PowerMem as a long-term memory tool provider for AgentScope agents through
+AgentScope's MCP client support. This keeps the integration lightweight:
+PowerMem owns memory storage and retrieval, while AgentScope registers the
+PowerMem MCP tools into its `Toolkit`.
+
+AgentScope supports HTTP and stdio MCP servers, stateful and stateless MCP
+clients, and registering MCP tools into `Toolkit`. PowerMem exposes the same
+memory tools through `powermem-mcp`, so no AgentScope-specific storage adapter is
+required.
+
+## Prerequisites
+
+- PowerMem installed with MCP support:
+
+```bash
+pip install "powermem[mcp]"
+```
+
+- PowerMem configured with your storage, LLM, and embedding providers.
+- AgentScope installed in the application environment.
+
+## Start PowerMem MCP
+
+Use streamable HTTP for a long-running local or remote AgentScope process:
+
+```bash
+powermem-mcp streamable-http 8848
+```
+
+PowerMem serves MCP at:
+
+```text
+http://localhost:8848/mcp
+```
+
+If your AgentScope process should launch PowerMem itself, stdio is also
+available:
+
+```bash
+powermem-mcp stdio
+```
+
+## Register PowerMem tools in AgentScope
+
+```python
+import asyncio
+
+from agentscope.mcp import HttpStatelessClient
+from agentscope.tool import Toolkit
+
+
+async def build_toolkit() -> Toolkit:
+    toolkit = Toolkit()
+    powermem = HttpStatelessClient(
+        name="powermem",
+        transport="streamable_http",
+        url="http://localhost:8848/mcp",
+    )
+
+    await toolkit.register_mcp_client(powermem, group_name="memory")
+    return toolkit
+
+
+toolkit = asyncio.run(build_toolkit())
+print([tool["function"]["name"] for tool in toolkit.get_json_schemas()])
+```
+
+The registered tools include the standard PowerMem MCP memory operations:
+
+- `add_memory`
+- `search_memories`
+- `get_memory_by_id`
+- `update_memory`
+- `delete_memory`
+- `delete_all_memories`
+- `list_memories`
+
+Pass the resulting `toolkit` to the AgentScope agent or workflow that should be
+able to remember and recall information.
+
+## Function-level calls
+
+AgentScope can also obtain a single callable MCP tool by name. This is useful
+when a workflow wants explicit memory read/write steps instead of registering all
+tools.
+
+```python
+import asyncio
+
+from agentscope.mcp import HttpStatelessClient
+
+
+async def search_powermem() -> None:
+    powermem = HttpStatelessClient(
+        name="powermem",
+        transport="streamable_http",
+        url="http://localhost:8848/mcp",
+    )
+
+    search_memories = await powermem.get_callable_function(
+        func_name="search_memories",
+        wrap_tool_result=True,
+    )
+
+    result = await search_memories(
+        query="dragonfruit-zx9",
+        user_id="agentscope-demo-user",
+        limit=5,
+    )
+    print(result)
+
+
+asyncio.run(search_powermem())
+```
+
+## Verify
+
+1. Start `powermem-mcp streamable-http 8848`.
+2. Run the AgentScope snippet above.
+3. Confirm `search_memories` and `add_memory` appear in
+   `toolkit.get_json_schemas()`.
+4. Add a probe memory with `add_memory` and search for the same token with
+   `search_memories`.
+
+## Troubleshooting
+
+- If AgentScope cannot list tools, confirm `http://localhost:8848/mcp` matches
+  the PowerMem MCP transport and port.
+- If memory calls fail, validate the PowerMem `.env` first. The MCP server
+  depends on the same storage, LLM, and embedding configuration as the Python SDK.
+- If the AgentScope process runs in a different shell or container, pass the same
+  PowerMem environment variables there, including `POWERMEM_API_KEY` when auth is
+  enabled.
+- Use the generic [MCP client guide](./mcp_client.md) for stdio, SSE, and auth
+  variations.
+
+## References
+
+- AgentScope MCP tutorial: https://doc.agentscope.io/tutorial/task_mcp.html
+- PowerMem MCP guide: ./mcp_client.md

--- a/docs/integrations/agentscope.md
+++ b/docs/integrations/agentscope.md
@@ -2,13 +2,12 @@
 
 Use PowerMem as a long-term memory tool provider for AgentScope agents through
 AgentScope's MCP client support. This keeps the integration lightweight:
-PowerMem owns memory storage and retrieval, while AgentScope registers the
-PowerMem MCP tools into its `Toolkit`.
+PowerMem owns memory storage and retrieval, while AgentScope discovers and calls
+PowerMem MCP tools through its MCP client.
 
 AgentScope supports HTTP and stdio MCP servers, stateful and stateless MCP
-clients, and registering MCP tools into `Toolkit`. PowerMem exposes the same
-memory tools through `powermem-mcp`, so no AgentScope-specific storage adapter is
-required.
+clients. PowerMem exposes the same memory tools through `powermem-mcp`, so no
+AgentScope-specific storage adapter is required.
 
 ## Prerequisites
 
@@ -42,32 +41,29 @@ available:
 powermem-mcp stdio
 ```
 
-## Register PowerMem tools in AgentScope
+## Connect PowerMem tools in AgentScope
 
 ```python
 import asyncio
 
-from agentscope.mcp import HttpStatelessClient
-from agentscope.tool import Toolkit
+from agentscope.mcp import HttpMCPConfig, MCPClient
 
 
-async def build_toolkit() -> Toolkit:
-    toolkit = Toolkit()
-    powermem = HttpStatelessClient(
+async def list_powermem_tools() -> None:
+    powermem = MCPClient(
         name="powermem",
-        transport="streamable_http",
-        url="http://localhost:8848/mcp",
+        is_stateful=False,
+        mcp_config=HttpMCPConfig(url="http://localhost:8848/mcp"),
     )
 
-    await toolkit.register_mcp_client(powermem, group_name="memory")
-    return toolkit
+    tools = await powermem.list_tools()
+    print([tool.name for tool in tools])
 
 
-toolkit = asyncio.run(build_toolkit())
-print([tool["function"]["name"] for tool in toolkit.get_json_schemas()])
+asyncio.run(list_powermem_tools())
 ```
 
-The registered tools include the standard PowerMem MCP memory operations:
+The discovered tools include the standard PowerMem MCP memory operations:
 
 - `add_memory`
 - `search_memories`
@@ -77,32 +73,29 @@ The registered tools include the standard PowerMem MCP memory operations:
 - `delete_all_memories`
 - `list_memories`
 
-Pass the resulting `toolkit` to the AgentScope agent or workflow that should be
-able to remember and recall information.
+AgentScope wraps MCP tools with a model-facing name such as
+`mcp__powermem__search_memories`; use the original PowerMem tool name when
+calling `get_tool()`.
 
 ## Function-level calls
 
-AgentScope can also obtain a single callable MCP tool by name. This is useful
-when a workflow wants explicit memory read/write steps instead of registering all
-tools.
+AgentScope can obtain a single callable MCP tool by name. This is useful when a
+workflow wants explicit memory read/write steps.
 
 ```python
 import asyncio
 
-from agentscope.mcp import HttpStatelessClient
+from agentscope.mcp import HttpMCPConfig, MCPClient
 
 
 async def search_powermem() -> None:
-    powermem = HttpStatelessClient(
+    powermem = MCPClient(
         name="powermem",
-        transport="streamable_http",
-        url="http://localhost:8848/mcp",
+        is_stateful=False,
+        mcp_config=HttpMCPConfig(url="http://localhost:8848/mcp"),
     )
 
-    search_memories = await powermem.get_callable_function(
-        func_name="search_memories",
-        wrap_tool_result=True,
-    )
+    search_memories = await powermem.get_tool("search_memories")
 
     result = await search_memories(
         query="dragonfruit-zx9",
@@ -120,7 +113,7 @@ asyncio.run(search_powermem())
 1. Start `powermem-mcp streamable-http 8848`.
 2. Run the AgentScope snippet above.
 3. Confirm `search_memories` and `add_memory` appear in
-   `toolkit.get_json_schemas()`.
+   the tool names printed by `list_tools()`.
 4. Add a probe memory with `add_memory` and search for the same token with
    `search_memories`.
 

--- a/docs/integrations/overview.md
+++ b/docs/integrations/overview.md
@@ -28,6 +28,8 @@ the local `pmem` CLI) — there are no per-client schema rewrites.
 
 - **[LangChain and LangGraph](./langchain.md)** — Persistent memory patterns
   for LCEL chains and LangGraph workflows.
+- **[AgentScope](./agentscope.md)** — Register PowerMem MCP tools into an
+  AgentScope `Toolkit` for long-term memory in AgentScope agents.
 
 For FastAPI and custom LLM / embedding / storage providers, see the
 **[Integrations Guide](../guides/0009-integrations.md)**.

--- a/docs/integrations/overview.md
+++ b/docs/integrations/overview.md
@@ -28,8 +28,8 @@ the local `pmem` CLI) — there are no per-client schema rewrites.
 
 - **[LangChain and LangGraph](./langchain.md)** — Persistent memory patterns
   for LCEL chains and LangGraph workflows.
-- **[AgentScope](./agentscope.md)** — Register PowerMem MCP tools into an
-  AgentScope `Toolkit` for long-term memory in AgentScope agents.
+- **[AgentScope](./agentscope.md)** — Connect to PowerMem MCP tools from
+  AgentScope workflows for long-term memory.
 
 For FastAPI and custom LLM / embedding / storage providers, see the
 **[Integrations Guide](../guides/0009-integrations.md)**.


### PR DESCRIPTION
## Summary

Closes #111.

- Add an AgentScope integration guide that connects PowerMem through `powermem-mcp` streamable HTTP.
- Show how to register PowerMem MCP tools into an AgentScope `Toolkit`.
- Add function-level `search_memories` usage and verification/troubleshooting notes.
- Link the guide from the README integration table and integrations overview.

## Validation

- `git diff --cached --check`
- `pnpm run build` from `docs/website`
