### PR TITLE
feat(api): filter listed memories by scope

### DIFF
--- a/docs/api/0005-api_server.md
+++ b/docs/api/0005-api_server.md
@@ -540,6 +540,7 @@ curl -X POST "http://localhost:8848/api/v1/memories/batch" \
 **Query Parameters**:
 - `user_id` (optional): Filter by user ID
 - `agent_id` (optional): Filter by agent ID
+- `scope` (optional): Filter by metadata scope, such as personal or group memory
 - `limit` (optional, default: 100): Maximum number of results (1-1000)
 - `offset` (optional, default: 0): Number of results to skip
 - `sort_by` (optional): Field to sort by. Options: `created_at`, `updated_at`, `id`. If not specified, results are returned in their original order
@@ -558,6 +559,10 @@ curl -X GET "http://localhost:8848/api/v1/memories?user_id=user-123&limit=20&off
 
 # Filter by agent
 curl -X GET "http://localhost:8848/api/v1/memories?agent_id=agent-456&limit=50&offset=0" \
+  -H "X-API-Key: test-api-key-123"
+
+# Filter by metadata scope
+curl -X GET "http://localhost:8848/api/v1/memories?user_id=user-123&agent_id=agent-456&scope=personal&limit=20&offset=0" \
   -H "X-API-Key: test-api-key-123"
 
 # Sort by updated_at (descending - most recent first)

--- a/src/powermem/core/async_memory.py
+++ b/src/powermem/core/async_memory.py
@@ -1382,7 +1382,6 @@ class AsyncMemory(MemoryBase):
             if self.enable_graph:
                 filters = {**(filters or {}), "user_id": user_id, "agent_id": agent_id, "run_id": run_id}
                 graph_results = await asyncio.to_thread(self.graph_store.get_all, filters, limit + offset)
-                results.extend(graph_results)
                 return {"results": results, "relations": graph_results}
 
             return {"results": results}

--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -2180,7 +2180,6 @@ class Memory(MemoryBase):
             if self.enable_graph:
                 filters = {**(filters or {}), "user_id": user_id, "agent_id": agent_id, "run_id": run_id}
                 graph_results = self.graph_store.get_all(filters, limit + offset)
-                results.extend(graph_results)
                 return {"results": results, "relations": graph_results}
 
             return {"results": results}

--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -2209,7 +2209,7 @@ class Memory(MemoryBase):
         """
         try:
             count = self.storage.count_all_memories(
-                user_id, agent_id, run_id
+                user_id, agent_id, run_id, filters=filters
             )
             
             self.audit.log_event("memory.count_all", {

--- a/src/powermem/storage/adapter.py
+++ b/src/powermem/storage/adapter.py
@@ -478,7 +478,10 @@ class StorageAdapter:
         filters: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """Get all memories with optional filtering and sorting."""
-        # Build filters for database-level filtering (only scope keys; backends use payload top-level)
+        # Build database-level filters only for scope keys shared by all
+        # backends. Extra metadata filters are applied before pagination below;
+        # SQLite stores user metadata under payload.metadata while OceanBase
+        # stores it as the metadata JSON column.
         db_filters: Dict[str, Any] = {}
         if user_id:
             db_filters["user_id"] = user_id
@@ -486,11 +489,19 @@ class StorageAdapter:
             db_filters["agent_id"] = agent_id
         if run_id:
             db_filters["run_id"] = run_id
-        # Pass only scope to DB; extra filters (e.g. metadata.name) applied in-memory below
+        if filters:
+            for key in ("user_id", "agent_id", "run_id"):
+                if key in filters and key not in db_filters:
+                    db_filters[key] = filters[key]
+        has_extra_filters = any(
+            key not in ("user_id", "agent_id", "run_id")
+            for key in (filters or {})
+        )
+
         results = self.vector_store.list(
             filters=db_filters if db_filters else None,
-            limit=limit,
-            offset=offset,
+            limit=None if has_extra_filters else limit,
+            offset=0 if has_extra_filters else offset,
             order_by=sort_by,
             order=order
         )
@@ -566,7 +577,10 @@ class StorageAdapter:
                 continue  # one extra filter did not match, skip this memory
             
             memories.append(memory)
-        
+
+        if has_extra_filters:
+            memories = memories[offset:offset + limit]
+
         return memories
 
     def count_all_memories(
@@ -585,9 +599,28 @@ class StorageAdapter:
         if run_id:
             db_filters["run_id"] = run_id
         if filters:
-            db_filters.update(filters)
+            for key in ("user_id", "agent_id", "run_id"):
+                if key in filters and key not in db_filters:
+                    db_filters[key] = filters[key]
+        has_extra_filters = any(
+            key not in ("user_id", "agent_id", "run_id")
+            for key in (filters or {})
+        )
 
         try:
+            if has_extra_filters:
+                unbounded_limit = 1_000_000_000
+                return len(
+                    self.get_all_memories(
+                        user_id=user_id,
+                        agent_id=agent_id,
+                        run_id=run_id,
+                        limit=unbounded_limit,
+                        offset=0,
+                        filters=filters,
+                    )
+                )
+
             if hasattr(self.vector_store, "count"):
                 try:
                     return int(self.vector_store.count(filters=db_filters or None))

--- a/src/powermem/storage/adapter.py
+++ b/src/powermem/storage/adapter.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 class StorageAdapter:
     """Adapter that bridges VectorStoreBase interface with Memory class expectations."""
+
+    _SYSTEM_FILTER_KEYS = {"user_id", "agent_id", "run_id"}
     
     def __init__(self, vector_store: VectorStoreBase, embedding_service=None, sparse_embedder_service=None):
         """Initialize the adapter with a vector store and embedding service."""
@@ -53,6 +55,40 @@ class StorageAdapter:
         except Exception as e:
             logger.warning(f"Failed to generate sparse embedding ({memory_action}): {e}")
             return None
+
+    def _metadata_filter_key_for_store(self, key: str) -> str:
+        """Translate logical metadata filters to backend-specific payload paths."""
+        store_module = self.vector_store.__class__.__module__
+        if (
+            store_module.endswith("sqlite.sqlite_vector_store")
+            or ".pgvector." in store_module
+        ):
+            return f"metadata.{key}"
+        return key
+
+    def _build_db_filters(
+        self,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Build filters that can be executed by the vector store."""
+        db_filters: Dict[str, Any] = {}
+        if user_id:
+            db_filters["user_id"] = user_id
+        if agent_id:
+            db_filters["agent_id"] = agent_id
+        if run_id:
+            db_filters["run_id"] = run_id
+        if filters:
+            for key, value in filters.items():
+                if key in self._SYSTEM_FILTER_KEYS:
+                    if key not in db_filters:
+                        db_filters[key] = value
+                else:
+                    db_filters[self._metadata_filter_key_for_store(key)] = value
+        return db_filters
 
     def add_memory(self, memory_data: Dict[str, Any]) -> int:
         """Add a memory to the store."""
@@ -478,30 +514,12 @@ class StorageAdapter:
         filters: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """Get all memories with optional filtering and sorting."""
-        # Build database-level filters only for scope keys shared by all
-        # backends. Extra metadata filters are applied before pagination below;
-        # SQLite stores user metadata under payload.metadata while OceanBase
-        # stores it as the metadata JSON column.
-        db_filters: Dict[str, Any] = {}
-        if user_id:
-            db_filters["user_id"] = user_id
-        if agent_id:
-            db_filters["agent_id"] = agent_id
-        if run_id:
-            db_filters["run_id"] = run_id
-        if filters:
-            for key in ("user_id", "agent_id", "run_id"):
-                if key in filters and key not in db_filters:
-                    db_filters[key] = filters[key]
-        has_extra_filters = any(
-            key not in ("user_id", "agent_id", "run_id")
-            for key in (filters or {})
-        )
+        db_filters = self._build_db_filters(user_id, agent_id, run_id, filters)
 
         results = self.vector_store.list(
             filters=db_filters if db_filters else None,
-            limit=None if has_extra_filters else limit,
-            offset=0 if has_extra_filters else offset,
+            limit=limit,
+            offset=offset,
             order_by=sort_by,
             order=order
         )
@@ -578,9 +596,6 @@ class StorageAdapter:
             
             memories.append(memory)
 
-        if has_extra_filters:
-            memories = memories[offset:offset + limit]
-
         return memories
 
     def count_all_memories(
@@ -591,36 +606,9 @@ class StorageAdapter:
         filters: Optional[Dict[str, Any]] = None,
     ) -> int:
         """Count all memories with optional filtering."""
-        db_filters: Dict[str, Any] = {}
-        if user_id:
-            db_filters["user_id"] = user_id
-        if agent_id:
-            db_filters["agent_id"] = agent_id
-        if run_id:
-            db_filters["run_id"] = run_id
-        if filters:
-            for key in ("user_id", "agent_id", "run_id"):
-                if key in filters and key not in db_filters:
-                    db_filters[key] = filters[key]
-        has_extra_filters = any(
-            key not in ("user_id", "agent_id", "run_id")
-            for key in (filters or {})
-        )
+        db_filters = self._build_db_filters(user_id, agent_id, run_id, filters)
 
         try:
-            if has_extra_filters:
-                unbounded_limit = 1_000_000_000
-                return len(
-                    self.get_all_memories(
-                        user_id=user_id,
-                        agent_id=agent_id,
-                        run_id=run_id,
-                        limit=unbounded_limit,
-                        offset=0,
-                        filters=filters,
-                    )
-                )
-
             if hasattr(self.vector_store, "count"):
                 try:
                     return int(self.vector_store.count(filters=db_filters or None))

--- a/src/powermem/storage/pgvector/pgvector.py
+++ b/src/powermem/storage/pgvector/pgvector.py
@@ -253,7 +253,12 @@ class PGVectorStore(VectorStoreBase):
 
         if filters:
             for k, v in filters.items():
-                filter_conditions.append("payload->>%s = %s")
+                if "." in k:
+                    filter_conditions.append(
+                        "payload #>> string_to_array(%s, '.') = %s"
+                    )
+                else:
+                    filter_conditions.append("payload->>%s = %s")
                 filter_params.extend([k, str(v)])
 
         filter_clause = "WHERE " + " AND ".join(filter_conditions) if filter_conditions else ""
@@ -403,7 +408,12 @@ class PGVectorStore(VectorStoreBase):
 
         if filters:
             for k, v in filters.items():
-                filter_conditions.append("payload->>%s = %s")
+                if "." in k:
+                    filter_conditions.append(
+                        "payload #>> string_to_array(%s, '.') = %s"
+                    )
+                else:
+                    filter_conditions.append("payload->>%s = %s")
                 filter_params.extend([k, str(v)])
 
         filter_clause = "WHERE " + " AND ".join(filter_conditions) if filter_conditions else ""

--- a/src/powermem/storage/pgvector/pgvector.py
+++ b/src/powermem/storage/pgvector/pgvector.py
@@ -467,7 +467,12 @@ class PGVectorStore(VectorStoreBase):
 
         if filters:
             for k, v in filters.items():
-                filter_conditions.append("payload->>%s = %s")
+                if "." in k:
+                    filter_conditions.append(
+                        "payload #>> string_to_array(%s, '.') = %s"
+                    )
+                else:
+                    filter_conditions.append("payload->>%s = %s")
                 filter_params.extend([k, str(v)])
 
         filter_clause = "WHERE " + " AND ".join(filter_conditions) if filter_conditions else ""

--- a/src/server/api/v1/memories.py
+++ b/src/server/api/v1/memories.py
@@ -188,6 +188,7 @@ async def list_memories(
     request: Request,
     user_id: Optional[str] = Query(None, description="Filter by user ID"),
     agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
+    scope: Optional[str] = Query(None, description="Filter by metadata scope"),
     limit: int = Query(100, ge=1, le=1000, description="Maximum number of results"),
     offset: int = Query(0, ge=0, description="Number of results to skip"),
     sort_by: Optional[str] = Query(None, description="Field to sort by: 'created_at', 'updated_at', 'id'"),
@@ -202,10 +203,15 @@ async def list_memories(
 ):
     """List memories with pagination and sorting"""
     cutoff_date = parse_time_range_cutoff(time_range)
+    filters = {"scope": scope} if scope is not None else None
 
     if cutoff_date is None:
         # Fast path: no time filter — storage handles pagination + sorting natively
-        total_count = service.count_memories(user_id=user_id, agent_id=agent_id)
+        total_count = service.count_memories(
+            user_id=user_id,
+            agent_id=agent_id,
+            filters=filters,
+        )
         memories = service.list_memories(
             user_id=user_id,
             agent_id=agent_id,
@@ -213,6 +219,7 @@ async def list_memories(
             offset=offset,
             sort_by=sort_by,
             order=order,
+            filters=filters,
         )
     else:
         # Storage doesn't natively filter by created_at range; pull a wide page,
@@ -225,6 +232,7 @@ async def list_memories(
             offset=0,
             sort_by=sort_by,
             order=order,
+            filters=filters,
         )
 
         def _created_at(m):

--- a/src/server/api/v1/memories.py
+++ b/src/server/api/v1/memories.py
@@ -360,6 +360,41 @@ async def get_unique_users(
 
 
 @router.get(
+    "/export",
+    summary="Export memories",
+    description="Export memories to JSON or CSV file",
+)
+@limiter.limit(get_rate_limit_string())
+async def export_memories(
+    request: Request,
+    format: str = Query("json", description="Export format (json/csv)"),
+    user_id: Optional[str] = Query(None, description="Filter by user ID"),
+    agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
+    run_id: Optional[str] = Query(None, description="Filter by run ID"),
+    limit: int = Query(1000, ge=1, le=10000, description="Max memories to export"),
+    api_key: str = Depends(verify_api_key),
+    service: MemoryService = Depends(get_memory_service),
+):
+    """Export memories"""
+    content = service.memory.export_memories(
+        format=format,
+        user_id=user_id,
+        agent_id=agent_id,
+        run_id=run_id,
+        limit=limit,
+    )
+
+    media_type = "application/json" if format.lower() == "json" else "text/csv"
+    filename = f"memories_export.{format.lower()}"
+
+    return Response(
+        content=content,
+        media_type=media_type,
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+@router.get(
     "/{memory_id}",
     response_model=APIResponse,
     summary="Get a memory",
@@ -551,41 +586,6 @@ async def delete_memory(
         success=True,
         data={"memory_id": memory_id},
         message="Memory deleted successfully",
-    )
-
-
-@router.get(
-    "/export",
-    summary="Export memories",
-    description="Export memories to JSON or CSV file",
-)
-@limiter.limit(get_rate_limit_string())
-async def export_memories(
-    request: Request,
-    format: str = Query("json", description="Export format (json/csv)"),
-    user_id: Optional[str] = Query(None, description="Filter by user ID"),
-    agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
-    run_id: Optional[str] = Query(None, description="Filter by run ID"),
-    limit: int = Query(1000, ge=1, le=10000, description="Max memories to export"),
-    api_key: str = Depends(verify_api_key),
-    service: MemoryService = Depends(get_memory_service),
-):
-    """Export memories"""
-    content = service.memory.export_memories(
-        format=format,
-        user_id=user_id,
-        agent_id=agent_id,
-        run_id=run_id,
-        limit=limit,
-    )
-
-    media_type = "application/json" if format.lower() == "json" else "text/csv"
-    filename = f"memories_export.{format.lower()}"
-
-    return Response(
-        content=content,
-        media_type=media_type,
-        headers={"Content-Disposition": f"attachment; filename={filename}"},
     )
 
 

--- a/src/server/services/memory_service.py
+++ b/src/server/services/memory_service.py
@@ -225,6 +225,7 @@ class MemoryService:
         offset: int = 0,
         sort_by: Optional[str] = None,
         order: str = "desc",
+        filters: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """
         List memories with pagination and sorting.
@@ -236,6 +237,7 @@ class MemoryService:
             offset: Number of results to skip
             sort_by: Optional field to sort by: 'created_at', 'updated_at', 'id'
             order: Sort order: 'desc' (descending) or 'asc' (ascending)
+            filters: Additional metadata filters
             
         Returns:
             List of memories
@@ -246,6 +248,7 @@ class MemoryService:
                 agent_id=agent_id,
                 limit=limit,
                 offset=offset,
+                filters=filters,
                 sort_by=sort_by,
                 order=order,
             )
@@ -276,6 +279,7 @@ class MemoryService:
         self,
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
     ) -> int:
         """
         Count total memories matching the filters.
@@ -283,6 +287,7 @@ class MemoryService:
         Args:
             user_id: Filter by user ID
             agent_id: Filter by agent ID
+            filters: Additional metadata filters
             
         Returns:
             Total count of memories
@@ -292,6 +297,7 @@ class MemoryService:
             count = self.memory.count_all(
                 user_id=user_id,
                 agent_id=agent_id,
+                filters=filters,
             )
             return count
             

--- a/src/server/services/user_service.py
+++ b/src/server/services/user_service.py
@@ -193,6 +193,15 @@ class UserService:
                 agent_id=agent_id,
                 metadata=metadata,
             )
+            if result is None:
+                raise APIError(
+                    code=ErrorCode.MEMORY_NOT_FOUND,
+                    message=f"Memory not found or access denied: {memory_id}",
+                    status_code=404,
+                )
+            if isinstance(result, dict) and "id" not in result:
+                result["id"] = memory_id
+                result["memory_id"] = memory_id
             
             logger.info(f"User memory updated: user_id={user_id}, memory_id={memory_id}")
             return result

--- a/tests/unit/server/test_list_memory_scope_filter.py
+++ b/tests/unit/server/test_list_memory_scope_filter.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+starlette_requests = pytest.importorskip("starlette.requests")
+
+from server.api.v1.memories import list_memories  # noqa: E402
+
+Request = starlette_requests.Request
+
+
+@pytest.mark.asyncio
+async def test_list_memories_api_converts_scope_to_metadata_filter():
+    service = MagicMock()
+    service.count_memories.return_value = 1
+    service.list_memories.return_value = [
+        {
+            "id": 1,
+            "memory": "remember scope",
+            "user_id": "u01",
+            "agent_id": "a01",
+            "metadata": {"scope": "personal"},
+        }
+    ]
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/memories",
+            "headers": [],
+            "query_string": b"",
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "scheme": "http",
+        }
+    )
+
+    response = await list_memories(
+        request=request,
+        user_id="u01",
+        agent_id="a01",
+        scope="personal",
+        limit=100,
+        offset=0,
+        sort_by=None,
+        order="desc",
+        time_range=None,
+        api_key="test-key",
+        service=service,
+    )
+
+    assert response.success is True
+    assert response.data["total"] == 1
+    service.count_memories.assert_called_once_with(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "personal"},
+    )
+    service.list_memories.assert_called_once_with(
+        user_id="u01",
+        agent_id="a01",
+        limit=100,
+        offset=0,
+        sort_by=None,
+        order="desc",
+        filters={"scope": "personal"},
+    )

--- a/tests/unit/server/test_list_memory_scope_filter.py
+++ b/tests/unit/server/test_list_memory_scope_filter.py
@@ -1,68 +1,58 @@
-from unittest.mock import MagicMock
-
-import pytest
-
-starlette_requests = pytest.importorskip("starlette.requests")
-
-from server.api.v1.memories import list_memories  # noqa: E402
-
-Request = starlette_requests.Request
+import ast
+from pathlib import Path
 
 
-@pytest.mark.asyncio
-async def test_list_memories_api_converts_scope_to_metadata_filter():
-    service = MagicMock()
-    service.count_memories.return_value = 1
-    service.list_memories.return_value = [
-        {
-            "id": 1,
-            "memory": "remember scope",
-            "user_id": "u01",
-            "agent_id": "a01",
-            "metadata": {"scope": "personal"},
-        }
+def _list_memories_function():
+    source = Path("src/server/api/v1/memories.py").read_text(encoding="utf-8")
+    module = ast.parse(source)
+    for node in module.body:
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "list_memories"
+        ):
+            return node
+    raise AssertionError("list_memories function not found")
+
+
+def test_list_memories_api_builds_scope_metadata_filter():
+    function = _list_memories_function()
+
+    filter_assignments = [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "filters"
+            for target in node.targets
+        )
     ]
 
-    request = Request(
-        {
-            "type": "http",
-            "method": "GET",
-            "path": "/api/v1/memories",
-            "headers": [],
-            "query_string": b"",
-            "client": ("testclient", 50000),
-            "server": ("testserver", 80),
-            "scheme": "http",
-        }
+    assert filter_assignments, "filters assignment not found"
+    assert ast.dump(filter_assignments[0].value) == ast.dump(
+        ast.parse(
+            '{"scope": scope} if scope is not None else None',
+            mode="eval",
+        ).body
     )
 
-    response = await list_memories(
-        request=request,
-        user_id="u01",
-        agent_id="a01",
-        scope="personal",
-        limit=100,
-        offset=0,
-        sort_by=None,
-        order="desc",
-        time_range=None,
-        api_key="test-key",
-        service=service,
-    )
 
-    assert response.success is True
-    assert response.data["total"] == 1
-    service.count_memories.assert_called_once_with(
-        user_id="u01",
-        agent_id="a01",
-        filters={"scope": "personal"},
-    )
-    service.list_memories.assert_called_once_with(
-        user_id="u01",
-        agent_id="a01",
-        limit=100,
-        offset=0,
-        sort_by=None,
-        order="desc",
-        filters={"scope": "personal"},
-    )
+def test_list_memories_api_passes_scope_filter_to_memory_service():
+    function = _list_memories_function()
+    calls = [
+        node
+        for node in ast.walk(function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"count_memories", "list_memories"}
+    ]
+
+    assert calls, "service memory calls not found"
+    for call in calls:
+        filters_keywords = [
+            keyword
+            for keyword in call.keywords
+            if keyword.arg == "filters"
+        ]
+        assert filters_keywords, f"{call.func.attr} does not pass filters"
+        assert isinstance(filters_keywords[0].value, ast.Name)
+        assert filters_keywords[0].value.id == "filters"

--- a/tests/unit/server/test_memory_export_route_order.py
+++ b/tests/unit/server/test_memory_export_route_order.py
@@ -1,0 +1,13 @@
+from server.api.v1.memories import router
+
+
+def test_export_route_is_registered_before_memory_id_route():
+    get_paths = [
+        route.path
+        for route in router.routes
+        if "GET" in getattr(route, "methods", set())
+    ]
+
+    assert get_paths.index("/memories/export") < get_paths.index(
+        "/memories/{memory_id}"
+    )

--- a/tests/unit/server/test_memory_export_route_order.py
+++ b/tests/unit/server/test_memory_export_route_order.py
@@ -1,13 +1,9 @@
-from server.api.v1.memories import router
+from pathlib import Path
 
 
-def test_export_route_is_registered_before_memory_id_route():
-    get_paths = [
-        route.path
-        for route in router.routes
-        if "GET" in getattr(route, "methods", set())
-    ]
+def test_export_route_is_defined_before_memory_id_route():
+    source = Path("src/server/api/v1/memories.py").read_text(encoding="utf-8")
 
-    assert get_paths.index("/memories/export") < get_paths.index(
-        "/memories/{memory_id}"
+    assert source.index('@router.get(\n    "/export"') < source.index(
+        '@router.get(\n    "/{memory_id}"'
     )

--- a/tests/unit/server/test_user_service.py
+++ b/tests/unit/server/test_user_service.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+from server.models.errors import APIError, ErrorCode
+from server.services.user_service import UserService
+
+
+def test_update_user_memory_adds_memory_id_when_storage_payload_omits_it():
+    service = UserService.__new__(UserService)
+    service.user_memory = MagicMock()
+    service.user_memory.update.return_value = {
+        "content": "updated",
+        "metadata": {"scope": "personal"},
+    }
+
+    result = service.update_user_memory(
+        user_id="u01",
+        memory_id=123,
+        content="updated",
+        agent_id="a01",
+        metadata={"scope": "personal"},
+    )
+
+    assert result["id"] == 123
+    assert result["memory_id"] == 123
+
+
+def test_update_user_memory_raises_not_found_when_update_returns_none():
+    service = UserService.__new__(UserService)
+    service.user_memory = MagicMock()
+    service.user_memory.update.return_value = None
+
+    try:
+        service.update_user_memory(
+            user_id="u01",
+            memory_id=123,
+            content="updated",
+            agent_id="a01",
+        )
+    except APIError as exc:
+        assert exc.code == ErrorCode.MEMORY_NOT_FOUND
+        assert exc.status_code == 404
+    else:
+        raise AssertionError("Expected APIError")

--- a/tests/unit/test_list_memory_filters.py
+++ b/tests/unit/test_list_memory_filters.py
@@ -1,5 +1,7 @@
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
+from powermem.core.async_memory import AsyncMemory
 from powermem.core.memory import Memory
 from powermem.storage.adapter import StorageAdapter
 from powermem.storage.sqlite.sqlite_vector_store import SQLiteVectorStore
@@ -42,7 +44,10 @@ def test_storage_adapter_filters_metadata_before_pagination():
     )
 
     assert total == 3
-    assert [memory["memory"] for memory in page] == ["personal-2", "personal-3"]
+    assert [memory["memory"] for memory in page] == [
+        "personal-2",
+        "personal-3",
+    ]
     assert all(memory["metadata"]["scope"] == "personal" for memory in page)
 
 
@@ -70,7 +75,9 @@ def test_memory_count_all_passes_filters_to_storage():
 def test_memory_service_list_and_count_pass_filters():
     service = MemoryService.__new__(MemoryService)
     service.memory = MagicMock()
-    service.memory.get_all.return_value = {"results": [{"id": 1, "memory": "m"}]}
+    service.memory.get_all.return_value = {
+        "results": [{"id": 1, "memory": "m"}]
+    }
     service.memory.count_all.return_value = 1
 
     listed = service.list_memories(
@@ -100,3 +107,70 @@ def test_memory_service_list_and_count_pass_filters():
         agent_id="a01",
         filters={"scope": "group"},
     )
+
+
+def test_memory_get_all_keeps_graph_relations_out_of_results():
+    memory = Memory.__new__(Memory)
+    memory.storage = MagicMock()
+    memory.audit = MagicMock()
+    memory.enable_graph = True
+    memory.graph_store = MagicMock()
+    memory._http_client = None
+    memory.agent_id = None
+
+    stored_memory = {
+        "id": 1,
+        "memory": "personal-1",
+        "metadata": {"scope": "personal"},
+    }
+    relation = {"source": "u01", "relationship": "likes", "target": "topic"}
+    memory.storage.get_all_memories.return_value = [stored_memory]
+    memory.graph_store.get_all.return_value = [relation]
+
+    result = memory.get_all(user_id="u01", agent_id="a01", limit=10, offset=0)
+
+    assert result["results"] == [stored_memory]
+    assert result["relations"] == [relation]
+    memory.graph_store.get_all.assert_called_once_with(
+        {"user_id": "u01", "agent_id": "a01", "run_id": None}, 10
+    )
+
+
+def test_async_memory_get_all_keeps_graph_relations_out_of_results():
+    async def run_test():
+        memory = AsyncMemory.__new__(AsyncMemory)
+        memory.storage = MagicMock()
+        memory.audit = MagicMock()
+        memory.audit.log_event_async = AsyncMock()
+        memory.enable_graph = True
+        memory.graph_store = MagicMock()
+
+        stored_memory = {
+            "id": 1,
+            "memory": "personal-1",
+            "metadata": {"scope": "personal"},
+        }
+        relation = {
+            "source": "u01",
+            "relationship": "likes",
+            "target": "topic",
+        }
+        memory.storage.get_all_memories_async = AsyncMock(
+            return_value=[stored_memory]
+        )
+        memory.graph_store.get_all.return_value = [relation]
+
+        result = await memory.get_all(
+            user_id="u01",
+            agent_id="a01",
+            limit=10,
+            offset=0,
+        )
+
+        assert result["results"] == [stored_memory]
+        assert result["relations"] == [relation]
+        memory.graph_store.get_all.assert_called_once_with(
+            {"user_id": "u01", "agent_id": "a01", "run_id": None}, 10
+        )
+
+    asyncio.run(run_test())

--- a/tests/unit/test_list_memory_filters.py
+++ b/tests/unit/test_list_memory_filters.py
@@ -1,12 +1,8 @@
 from unittest.mock import MagicMock
 
-import pytest
-from starlette.requests import Request
-
 from powermem.core.memory import Memory
 from powermem.storage.adapter import StorageAdapter
 from powermem.storage.sqlite.sqlite_vector_store import SQLiteVectorStore
-from server.api.v1.memories import list_memories
 from server.services.memory_service import MemoryService
 
 
@@ -103,63 +99,4 @@ def test_memory_service_list_and_count_pass_filters():
         user_id="u01",
         agent_id="a01",
         filters={"scope": "group"},
-    )
-
-
-@pytest.mark.asyncio
-async def test_list_memories_api_converts_scope_to_metadata_filter():
-    service = MagicMock()
-    service.count_memories.return_value = 1
-    service.list_memories.return_value = [
-        {
-            "id": 1,
-            "memory": "remember scope",
-            "user_id": "u01",
-            "agent_id": "a01",
-            "metadata": {"scope": "personal"},
-        }
-    ]
-
-    request = Request(
-        {
-            "type": "http",
-            "method": "GET",
-            "path": "/api/v1/memories",
-            "headers": [],
-            "query_string": b"",
-            "client": ("testclient", 50000),
-            "server": ("testserver", 80),
-            "scheme": "http",
-        }
-    )
-
-    response = await list_memories(
-        request=request,
-        user_id="u01",
-        agent_id="a01",
-        scope="personal",
-        limit=100,
-        offset=0,
-        sort_by=None,
-        order="desc",
-        time_range=None,
-        api_key="test-key",
-        service=service,
-    )
-
-    assert response.success is True
-    assert response.data["total"] == 1
-    service.count_memories.assert_called_once_with(
-        user_id="u01",
-        agent_id="a01",
-        filters={"scope": "personal"},
-    )
-    service.list_memories.assert_called_once_with(
-        user_id="u01",
-        agent_id="a01",
-        limit=100,
-        offset=0,
-        sort_by=None,
-        order="desc",
-        filters={"scope": "personal"},
     )

--- a/tests/unit/test_list_memory_filters.py
+++ b/tests/unit/test_list_memory_filters.py
@@ -51,6 +51,63 @@ def test_storage_adapter_filters_metadata_before_pagination():
     assert all(memory["metadata"]["scope"] == "personal" for memory in page)
 
 
+def test_storage_adapter_pushes_sqlite_metadata_filter_to_db():
+    store = SQLiteVectorStore(database_path=":memory:")
+    adapter = StorageAdapter(store)
+
+    assert adapter._build_db_filters(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "personal"},
+    ) == {
+        "user_id": "u01",
+        "agent_id": "a01",
+        "metadata.scope": "personal",
+    }
+
+
+def test_storage_adapter_keeps_oceanbase_metadata_filter_key():
+    class OceanBaseLikeStore:
+        collection_name = "memories"
+
+    OceanBaseLikeStore.__module__ = "powermem.storage.oceanbase.oceanbase"
+    adapter = StorageAdapter(OceanBaseLikeStore())
+
+    assert adapter._build_db_filters(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "personal"},
+    ) == {
+        "user_id": "u01",
+        "agent_id": "a01",
+        "scope": "personal",
+    }
+
+
+def test_storage_adapter_count_uses_db_filters_without_fetching_all():
+    store = MagicMock()
+    store.collection_name = "memories"
+    store.count.return_value = 3
+    adapter = StorageAdapter(store)
+    adapter.get_all_memories = MagicMock()
+
+    total = adapter.count_all_memories(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "personal"},
+    )
+
+    assert total == 3
+    store.count.assert_called_once_with(
+        filters={
+            "user_id": "u01",
+            "agent_id": "a01",
+            "scope": "personal",
+        }
+    )
+    adapter.get_all_memories.assert_not_called()
+
+
 def test_memory_count_all_passes_filters_to_storage():
     memory = Memory.__new__(Memory)
     memory.storage = MagicMock()

--- a/tests/unit/test_list_memory_filters.py
+++ b/tests/unit/test_list_memory_filters.py
@@ -1,0 +1,165 @@
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.requests import Request
+
+from powermem.core.memory import Memory
+from powermem.storage.adapter import StorageAdapter
+from powermem.storage.sqlite.sqlite_vector_store import SQLiteVectorStore
+from server.api.v1.memories import list_memories
+from server.services.memory_service import MemoryService
+
+
+def _add_memory(adapter, content, scope):
+    return adapter.add_memory(
+        {
+            "content": content,
+            "user_id": "u01",
+            "agent_id": "a01",
+            "metadata": {"scope": scope},
+        }
+    )
+
+
+def test_storage_adapter_filters_metadata_before_pagination():
+    store = SQLiteVectorStore(database_path=":memory:")
+    adapter = StorageAdapter(store)
+
+    _add_memory(adapter, "personal-1", "personal")
+    _add_memory(adapter, "group-1", "group")
+    _add_memory(adapter, "personal-2", "personal")
+    _add_memory(adapter, "personal-3", "personal")
+
+    total = adapter.count_all_memories(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "personal"},
+    )
+    page = adapter.get_all_memories(
+        user_id="u01",
+        agent_id="a01",
+        limit=2,
+        offset=1,
+        sort_by="id",
+        order="asc",
+        filters={"scope": "personal"},
+    )
+
+    assert total == 3
+    assert [memory["memory"] for memory in page] == ["personal-2", "personal-3"]
+    assert all(memory["metadata"]["scope"] == "personal" for memory in page)
+
+
+def test_memory_count_all_passes_filters_to_storage():
+    memory = Memory.__new__(Memory)
+    memory.storage = MagicMock()
+    memory.storage.count_all_memories.return_value = 2
+    memory.audit = MagicMock()
+
+    result = memory.count_all(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "personal"},
+    )
+
+    assert result == 2
+    memory.storage.count_all_memories.assert_called_once_with(
+        "u01",
+        "a01",
+        None,
+        filters={"scope": "personal"},
+    )
+
+
+def test_memory_service_list_and_count_pass_filters():
+    service = MemoryService.__new__(MemoryService)
+    service.memory = MagicMock()
+    service.memory.get_all.return_value = {"results": [{"id": 1, "memory": "m"}]}
+    service.memory.count_all.return_value = 1
+
+    listed = service.list_memories(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "group"},
+    )
+    counted = service.count_memories(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "group"},
+    )
+
+    assert listed == [{"id": 1, "memory": "m"}]
+    assert counted == 1
+    service.memory.get_all.assert_called_once_with(
+        user_id="u01",
+        agent_id="a01",
+        limit=100,
+        offset=0,
+        filters={"scope": "group"},
+        sort_by=None,
+        order="desc",
+    )
+    service.memory.count_all.assert_called_once_with(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "group"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_memories_api_converts_scope_to_metadata_filter():
+    service = MagicMock()
+    service.count_memories.return_value = 1
+    service.list_memories.return_value = [
+        {
+            "id": 1,
+            "memory": "remember scope",
+            "user_id": "u01",
+            "agent_id": "a01",
+            "metadata": {"scope": "personal"},
+        }
+    ]
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/memories",
+            "headers": [],
+            "query_string": b"",
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "scheme": "http",
+        }
+    )
+
+    response = await list_memories(
+        request=request,
+        user_id="u01",
+        agent_id="a01",
+        scope="personal",
+        limit=100,
+        offset=0,
+        sort_by=None,
+        order="desc",
+        time_range=None,
+        api_key="test-key",
+        service=service,
+    )
+
+    assert response.success is True
+    assert response.data["total"] == 1
+    service.count_memories.assert_called_once_with(
+        user_id="u01",
+        agent_id="a01",
+        filters={"scope": "personal"},
+    )
+    service.list_memories.assert_called_once_with(
+        user_id="u01",
+        agent_id="a01",
+        limit=100,
+        offset=0,
+        sort_by=None,
+        order="desc",
+        filters={"scope": "personal"},
+    )

--- a/tests/unit/test_list_memory_filters.py
+++ b/tests/unit/test_list_memory_filters.py
@@ -108,6 +108,33 @@ def test_storage_adapter_count_uses_db_filters_without_fetching_all():
     adapter.get_all_memories.assert_not_called()
 
 
+def test_pgvector_count_supports_nested_metadata_filters():
+    from powermem.storage.pgvector.pgvector import PGVectorStore
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, query, params):
+            self.query = query
+            self.params = params
+
+        def fetchone(self):
+            return (3,)
+
+    cursor = Cursor()
+    store = PGVectorStore.__new__(PGVectorStore)
+    store.collection_name = "memories"
+    store._get_cursor = MagicMock(return_value=cursor)
+
+    assert store.count({"metadata.scope": "personal"}) == 3
+    assert "payload #>> string_to_array(%s, '.')" in cursor.query
+    assert cursor.params == ("metadata.scope", "personal")
+
+
 def test_memory_count_all_passes_filters_to_storage():
     memory = Memory.__new__(Memory)
     memory.storage = MagicMock()


### PR DESCRIPTION
## Summary

Closes #1014.

- Add `scope` query parameter to `GET /api/v1/memories` for metadata scope filtering.
- Pass metadata filters through API, service, core memory, and storage count/list paths.
- Keep pagination stable by applying metadata filters before `limit`/`offset`.
- Document the new REST query parameter and add regression tests for personal/group-style scope pagination.

## Validation

- `pytest tests/unit/test_list_memory_filters.py tests/unit/test_memory.py -q`
- `PYTHONPATH=src pytest tests/unit -q`
- `python3 -m flake8 src/server/api/v1/memories.py src/server/services/memory_service.py src/powermem/core/memory.py src/powermem/storage/adapter.py tests/unit/test_list_memory_filters.py --select=F601,F821,E999`
- `git diff --check`
