### PR TITLE
feat(init): change default data dir to ~/.powermem

### DIFF
--- a/apps/claude-code-plugin/SETUP.md
+++ b/apps/claude-code-plugin/SETUP.md
@@ -37,7 +37,7 @@ PyPI package.
 Installed-plugin init is idempotent and uses plugin-local state:
 
 ```text
-${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/memory-powermem-powermem}/
+$HOME/.powermem/
   .env
   runtime.env
   server.pid

--- a/apps/claude-code-plugin/hooks/run-hook.sh
+++ b/apps/claude-code-plugin/hooks/run-hook.sh
@@ -2,11 +2,7 @@
 # Select the correct native binary for macOS / Linux. Pass-through args (e.g. "poll" for file watcher).
 ROOT=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 PLUGIN_ROOT=$(CDPATH= cd -- "$ROOT/.." && pwd)
-if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
-  DATA_DIR=$CLAUDE_PLUGIN_DATA
-else
-  DATA_DIR="$HOME/.claude/plugins/data/memory-powermem-powermem"
-fi
+DATA_DIR="$HOME/.powermem"
 if [ -f "$DATA_DIR/runtime.env" ]; then
   # shellcheck disable=SC1090
   . "$DATA_DIR/runtime.env"

--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -5,11 +5,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 PLUGIN_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 
 powermem_data_dir() {
-  if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
-    printf '%s\n' "$CLAUDE_PLUGIN_DATA"
-  else
-    printf '%s\n' "$HOME/.claude/plugins/data/memory-powermem-powermem"
-  fi
+  printf '%s\n' "$HOME/.powermem"
 }
 
 DATA_DIR=$(powermem_data_dir)

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -75,7 +75,9 @@ provider = (
     or key_provider
     or model_prefix
 )
-model = os.environ.get("POWERMEM_INIT_LLM_MODEL", raw_model).strip()
+# Strip provider prefix from raw model name (e.g. "anthropic/claude-sonnet-4-6" -> "claude-sonnet-4-6")
+raw_model_clean = raw_model.split("/", 1)[1].strip() if "/" in raw_model else raw_model
+model = os.environ.get("POWERMEM_INIT_LLM_MODEL", raw_model_clean).strip()
 if provider and model:
     model = normalize_model(provider, model)
 

--- a/src/powermem/settings.py
+++ b/src/powermem/settings.py
@@ -8,6 +8,7 @@ def _get_default_env_file() -> Optional[str]:
     project_root = Path(__file__).resolve().parents[2]
     candidates = (
         Path.cwd() / ".env",
+        Path.home() / ".powermem" / ".env",
         project_root / ".env",
         project_root / "examples" / "configs" / ".env",
     )


### PR DESCRIPTION
## Summary
- Remove `CLAUDE_PLUGIN_DATA` dependency from `common.sh`, `run-hook.sh`
- Hardcode data directory to `$HOME/.powermem`  
- Add `~/.powermem/.env` to `settings.py` auto-discovery candidates
- Fix model prefix stripping bug in `init.sh` (prefix not stripped when provider detected from key)
- Update `SETUP.md` documented default path

## Test plan
- [x] `common.sh` sources correctly with `DATA_DIR=$HOME/.powermem`
- [x] `run-hook.sh` reads `runtime.env` from `$HOME/.powermem/runtime.env`
- [x] `settings.py` discovers `.env` from `~/.powermem/.env`
- [x] `.env` created at `~/.powermem/.env` by init.sh
- [x] init.sh → LLM validation → pip install with extras → server startup healthy
- [x] Model prefix stripping: `anthropic/claude-sonnet-4-6` correctly becomes model=`claude-sonnet-4-6` with provider detected from key