### PR TITLE
fix(init): include server,seekdb extras and improve LLM auto-detection

### DIFF
--- a/apps/claude-code-plugin/SETUP.md
+++ b/apps/claude-code-plugin/SETUP.md
@@ -327,7 +327,7 @@ writing. Never silently patch `.env`.**
         " >> /tmp/powermem-model-download.log 2>&1 &
 
       **Non-CN region (HuggingFace path):**
-        $POWERMEM_PYTHON -c "
+        $POWERMEM_PYTHON -m pip install -q huggingface_hub && $POWERMEM_PYTHON -c "
         from huggingface_hub import snapshot_download
         snapshot_download('sentence-transformers/all-MiniLM-L6-v2')
         print('Model download complete.')
@@ -335,6 +335,19 @@ writing. Never silently patch `.env`.**
 
       Store the background PID:
         POWERMEM_MODEL_DL_PID=$!
+    - Ask whether to build the Web Dashboard EARLY — before starting the server —
+      so the build runs in parallel with model download and server startup. Use
+      AskUserQuestion (single-select):
+
+      | Option | Description |
+      |--------|-------------|
+      | Yes, build dashboard | Run `make build-dashboard` in background, parallel with model download and server startup |
+      | No, skip | Continue without building the dashboard |
+
+      If the user selects "Yes, build dashboard", launch it in the BACKGROUND
+      immediately (do NOT wait for it — model download starts in parallel too):
+        make build-dashboard >> /tmp/powermem-dashboard-build.log 2>&1 &
+        DASHBOARD_BUILD_PID=$!
     - Build the hook binaries FIRST — they get copied into Claude's plugin cache at
       install time, so they must exist on disk before step "install":
         if Go 1.22+ is present:  make build-claude-hook
@@ -386,21 +399,7 @@ writing. Never silently patch `.env`.**
                    && echo "Server ready after $((i*5))s." && break
                  echo "  still starting... ($((i*5))s)"
                done; }
-    - Ask whether to build the Web Dashboard EARLY — before starting the server —
-      so the build runs in parallel with model download and server startup. Use
-      AskUserQuestion (single-select):
-
-      | Option | Description |
-      |--------|-------------|
-      | Yes, build dashboard | Run `make build-dashboard` in background, parallel with model download and server startup |
-      | No, skip | Continue without building the dashboard |
-
-      If the user selects "Yes, build dashboard", launch it in the BACKGROUND
-      immediately (do NOT wait for it — model download starts in parallel too):
-        make build-dashboard >> /tmp/powermem-dashboard-build.log 2>&1 &
-        DASHBOARD_BUILD_PID=$!
-
-      **After the server is healthy**, auto-detect dashboard availability:
+    - **After the server is healthy**, auto-detect dashboard availability:
       ```bash
       # Wait for dashboard build to finish (if started):
       if [ -n "${DASHBOARD_BUILD_PID:-}" ] && kill -0 "$DASHBOARD_BUILD_PID" 2>/dev/null; then

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -50,23 +50,35 @@ raw_model = (
     or ""
 ).strip()
 
-provider = os.environ.get("POWERMEM_INIT_LLM_PROVIDER", "").strip().lower()
-model = raw_model
-if not provider and "/" in raw_model:
-    provider, model = raw_model.split("/", 1)
-    provider = provider.strip().lower()
-    model = model.strip()
+# API key detection drives provider selection. First match wins.
+KEY_SOURCES = [
+    ("POWERMEM_INIT_LLM_API_KEY", None),
+    ("ANTHROPIC_AUTH_TOKEN",       "anthropic"),
+    ("ANTHROPIC_API_KEY",          "anthropic"),
+    ("OPENAI_API_KEY",             "openai"),
+    ("DEEPSEEK_API_KEY",           "deepseek"),
+    ("DASHSCOPE_API_KEY",          "qwen"),
+]
+api_key = ""
+key_provider = ""
+for env_var, implied_provider in KEY_SOURCES:
+    val = (os.environ.get(env_var) or settings_env.get(env_var) or "").strip()
+    if val:
+        api_key = val
+        if implied_provider:
+            key_provider = implied_provider
+        break
 
-model = os.environ.get("POWERMEM_INIT_LLM_MODEL", model).strip()
+model_prefix = raw_model.split("/", 1)[0].strip().lower() if "/" in raw_model else ""
+provider = (
+    os.environ.get("POWERMEM_INIT_LLM_PROVIDER", "").strip().lower()
+    or key_provider
+    or model_prefix
+)
+model = os.environ.get("POWERMEM_INIT_LLM_MODEL", raw_model).strip()
 if provider and model:
     model = normalize_model(provider, model)
 
-api_key = (
-    os.environ.get("POWERMEM_INIT_LLM_API_KEY")
-    or settings_env.get("ANTHROPIC_AUTH_TOKEN")
-    or settings_env.get("ANTHROPIC_API_KEY")
-    or ""
-).strip()
 base_url = (
     os.environ.get("POWERMEM_INIT_LLM_BASE_URL")
     or settings_env.get("ANTHROPIC_BASE_URL")
@@ -105,11 +117,93 @@ print(f"Wrote {env_path} with provider={provider}, model={model}, api_key={'set'
 PY
 }
 
+validate_llm_config() {
+  "$BOOTSTRAP_PYTHON" - "$ENV_FILE" <<'PY'
+import json, os, sys, urllib.request, urllib.error
+from pathlib import Path
+
+env = {}
+for line in Path(sys.argv[1]).read_text().splitlines():
+    line = line.strip()
+    if '=' in line and not line.startswith('#'):
+        k, v = line.split('=', 1)
+        env[k.strip()] = v.strip()
+
+provider = env.get('LLM_PROVIDER', '')
+model    = env.get('LLM_MODEL', '')
+api_key  = env.get('LLM_API_KEY', '')
+base_url = env.get(f'{provider.upper()}_LLM_BASE_URL', '') if provider else ''
+
+if provider in {'ollama', 'vllm'} or not api_key:
+    sys.exit(0)
+
+CONFIGS = {
+    'anthropic': {
+        'url':     lambda b: f"{b or 'https://api.anthropic.com'}/v1/messages",
+        'headers': lambda k: {'x-api-key': k, 'anthropic-version': '2023-06-01',
+                              'content-type': 'application/json'},
+        'body':    lambda m: {'model': m, 'max_tokens': 1,
+                              'messages': [{'role': 'user', 'content': 'hi'}]},
+    },
+    'openai': {
+        'url':     lambda b: f"{b or 'https://api.openai.com'}/v1/chat/completions",
+        'headers': lambda k: {'authorization': f'Bearer {k}',
+                              'content-type': 'application/json'},
+        'body':    lambda m: {'model': m, 'max_tokens': 1,
+                              'messages': [{'role': 'user', 'content': 'hi'}]},
+    },
+    'deepseek': {
+        'url':     lambda b: f"{b or 'https://api.deepseek.com'}/v1/chat/completions",
+        'headers': lambda k: {'authorization': f'Bearer {k}',
+                              'content-type': 'application/json'},
+        'body':    lambda m: {'model': m, 'max_tokens': 1,
+                              'messages': [{'role': 'user', 'content': 'hi'}]},
+    },
+    'qwen': {
+        'url':     lambda b: f"{b or 'https://dashscope.aliyuncs.com/compatible-mode'}/v1/chat/completions",
+        'headers': lambda k: {'authorization': f'Bearer {k}',
+                              'content-type': 'application/json'},
+        'body':    lambda m: {'model': m, 'max_tokens': 1,
+                              'messages': [{'role': 'user', 'content': 'hi'}]},
+    },
+}
+
+cfg = CONFIGS.get(provider)
+if not cfg:
+    print(f"No test template for provider={provider!r}, skipping LLM validation")
+    sys.exit(0)
+
+url     = cfg['url'](base_url)
+headers = cfg['headers'](api_key)
+body    = json.dumps(cfg['body'](model)).encode()
+
+try:
+    req = urllib.request.Request(url, data=body, headers=headers, method='POST')
+    with urllib.request.urlopen(req, timeout=15):
+        print(f"LLM test OK (provider={provider}, model={model})")
+        sys.exit(0)
+except urllib.error.HTTPError as e:
+    err = e.read().decode(errors='replace')
+    print(f"LLM test failed (HTTP {e.code}): {err}", file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f"LLM test error: {e}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
 if [ ! -f "$ENV_FILE" ]; then
   echo "Creating plugin .env from Claude settings or POWERMEM_INIT_* variables."
   create_env_file
 else
   echo "Using existing plugin .env: $ENV_FILE"
+fi
+
+echo "Validating LLM config..."
+if ! validate_llm_config; then
+  echo "LLM validation failed. The model name may not match the provider." >&2
+  echo "Re-run with POWERMEM_INIT_LLM_MODEL=<model> (and optionally POWERMEM_INIT_LLM_PROVIDER=<provider>) to override." >&2
+  exit 1
 fi
 
 if [ ! -x "$(venv_powermem_server)" ]; then
@@ -120,7 +214,7 @@ if [ ! -x "$(venv_powermem_server)" ]; then
   PYTHON=$(venv_python)
   echo "Venv Python: $PYTHON ($(python_version "$PYTHON"))"
   "$PYTHON" -m pip install -U pip setuptools wheel
-  PACKAGE=${POWERMEM_INIT_PACKAGE:-powermem}
+  PACKAGE=${POWERMEM_INIT_PACKAGE:-powermem[server,seekdb]}
   echo "Installing $PACKAGE"
   "$PYTHON" -m pip install "$PACKAGE"
 else


### PR DESCRIPTION
## Summary

- **`init.sh`**: Default `POWERMEM_INIT_PACKAGE` to `powermem[server,seekdb]` so `pyseekdb` is installed on fresh plugin init, fixing `ModuleNotFoundError: No module named 'pyseekdb'` at server startup
- **`init.sh`**: Detect LLM provider from available API key rather than model name prefix — prevents provider/key mismatch when `settings.json` has e.g. `model: "qwen/..."` but the only available key is `ANTHROPIC_API_KEY`; key priority order: `ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY` → `OPENAI_API_KEY` → `DEEPSEEK_API_KEY` → `DASHSCOPE_API_KEY`
- **`init.sh`**: Add `validate_llm_config` step after `.env` creation — makes a minimal test API call and fails early with a clear error if provider/model/key are incompatible, instead of silently starting a broken server
- **`SETUP.md`**: Fix non-CN model preload — add `pip install huggingface_hub` before `snapshot_download` call (mirrors the CN path which installs `modelscope` first)
- **`SETUP.md`**: Fix dashboard build ordering — move the background build prompt to immediately after model download is started in background, so dashboard build runs in parallel with model download and server startup
