### PR TITLE
Fix search score and threshold handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -e ".[dev,test]"
+          pip install -e ".[dev,test,server]"
 
       - name: Run tests (unit + integration, excluding all e2e tests and regression tests)
         run: |

--- a/src/server/api/v1/search.py
+++ b/src/server/api/v1/search.py
@@ -101,6 +101,7 @@ async def search_memories_post(
         run_id=body.run_id,
         filters=body.filters,
         limit=fetch_limit,
+        threshold=body.threshold,
     )
 
     raw_items = results.get("results", [])
@@ -137,6 +138,12 @@ async def search_memories_get(
     agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
     run_id: Optional[str] = Query(None, description="Filter by run ID"),
     limit: int = Query(30, ge=1, le=100, description="Maximum number of results"),
+    threshold: Optional[float] = Query(
+        None,
+        ge=0.0,
+        le=1.0,
+        description="Minimum similarity score threshold",
+    ),
     api_key: str = Depends(verify_api_key),
     service: SearchService = Depends(get_search_service),
 ):
@@ -148,6 +155,7 @@ async def search_memories_get(
         run_id=run_id,
         filters=None,  # GET method doesn't support complex filters
         limit=limit,
+        threshold=threshold,
     )
     
     search_results = [

--- a/src/server/models/request.py
+++ b/src/server/models/request.py
@@ -72,6 +72,12 @@ class SearchRequest(BaseModel):
     run_id: Optional[str] = Field(None, description="Filter by run ID")
     filters: Optional[Dict[str, Any]] = Field(None, description="Additional filters")
     limit: int = Field(default=30, ge=1, le=100, description="Maximum number of results")
+    threshold: Optional[float] = Field(
+        None,
+        ge=0.0,
+        le=1.0,
+        description="Minimum similarity score threshold",
+    )
     time_range: Optional[str] = Field(
         default=None,
         description="Preset time window: '7d', '30d', '90d', or 'all'. When set, only memories created within the window are returned.",

--- a/src/server/services/search_service.py
+++ b/src/server/services/search_service.py
@@ -35,6 +35,7 @@ class SearchService:
         run_id: Optional[str] = None,
         filters: Optional[Dict[str, Any]] = None,
         limit: int = 30,
+        threshold: Optional[float] = None,
     ) -> Dict[str, Any]:
         """
         Search memories.
@@ -46,6 +47,7 @@ class SearchService:
             run_id: Filter by run ID
             filters: Additional filters
             limit: Maximum number of results
+            threshold: Minimum similarity score threshold
             
         Returns:
             Search results dictionary
@@ -68,6 +70,7 @@ class SearchService:
                 run_id=run_id,
                 filters=filters,
                 limit=limit,
+                threshold=threshold,
             )
             
             logger.info(f"Search completed: {len(results.get('results', []))} results")

--- a/src/server/utils/converters.py
+++ b/src/server/utils/converters.py
@@ -2,9 +2,13 @@
 Data conversion utilities for PowerMem API
 """
 
+import logging
 from typing import Any, Dict, List, Optional
 from datetime import datetime
 from ..models.response import MemoryResponse, SearchResult, UserProfileResponse
+
+
+logger = logging.getLogger("server")
 
 
 def memory_to_response(memory_data: Dict[str, Any]) -> MemoryResponse:
@@ -76,13 +80,35 @@ def search_result_to_response(result: Dict[str, Any]) -> SearchResult:
         ""
     )
 
+    memory_id = result.get("memory_id") or result.get("id")
+    raw_score = result.get("score")
+    similarity = result.get("similarity")
+    resolved_score = raw_score if raw_score is not None else similarity
     created_at = _parse_datetime(result.get("created_at")) if "created_at" in result else None
     updated_at = _parse_datetime(result.get("updated_at")) if "updated_at" in result else None
 
+    logger.debug(
+        "Search result score conversion: memory_id=%s raw_score=%r similarity=%r resolved_score=%r",
+        memory_id,
+        raw_score,
+        similarity,
+        resolved_score,
+    )
+    if resolved_score is None:
+        logger.warning(
+            "Search result score resolved to null during API conversion: "
+            "memory_id=%s raw_score=%r similarity=%r score_key_present=%s similarity_key_present=%s",
+            memory_id,
+            raw_score,
+            similarity,
+            "score" in result,
+            "similarity" in result,
+        )
+
     return SearchResult(
-        memory_id=result.get("memory_id") or result.get("id"),
+        memory_id=memory_id,
         content=content,
-        score=result.get("score") or result.get("similarity"),
+        score=resolved_score,
         metadata=result.get("metadata", {}),
         user_id=result.get("user_id"),
         agent_id=result.get("agent_id"),

--- a/tests/unit/server/test_search_score_threshold.py
+++ b/tests/unit/server/test_search_score_threshold.py
@@ -1,0 +1,80 @@
+import inspect
+
+import pytest
+from pydantic import ValidationError
+
+from server.api.v1 import search as search_api
+from server.models.request import SearchRequest
+from server.services.search_service import SearchService
+from server.utils.converters import search_result_to_response
+
+
+class FakeMemory:
+    def __init__(self):
+        self.search_kwargs = None
+
+    def search(self, **kwargs):
+        self.search_kwargs = kwargs
+        return {"results": []}
+
+
+class FakeMetricsCollector:
+    def record_memory_operation(self, operation, status):
+        pass
+
+
+def test_search_result_to_response_preserves_zero_score():
+    result = search_result_to_response(
+        {
+            "id": 1,
+            "content": "zero score is still a valid score",
+            "score": 0.0,
+        }
+    )
+
+    assert result.score == 0.0
+
+
+def test_search_result_to_response_falls_back_to_similarity_only_when_score_is_none():
+    result = search_result_to_response(
+        {
+            "id": 1,
+            "content": "fallback score",
+            "score": None,
+            "similarity": 0.42,
+        }
+    )
+
+    assert result.score == 0.42
+
+
+def test_search_request_accepts_threshold():
+    request = SearchRequest(query="coffee", limit=10, threshold=0.3)
+
+    assert request.threshold == 0.3
+
+
+def test_search_get_route_exposes_threshold_query_parameter():
+    signature = inspect.signature(search_api.search_memories_get)
+
+    assert "threshold" in signature.parameters
+
+
+@pytest.mark.parametrize("threshold", [-0.1, 1.1])
+def test_search_request_rejects_invalid_threshold(threshold):
+    with pytest.raises(ValidationError):
+        SearchRequest(query="coffee", threshold=threshold)
+
+
+def test_search_service_passes_threshold_to_memory_search(monkeypatch):
+    fake_memory = FakeMemory()
+    service = SearchService.__new__(SearchService)
+    service.memory = fake_memory
+    monkeypatch.setattr(
+        "server.services.search_service.get_metrics_collector",
+        lambda: FakeMetricsCollector(),
+    )
+
+    service.search_memories(query="coffee", threshold=0.3)
+
+    assert fake_memory.search_kwargs["threshold"] == 0.3


### PR DESCRIPTION
## What changed

- Preserve valid `score=0.0` values when converting HTTP search results instead of turning them into `null`.
- Add `threshold` support to HTTP search requests for both POST body and GET query parameters.
- Pass the HTTP `threshold` value through `SearchService` to `Memory.search()`.
- Add focused unit coverage for score conversion and threshold validation/propagation.

## Why

Search results can legitimately have a zero score. The API converter previously used truthiness fallback, so `0.0` was treated as missing and serialized as `null` when no `similarity` fallback existed.

HTTP users also had no way to pass the existing core search threshold even though CLI and MCP already expose similar behavior.

## Validation

```bash
PYTHONPATH=src .venv/bin/python -m pytest tests/unit/server/test_search_score_threshold.py -q
```

Result: `7 passed`.
