### PR TITLE
[uv] Use uvx for Claude plugin backend init

### DIFF
--- a/apps/claude-code-plugin/README.md
+++ b/apps/claude-code-plugin/README.md
@@ -30,25 +30,30 @@ installed skills such as `/memory-powermem:init`, `/memory-powermem:status`,
 `/memory-powermem:stop`, and `/memory-powermem:reset`.
 
 The marketplace install only installs the Claude Code plugin connector. The
-`/memory-powermem:init` step prepares the backend by creating a plugin-local venv
-and installing `powermem` from PyPI.
+`/memory-powermem:init` step prepares the backend by ensuring `uv`, then starts
+PowerMem with the uvx-style launcher
+`uvx --from 'powermem[server,seekdb]' powermem-server`. If `uv` is missing, init
+installs it automatically: non-CN networks use the official Astral installer,
+while CN networks use the USTC mirror at
+`https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/`.
+CN package resolution uses `--default-index https://pypi.tuna.tsinghua.edu.cn/simple`.
 
 The PyPI package used by init must include the backend features and dependencies
 required by the plugin, including the default local embedding path
 (`sentence-transformers` / `all-MiniLM-L6-v2`). If you are testing plugin changes
-that depend on unpublished backend code, run init with `POWERMEM_INIT_PACKAGE`
-instead of the skill command:
+that depend on unpublished backend code, set `POWERMEM_INIT_PACKAGE` to a Git URL;
+init passes it to `uvx --from`:
 
 ```bash
-POWERMEM_INIT_PACKAGE='powermem @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>' \
+POWERMEM_INIT_PACKAGE='powermem[server,seekdb] @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>' \
   sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
 ```
 
-For marketplace branch testing before merge, add the marketplace from the same
-branch:
+For marketplace branch testing before merge, you can also add the marketplace
+from the same branch:
 
 ```text
-/plugin marketplace add owner/powermem@<branch>
+/plugin marketplace add https://github.com/owner/powermem.git#<branch>
 /plugin install memory-powermem@powermem
 /reload-plugins
 ```
@@ -90,8 +95,10 @@ If powermem-server has an error (HTTP 503, 500, or the hook calls fail):
    - "open seekdb failed" / "opened by other process" → a stale lock file.
      Kill all powermem-server processes, then clean and restart:
        pkill -9 -f powermem-server && rm -rf ./seekdb_data && powermem-server --host 0.0.0.0 --port 8848
-   - "ModuleNotFoundError" → missing pip dependency. Install it:
-       pip install <missing-package>
+   - "ModuleNotFoundError" → missing Python dependency. Re-run init with a package
+     version or Git ref that includes the dependency:
+       POWERMEM_INIT_PACKAGE='powermem[server,seekdb] @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>' \
+         sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
 3. After applying a fix, re-run the failing operation and confirm the log shows
    the request succeeded (200 status, no ERROR lines).
 ```

--- a/apps/claude-code-plugin/SETUP.md
+++ b/apps/claude-code-plugin/SETUP.md
@@ -26,13 +26,13 @@ do not run `claude plugin install`, and do not build the dashboard. The plugin i
 already installed; this section only prepares the PowerMem backend that the plugin
 connects to.
 
-Installed-plugin init creates a plugin-local Python environment and installs the
-backend package with `pip install powermem` by default. Therefore the PyPI release
-used by this flow must already contain the backend capabilities required by the
-plugin, including the local embedding dependencies. If the user is validating a
-plugin change that depends on unpublished backend code, use
-`POWERMEM_INIT_PACKAGE` to install that exact Git branch or commit instead of the
-PyPI package.
+Installed-plugin init ensures `uv` is available, then starts the backend with the
+uvx-style launcher `uvx --from 'powermem[server,seekdb]' powermem-server`. It does
+not create a plugin-local venv. Therefore the PyPI release used by this flow must
+already contain the backend capabilities required by the plugin, including the
+local embedding dependencies. If the user is validating a plugin change that
+depends on unpublished backend code, use `POWERMEM_INIT_PACKAGE` to pass that
+exact Git branch or commit to `uvx --from` instead of the PyPI package.
 
 Installed-plugin init is idempotent and uses plugin-local state:
 
@@ -42,7 +42,7 @@ $HOME/.powermem/
   runtime.env
   powermem.pid
   powermem-server.log
-  venv/
+  seekdb_data/
 ```
 
 Follow these steps:
@@ -62,7 +62,7 @@ sh "$CLAUDE_PLUGIN_ROOT/scripts/..."
 1. If the skill was just installed or updated, ask the user to run `/reload-plugins`
    first, then retry `/memory-powermem:init`.
 2. Run `sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"` and inspect whether config,
-   venv, managed PID, Python versions, and health are present.
+   uv, managed PID, Python versions, and health are present.
 3. If `.env` is missing, run init with auto-detection first:
 
    ```bash
@@ -100,9 +100,9 @@ sh "$CLAUDE_PLUGIN_ROOT/scripts/..."
 
    Optional variables:
    - `POWERMEM_INIT_LLM_BASE_URL` for a custom provider gateway.
-   - `POWERMEM_INIT_PACKAGE` to test unpublished backend code instead of PyPI
-     `powermem`, for example
-     `powermem @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>`.
+   - `POWERMEM_INIT_PACKAGE` to test unpublished backend code through
+     `uvx --from` instead of PyPI `powermem`, for example
+     `powermem[server,seekdb] @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>`.
    - `POWERMEM_INIT_PYTHON` to force a specific Python >= 3.11.
    - `POWERMEM_INIT_PORT` to force the managed server port.
    - `POWERMEM_INIT_PRELOAD_MODEL=1` to pre-download the default local
@@ -114,17 +114,16 @@ sh "$CLAUDE_PLUGIN_ROOT/scripts/..."
 7. The hook launcher reads `runtime.env`, so once init writes a base URL, prompt
    recall and session-save hooks use that backend automatically.
 
-Model preload branches on region (same as source setup — detect with Step 1a):
-
-- **CN region**: download from **ModelScope**, then bridge into HuggingFace hub cache
-  layout. Do NOT use `sentence_transformers.SentenceTransformer(...)` or raw
-  `huggingface_hub` — they hang on networks where HuggingFace is blocked.
-- **Non-CN region**: download directly via `huggingface_hub.snapshot_download`.
+Installed-plugin model preload uses `uvx --from modelscope python` to download
+from **ModelScope**, then bridges the files into the HuggingFace hub cache layout.
+Do NOT use `sentence_transformers.SentenceTransformer(...)` for preload; it starts
+model initialization instead of just populating the cache and can hang on networks
+where HuggingFace is blocked.
 
 If startup fails with `No module named 'sentence_transformers'`, the backend
-package installed in the plugin venv does not include the local embedding
-dependency. Publish or install a backend build that includes it, or set
-`POWERMEM_INIT_PACKAGE` to a Git branch/commit that does.
+package resolved by `uvx --from` does not include the local embedding dependency.
+Publish a backend build that includes it, or set `POWERMEM_INIT_PACKAGE` to a Git
+branch/commit that does.
 
 To test connectivity:
 ```bash
@@ -172,8 +171,8 @@ state and either skip, reuse, or refresh it instead of failing or duplicating wo
    apps/claude-code-plugin/ both exist). Tell me which path you will take:
      - SOURCE  -> build & deploy from this checkout and install the Claude Code
                   plugin GLOBALLY in HTTP mode (hooks -> REST; needs Go 1.22+).
-     - PIP     -> install from PyPI and connect via the powermem-mcp server
-                  (the plugin is NOT on PyPI, so pip users integrate over MCP).
+     - PYPI/MCP -> install PowerMem from PyPI with uv and connect via the
+                   powermem-mcp server (the plugin itself is NOT on PyPI).
 
 **⚠️ RULE: Every time you need to modify `.env` — for any reason, even a
 single variable — you MUST stop and ask the user what value to use. Show
@@ -182,51 +181,65 @@ rules above), propose the change, and WAIT for the user's confirmation before
 writing. Never silently patch `.env`.**
 
    1a. DETECT REGION (run before any network operations). Detect whether this
-   machine is in China — this determines model download source and PyPI mirror:
+   machine is in China — this determines uv install source, model download source,
+   and Python package index:
 
    ```bash
    CC=$(curl -s -m 5 https://ipinfo.io/country 2>/dev/null || echo "UNKNOWN")
    echo "Region: $CC"
    ```
 
-   - **If `CC=CN`**: use **ModelScope** for model downloads, and set PyPI mirror
-     to `https://pypi.tuna.tsinghua.edu.cn/simple/`.
-   - **If `CC != CN` (or `UNKNOWN`)**: use **HuggingFace** for model downloads,
-     and use the default PyPI index.
-   - Store `CC` in a shell variable — every pip install and model download step
-     below branches on this value. Re-check on every re-run (region may change
-     if the machine moves or VPN state changes).
+   - **If `CC=CN`**: install uv through the USTC GitHub Release mirror, use
+     **ModelScope** for model downloads, and set the Python package index to
+     `https://pypi.tuna.tsinghua.edu.cn/simple/`.
+   - **If `CC != CN` (or `UNKNOWN`)**: install uv through the official Astral
+     installer, use **HuggingFace** for model downloads, and use the default PyPI
+     index.
+   - Store `CC` in a shell variable — every uv install, package install, and model
+     download step below branches on this value. Re-check on every re-run (region
+     may change if the machine moves or VPN state changes).
 
-   **pip install conventions (apply to ALL pip commands in this file):**
+   **uv installation (run before any Python package install):**
 
-   a. **CN mirror** — if `CC=CN`, prefix every pip install with
-      `-i https://pypi.tuna.tsinghua.edu.cn/simple/ --trusted-host pypi.tuna.tsinghua.edu.cn`.
-      Non-CN (or UNKNOWN) uses the default PyPI index with no extra flags.
+   ```bash
+   if ! command -v uv >/dev/null 2>&1; then
+     if [ "$CC" = "CN" ]; then
+       export UV_DOWNLOAD_URL=https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/
+       curl -sL https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/uv-installer.sh | sh
+     else
+       curl -LsSf https://astral.sh/uv/install.sh | sh
+     fi
+     export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+   fi
+   uv --version
+   ```
 
-   b. **Timeout — set once** before any pip install:
-      ```bash
-      pip config set global.timeout 60
-      ```
+   **uv pip conventions (apply to ALL package installs in this file):**
 
-   c. **Retry — on failure, retry up to 3 times.** If a pip install command fails,
-      do NOT immediately escalate to the user. Retry the EXACT same command up to
-      2 more times (3 total attempts). If all 3 fail, only then report the error.
-      Between retries, wait 2 seconds:
+   a. **CN mirror** — if `CC=CN`, add
+      `--default-index https://pypi.tuna.tsinghua.edu.cn/simple` to every
+      `uv pip install` command. Non-CN (or UNKNOWN) uses the default PyPI index
+      with no extra flags.
+
+   b. **Retry — on failure, retry up to 3 times.** If a `uv pip install` command
+      fails, do NOT immediately escalate to the user. Retry the EXACT same command
+      up to 2 more times (3 total attempts). If all 3 fail, only then report the
+      error. Between retries, wait 2 seconds:
       ```bash
       for i in 1 2 3; do
-        pip install ... && break
-        echo "pip install attempt $i failed, retrying in 2s..."
+        uv pip install --python "$POWERMEM_PYTHON" ... && break
+        echo "uv pip install attempt $i failed, retrying in 2s..."
         sleep 2
       done
       ```
-      This applies to ALL pip install calls: editable installs, dependency installs,
-      model download dependencies, etc.
+      This applies to editable installs, dependency installs, model download
+      dependencies, etc.
 
-   d. **All four pip install locations** affected by (a)-(c):
-      1. `pip install -e '.[server,mcp,seekdb]'` (source editable install)
-      2. `$POWERMEM_PYTHON -m pip install -q modelscope` (model download dep)
-      3. `pip install "powermem[mcp,seekdb]"` (PIP path)
-      4. `$POWERMEM_PYTHON -m pip install -q huggingface_hub` (non-CN model download dep)
+   c. **All four package install locations** affected by (a)-(b):
+      1. `uv pip install --python "$POWERMEM_PYTHON" -e '.[server,mcp,seekdb]'`
+      2. `uv pip install --python "$POWERMEM_PYTHON" -q modelscope`
+      3. `uv pip install --python "$POWERMEM_PYTHON" "powermem[mcp,seekdb]"`
+      4. `uv pip install --python "$POWERMEM_PYTHON" -q huggingface_hub`
 
 2. COLLECT CONFIG (idempotent). If a .env already exists in the working directory
    with LLM_PROVIDER / LLM_API_KEY or LLM_AUTH_TOKEN / LLM_MODEL set to real
@@ -327,27 +340,34 @@ writing. Never silently patch `.env`.**
    `.env.example.full`; a typo is silently ignored.
 
 3a. SOURCE path (global install):
-    - pip install -e '.[server,mcp,seekdb]'
+    - Ensure uv is installed using Step 1a, then create/reuse an explicit Python
+      environment and install PowerMem with uv:
+      ```bash
+      uv venv venv --python python3.11
+      POWERMEM_PYTHON="$(pwd)/venv/bin/python"
+      export PATH="$(pwd)/venv/bin:$PATH"
+      uv pip install --python "$POWERMEM_PYTHON" -e '.[server,mcp,seekdb]'
+      ```
       ⚠️ All three extras are required: `[server]` adds fastapi/uvicorn; `[mcp]` adds
       fastmcp, which is checked at import time and calls sys.exit(1) if missing —
       this kills the HTTP server before it can start even in HTTP-only mode;
       `[seekdb]` adds the embedded seekdb storage backend (default).
-    - Immediately after pip install, detect which Python interpreter was used. Read
+    - Immediately after `uv pip install`, detect which Python interpreter was used. Read
       the shebang from the freshly-installed `powermem-server` entry point — this is
-      the only reliable way to guarantee that the model-download script, the pip call
+      the only reliable way to guarantee that the model-download script, the uv call
       inside it, and the server all use the exact same interpreter and site-packages.
       On many Linux systems the default `python` points to a version below 3.11 and `python3` may point to a different minor
-      version than what pip used; relying on bare `python` or `pip` will silently use
+      version than what uv used; relying on bare `python` will silently use
       the wrong environment and the download will fail with an ImportError:
         POWERMEM_PYTHON=$(head -1 "$(command -v powermem-server)" \
           | sed 's|#!||;s| .*||')
         echo "Using interpreter: $POWERMEM_PYTHON"   # e.g. /usr/bin/python3.11
-    - Start the embedding model download in the background immediately after pip
-      install, so it runs in parallel with the remaining setup steps (hook build,
+    - Start the embedding model download in the background immediately after the
+      uv package install, so it runs in parallel with the remaining setup steps (hook build,
       plugin stage/install). Branch on the region detected in Step 1a:
 
       **CN region (ModelScope path):**
-        $POWERMEM_PYTHON -m pip install -q modelscope && $POWERMEM_PYTHON -c "
+        uv pip install --python "$POWERMEM_PYTHON" -q modelscope && $POWERMEM_PYTHON -c "
         from modelscope import snapshot_download
         snapshot_download('AI-ModelScope/all-MiniLM-L6-v2')
         import os, shutil, urllib.request, json
@@ -372,7 +392,7 @@ writing. Never silently patch `.env`.**
         " >> /tmp/powermem-model-download.log 2>&1 &
 
       **Non-CN region (HuggingFace path):**
-        $POWERMEM_PYTHON -m pip install -q huggingface_hub && $POWERMEM_PYTHON -c "
+        uv pip install --python "$POWERMEM_PYTHON" -q huggingface_hub && $POWERMEM_PYTHON -c "
         from huggingface_hub import snapshot_download
         snapshot_download('sentence-transformers/all-MiniLM-L6-v2')
         print('Model download complete.')
@@ -396,7 +416,7 @@ writing. Never silently patch `.env`.**
     - Build the hook binaries FIRST — they get copied into Claude's plugin cache at
       install time, so they must exist on disk before step "install":
         if Go 1.22+ is present:  make build-claude-hook
-        else tell me, and offer to install Go or fall back to the PIP path below.
+        else tell me, and offer to install Go or fall back to the PYPI/MCP path below.
     - Ensure the plugin's root .mcp.json stays empty ({}) — default HTTP mode.
     - STAGE the plugin into a stable, Claude-owned location so the marketplace does
       NOT depend on this checkout — you can move or delete the repo afterwards and
@@ -432,7 +452,7 @@ writing. Never silently patch `.env`.**
         grep -q "complete" /tmp/powermem-model-download.log 2>/dev/null \
           || { echo "Model download failed. Check /tmp/powermem-model-download.log"; exit 1; }
     - Start the API server only if it is not already healthy (idempotent).
-      ⚠️ STARTUP TIME: first launch takes 60–120s (seekdb init + embedder load).
+      ⚠️ STARTUP TIME: first launch can take 60–120s (local embedder load/download + uvicorn bind).
       Exit code 7 means the port is not yet bound — do NOT kill and restart.
         curl -s http://localhost:8848/api/v1/system/health | grep -q healthy \
           || { powermem-server --host 0.0.0.0 --port 8848 &
@@ -468,9 +488,12 @@ writing. Never silently patch `.env`.**
       memory-powermem@powermem). Do NOT print a --plugin-dir command — it is global
       now; every `claude` and `claude -p` loads it automatically.
 
-3b. PIP path:
+3b. PYPI/MCP path:
     - Install the MCP extra in the environment that Claude will use, then:
-      pip install "powermem[mcp,seekdb]"
+      uv venv venv --python python3.11
+      POWERMEM_PYTHON="$(pwd)/venv/bin/python"
+      export PATH="$(pwd)/venv/bin:$PATH"
+      uv pip install --python "$POWERMEM_PYTHON" "powermem[mcp,seekdb]"
       powermem-mcp --help
     - Register the MCP server globally so it persists across sessions (stdio = no
       port), run from the directory holding the .env. Idempotent: if `claude mcp get
@@ -533,13 +556,12 @@ writing. Never silently patch `.env`.**
       prompt from an UNRELATED dir with NO --plugin-dir, then check the logs for
       the two hook-driven calls it triggers:
         ( cd /tmp && claude -p "Reply with exactly: probe ok" )
-      Then in `server.log` (powermem-server) and `seekdb_data/log/seekdb.log`
-      (seekdb), AFTER that run, you MUST see both:
+      Then in `server.log` (powermem-server), AFTER that run, you MUST see both:
         POST /api/v1/memories/search   <- UserPromptSubmit hook (auto-recall)
         POST /api/v1/memories          <- SessionEnd hook (auto-save)
       Seeing both proves PowerMem loads automatically in every `claude`/`claude -p`.
 
-   PIP/MCP path: confirm `claude mcp list` shows powermem as "connected" (not
+   PYPI/MCP path: confirm `claude mcp list` shows powermem as "connected" (not
    "failed"). If it shows failed, run the MCP diagnostics below and do not report
    success until the direct MCP process starts cleanly and Claude shows it connected.
 
@@ -612,24 +634,24 @@ and their resolutions discovered during actual setup attempts:
 ### Error Resolution Checklist
 
 #### [E001] PEP 668 System Protection
-**Problem**: `pip install` fails with "externally-managed-environment"
-**Fix**: Use virtual environment
+**Problem**: system Python blocks package installation with "externally-managed-environment"
+**Fix**: use uv with a virtual environment
 ```bash
-python3 -m venv venv
+uv venv venv --python python3.11
 source venv/bin/activate
-pip install -e '.[server,seekdb]'
+uv pip install --python "$VIRTUAL_ENV/bin/python" -e '.[server,seekdb]'
 ```
 
 #### [E002] Missing Server Dependencies
 **Problem**: Server startup fails with missing packages
 **Fix**: Install missing dependencies
 ```bash
-pip install 'powermem[server,seekdb]'
+uv pip install --python "$POWERMEM_PYTHON" 'powermem[server,seekdb]'
 ```
 
 #### [E003] SeekDB File Locking
 **Problem**: "open seekdb failed OB_ERROR(4000)" or "db opened by other process"
-**Fix**: Clean corrupted data
+**Fix**: Stop duplicate servers, then remove stale seekdb data only if data loss is acceptable
 ```bash
 pkill -f powermem-server
 rm -rf seekdb_data
@@ -647,7 +669,8 @@ make build-claude-hook
 #### [E005] Storage Backend Initialization
 **Problem**: 503 errors on API calls despite server health
 **Fix**: the Claude Code plugin defaults to embedded OceanBase/seekdb. Stop the
-managed server, remove stale seekdb data, and restart init:
+managed server, remove stale seekdb data only if you accept deleting local memories, and
+restart init:
 ```bash
 sh "$CLAUDE_PLUGIN_ROOT/scripts/stop.sh"
 rm -rf "$HOME/.powermem/seekdb_data"
@@ -664,7 +687,7 @@ Step 1a). Quick reference:
 ```bash
 # Detect the correct interpreter first (same one powermem uses):
 POWERMEM_PYTHON=$(head -1 "$(command -v powermem-server)" | sed 's|#!||;s| .*||')
-$POWERMEM_PYTHON -m pip install modelscope
+uv pip install --python "$POWERMEM_PYTHON" modelscope
 $POWERMEM_PYTHON -c "from modelscope import snapshot_download; \
                      snapshot_download('AI-ModelScope/all-MiniLM-L6-v2')"
 # Verify (note: models/ subdirectory is required):
@@ -674,15 +697,14 @@ ls ~/.cache/modelscope/hub/models/AI-ModelScope/all-MiniLM-L6-v2/
 **Non-CN region** (HuggingFace direct):
 ```bash
 POWERMEM_PYTHON=$(head -1 "$(command -v powermem-server)" | sed 's|#!||;s| .*||')
-$POWERMEM_PYTHON -m pip install huggingface_hub
+uv pip install --python "$POWERMEM_PYTHON" huggingface_hub
 $POWERMEM_PYTHON -c "from huggingface_hub import snapshot_download; \
                      snapshot_download('sentence-transformers/all-MiniLM-L6-v2')"
 # Verify:
 ls ~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2/snapshots/
 ```
-⚠️ Do NOT use bare `pip` or `python` here — on many systems the default `python` version is below 3.11
-and `pip` may target a different minor version than what powermem was installed under.
-Using the shebang from `powermem-server` guarantees all three steps (pip, download,
+⚠️ Do NOT use bare `python` here — on many systems the default `python` version is below 3.11.
+Using the shebang from `powermem-server` guarantees all three steps (uv install, download,
 bridge) run in the same environment.
 Then run the bridge script from Step 3a to populate the HuggingFace hub cache
 structure — the embedder's cache-detection function checks `~/.cache/huggingface/hub/`,
@@ -705,18 +727,18 @@ curl -s -m 10 -o /dev/null -w "HuggingFace: HTTP %{http_code}\n" \
 **Problem**: `curl` returns exit code 7 ("Failed to connect") right after launching
 `powermem-server`.
 **Cause**: The server process is running but not yet listening on port 8848. First
-launch takes 60–120s (seekdb table creation + embedder load + uvicorn bind).
+launch can take 60–120s (local embedder load/download + uvicorn bind).
 **Fix**: Use the polling loop from Step 3a. Do NOT kill and restart — restarting
 resets initialization and makes startup take even longer.
 
 #### [E009] Server Exits Immediately — `fastapi`, `uvicorn`, or `fastmcp` Missing
 **Problem**: Server exits immediately after launch with "Missing dependencies" error.
-**Cause**: `pip install -e .` installs only base dependencies. `fastmcp` is checked
+**Cause**: installing only the base project skips optional server/MCP dependencies. `fastmcp` is checked
 at **import time** and calls `sys.exit(1)` if absent — `try/except` cannot catch this,
 so even the HTTP-only server is killed before it starts.
 **Fix**:
 ```bash
-pip install -e '.[server,mcp]'
+uv pip install --python "$POWERMEM_PYTHON" -e '.[server,mcp,seekdb]'
 ```
 
 #### [E010] Anthropic `temperature` + `top_p` both sent → 400
@@ -756,32 +778,36 @@ Diagnosis:
   waiting for JSON-RPC input; re-check Claude-side registration next.
 
 #### [E011] Python Version Below 3.11
-**Problem**: `pip install` fails or venv created with wrong Python version.
+**Problem**: package installation fails or venv created with wrong Python version.
 PowerMem requires Python >= 3.11 (`pyproject.toml: requires-python = ">=3.11"`).
 **Fix**: Verify and use Python 3.11+:
 ```bash
 python3 --version  # must be >= 3.11
 # If too old, find and use a newer Python:
 python3.11 --version
-python3.11 -m venv venv
+uv venv venv --python python3.11
 source venv/bin/activate
 ```
 
-#### [E012] pip Too Old for Editable Install
-**Problem**: `pip install -e .` fails with "File setup.py not found. Directory cannot
-be installed in editable mode."
-**Cause**: pip < 21.3 does not support editable installs via pyproject.toml (PEP 660).
-**Fix**: Upgrade pip first:
+#### [E012] uv Missing or Not on PATH
+**Problem**: `uv: command not found`
+**Fix**: Install uv for your region, then add the install directory to PATH:
 ```bash
-source venv/bin/activate
-pip install --upgrade pip
-pip install -e '.[server,mcp,seekdb]'
+# Non-CN:
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# CN:
+export UV_DOWNLOAD_URL=https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/
+curl -sL https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/uv-installer.sh | sh
+
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+uv --version
 ```
 
 #### [E013] Internal PyPI Mirror Missing Packages
-**Problem**: `pip install` fails with "No matching distribution found for pyobvector"
+**Problem**: `uv pip install` fails with "No matching distribution found for pyobvector"
 (or pyseekdb, onnxruntime, etc.).
-**Cause**: The configured pip index (e.g. internal mirror at `yum.tbsite.net`) does not
+**Cause**: The configured Python package index (e.g. internal mirror at `yum.tbsite.net`) does not
 mirror all required packages.
 **Fix**: If the package is already installed elsewhere (e.g. system Python 3.11), copy
 it into the venv:
@@ -803,11 +829,11 @@ initialization failed" with `ModuleNotFoundError: No module named 'onnxruntime'`
 (or `tenacity`, `tokenizers`).
 **Cause**: When packages like pyobvector/pyseekdb are copied manually into the venv,
 their transitive dependencies (onnxruntime, tenacity, tokenizers, etc.) are not
-automatically resolved by pip.
+automatically resolved by the package installer.
 **Fix**: Install the missing transitive dependencies:
 ```bash
 source venv/bin/activate
-pip install onnxruntime tenacity tokenizers
+uv pip install --python "$VIRTUAL_ENV/bin/python" onnxruntime tenacity tokenizers
 ```
 To verify no other dependencies are missing after manual copying:
 ```bash
@@ -819,8 +845,8 @@ python -c "import pyseekdb" 2>&1    # should produce no output
 
 1. **Verify Python version**: `python3 --version` (must be >= 3.11, see [E011])
 2. **Verify Go version**: `go version` (must be 1.22+)
-3. **Verify pip version**: `python3 -m pip --version` (must be >= 21.3, see [E012])
-4. **Check mirror access**: `pip config list` — if using an internal mirror, verify
+3. **Verify uv**: `uv --version` (install it with [E012] if missing)
+4. **Check mirror access**: if using an internal mirror, verify
    it has `pyobvector`, `pyseekdb`, and `onnxruntime`; see [E013] if not.
 
 ## STEP BY STEP PROVEN PATH
@@ -829,16 +855,13 @@ Given the encountered errors, here are the tested workarounds for each approach:
 
 ### Method A: SOURCE Path (Current Directory Build)
 ```bash
-# Create virtual environment to avoid PEP 668 issues
-# (use python3.11 explicitly if the default python3 is < 3.11)
-python3 -m venv venv
+# Create virtual environment to avoid PEP 668 issues.
+uv venv venv --python python3.11
 source venv/bin/activate
-
-# Upgrade pip first (needed for pyproject.toml editable installs)
-pip install --upgrade pip
+POWERMEM_PYTHON="$VIRTUAL_ENV/bin/python"
 
 # Install everything with ALL required extras
-pip install -e '.[server,mcp,seekdb]'
+uv pip install --python "$POWERMEM_PYTHON" -e '.[server,mcp,seekdb]'
 
 # Build and stage Claude hooks
 make build-claude-hook
@@ -854,12 +877,13 @@ claude plugin install memory-powermem@powermem --scope user
 powermem-server --host 0.0.0.0 --port 8848 &
 ```
 
-### Method B: PIP Path (Recommended for Stability)
+### Method B: PYPI/MCP Path (Recommended for Stability)
 ```bash
 # Clean virtual environment approach
-python3 -m venv venv
+uv venv venv --python python3.11
 source venv/bin/activate
-pip install 'powermem[mcp,seekdb]'
+POWERMEM_PYTHON="$VIRTUAL_ENV/bin/python"
+uv pip install --python "$POWERMEM_PYTHON" 'powermem[mcp,seekdb]'
 claude mcp remove powermem 2>/dev/null
 claude mcp add powermem -- powermem-mcp stdio
 ```
@@ -869,11 +893,11 @@ claude mcp add powermem -- powermem-mcp stdio
 # Common troubleshooting commands
 lsof -i :8848    # Check if port is in use
 pkill -f powermem-server  # Kill any running server
-rm -rf seekdb_data  # Reset SeekDB if corrupted
+rm -rf seekdb_data  # Reset SeekDB if corrupted and data loss is acceptable
 
 # Check logs
-tail -f server.log              # PowerMem server errors
-tail -f seekdb_data/log/seekdb.log  # SeekDB engine errors
+tail -f server.log                    # PowerMem server errors
+tail -f seekdb_data/log/seekdb.log    # SeekDB engine errors
 ```
 
 ## FINAL VALIDATION STEPS
@@ -921,12 +945,12 @@ systemctl --user start powermem.service
 
 ## SUMMARY
 
-**Path taken**: **[Based on observed errors, recommend PIP approach for stability]**
+**Path taken**: **[Based on observed errors, recommend PYPI/MCP approach for stability]**
 - **.env location**: $(pwd)/.env
 - **Virtual environment**: $(pwd)/venv  
 - **Plugin marketplace**: ~/.claude/marketplaces/powermem
 - **Server URL**: http://localhost:8848
-- **Memory system**: SQLite storage with HTTP hooks
+- **Memory system**: seekdb storage with HTTP hooks
 - **Global enablement**: Complete via `claude plugin install`
 - **Usage**: Run `claude` command with no extra flags needed
 

--- a/apps/claude-code-plugin/UNINSTALL.md
+++ b/apps/claude-code-plugin/UNINSTALL.md
@@ -6,8 +6,8 @@ This file is a **prompt for Claude Code**. Open Claude Code in your terminal and
 
 It reverses everything `SETUP.md` did: it unregisters the plugin/MCP server, removes the
 staged marketplace copy (~/.claude/marketplaces/powermem), stops the PowerMem API server,
-uninstalls the powermem package, and (with my confirmation) cleans up build artifacts and
-stored data.
+cleans up legacy package installs when present, and (with my confirmation) cleans up build
+artifacts and stored data.
 
 ---
 
@@ -27,7 +27,7 @@ confirmation — those steps are gated below.
    pyproject.toml here has name = "powermem" (or src/powermem/ and
    apps/claude-code-plugin/ both exist). Tell me which path applies:
      - SOURCE  -> global plugin install (HTTP hooks) was used.
-     - PIP     -> the powermem-mcp server (MCP) was used.
+     - PYPI/MCP -> the powermem-mcp server (MCP) was used.
    If unsure, check both: `claude plugin list` (look for memory-powermem@powermem)
    and `claude mcp list` (look for powermem). If NEITHER is present, PowerMem is already
    unregistered — say so, then still run the remaining steps (they will all be harmless
@@ -58,15 +58,19 @@ confirmation — those steps are gated below.
       "memory-powermem@powermem". If a stale enabledPlugins entry remains, remove
       just that key (leave my other plugins untouched).
 
-3b. PIP path — remove the MCP server registration (idempotent):
+3b. PYPI/MCP path — remove the MCP server registration (idempotent):
         claude mcp remove powermem 2>/dev/null || true
     Verify `claude mcp list` no longer lists powermem.
 
-4. REMOVE THE PYTHON PACKAGE (idempotent). Uninstall the powermem package; this also
-   removes the powermem-server / powermem-mcp commands. Skip quietly if not installed:
-        pip uninstall -y powermem 2>/dev/null || true
-   Verify it is gone: `python -c "import powermem"` must fail, and `which powermem-server`
-   must return nothing.
+4. REMOVE LEGACY PYTHON PACKAGE INSTALLS (idempotent). Marketplace init starts the
+   backend with `uvx --from` and does not install `powermem` into a plugin venv. If
+   this machine previously used a source, MCP, or legacy venv install, uninstall
+   that package from the environment used for setup. Skip quietly if not installed:
+        [ -n "${VIRTUAL_ENV:-}" ] && uv pip uninstall --python "$VIRTUAL_ENV/bin/python" powermem 2>/dev/null || true
+        pip uninstall -y powermem 2>/dev/null || true  # legacy installs
+   Verify legacy installs are gone: `python -c "import powermem"` should fail in the
+   current environment, and `which powermem-server` should return nothing unless it is
+   intentionally provided by another environment.
 
 5. OPTIONAL CLEANUP — ask me before each of these; they are not required to disable
    the integration, and some destroy data:
@@ -75,16 +79,17 @@ confirmation — those steps are gated below.
         rm -rf apps/claude-code-plugin/hooks/bin
       (You may also restore the committed default if it drifted:
         git checkout -- apps/claude-code-plugin/.mcp.json 2>/dev/null || true)
-    - Stored memories (DESTRUCTIVE — this erases all my saved memories): the embedded
-      seekdb data lives in `./seekdb_data/` (or the path in my .env).
-      For SQLite storage mode, data lives in `./sqlite_data/`.
+    - Stored memories (DESTRUCTIVE — this erases all my saved memories): the default
+      embedded seekdb/OceanBase storage mode uses `./seekdb_data/` (or the path in
+      my .env). SQLite storage mode uses `./sqlite_data/` only if explicitly
+      configured.
       Only delete it if I explicitly say so.
     - Secrets: do NOT touch my .env unless I explicitly ask. If I do, redact the key
       in any output.
 
 6. SUMMARIZE: which path applied, what was removed vs. already absent, confirmation
    that the server is stopped and the plugin/MCP server is no longer registered, and
-   list anything left in place by design (e.g. .env, seekdb_data/, sqlite_data/,
+   list anything left in place by design (e.g. .env, sqlite_data/, seekdb_data/,
    the powermem package) so I know what — if anything — to clean up manually.
 
 For the install procedure, see SETUP.md. For the full manual reference, see

--- a/apps/claude-code-plugin/hooks/run-hook.sh
+++ b/apps/claude-code-plugin/hooks/run-hook.sh
@@ -3,14 +3,15 @@
 ROOT=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 PLUGIN_ROOT=$(CDPATH= cd -- "$ROOT/.." && pwd)
 DATA_DIR="${POWERMEM_DATA_DIR:-$HOME/.powermem}"
-if [ -f "$DATA_DIR/runtime.env" ]; then
+load_env_file() {
+  [ -f "$1" ] || return 0
+  set -a
   # shellcheck disable=SC1090
-  . "$DATA_DIR/runtime.env"
-fi
-if [ -f "$PLUGIN_ROOT/config/runtime.env" ]; then
-  # shellcheck disable=SC1090
-  . "$PLUGIN_ROOT/config/runtime.env"
-fi
+  . "$1"
+  set +a
+}
+load_env_file "$DATA_DIR/runtime.env"
+load_env_file "$PLUGIN_ROOT/config/runtime.env"
 case "$(uname -s 2>/dev/null)" in
   Darwin) GOOS=darwin ;;
   Linux) GOOS=linux ;;

--- a/apps/claude-code-plugin/init-flow.svg
+++ b/apps/claude-code-plugin/init-flow.svg
@@ -124,23 +124,24 @@
   <text x="295" y="2152" class="sub-title">子流程 D：准备本机运行环境</text>
 
   <rect x="430" y="2220" width="560" height="92" class="service"/>
-  <text x="710" y="2258" text-anchor="middle" class="text">1. 检查 ~/.powermem/venv</text>
-  <text x="710" y="2288" text-anchor="middle" class="small">缺少 venv 时用 bootstrap Python 创建</text>
+  <text x="710" y="2258" text-anchor="middle" class="text">1. 准备 uvx 后端来源</text>
+  <text x="710" y="2288" text-anchor="middle" class="small">默认 powermem[server,seekdb]，也可指向 Git</text>
 
-  <rect x="430" y="2380" width="560" height="126" class="service"/>
-  <text x="710" y="2420" text-anchor="middle" class="text">2. 确保 venv 里有 powermem-server</text>
-  <text x="710" y="2450" text-anchor="middle" class="small">已有可执行文件则复用，不重装</text>
-  <text x="710" y="2478" text-anchor="middle" class="small">缺少时安装 powermem[server,seekdb]</text>
+  <rect x="430" y="2380" width="560" height="142" class="service"/>
+  <text x="710" y="2416" text-anchor="middle" class="text">2. 通过 uvx 启动 powermem-server</text>
+  <text x="710" y="2446" text-anchor="middle" class="small">已有可执行文件则复用，不重装</text>
+  <text x="710" y="2474" text-anchor="middle" class="small">CN 包解析追加 TUNA default index</text>
+  <text x="710" y="2502" text-anchor="middle" class="small">默认使用 embedded seekdb 存储</text>
 
   <rect x="1075" y="2220" width="620" height="122" class="service"/>
-  <text x="1385" y="2260" text-anchor="middle" class="text">3. pip install 镜像选择</text>
+  <text x="1385" y="2260" text-anchor="middle" class="text">3. uv 安装与镜像选择</text>
   <text x="1385" y="2290" text-anchor="middle" class="small">公网 IP 检测为 CN 时追加</text>
   <text x="1385" y="2318" text-anchor="middle" class="small">-i https://pypi.tuna.tsinghua.edu.cn/simple</text>
 
   <rect x="1075" y="2410" width="620" height="118" class="service"/>
   <text x="1385" y="2450" text-anchor="middle" class="text">4. 可选预下载 embedding 模型</text>
   <text x="1385" y="2480" text-anchor="middle" class="small">POWERMEM_INIT_PRELOAD_MODEL=1</text>
-  <text x="1385" y="2508" text-anchor="middle" class="small">preload-model.sh 安装 modelscope 时沿用镜像</text>
+  <text x="1385" y="2508" text-anchor="middle" class="small">preload-model.sh 通过 uvx --from modelscope 运行</text>
 
   <rect x="680" y="2580" width="760" height="55" class="service"/>
   <text x="1060" y="2616" text-anchor="middle" class="small">输出：本机已有可执行的 powermem-server，可用于启动 managed 服务</text>

--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -14,6 +14,7 @@ RUNTIME_FILE="${POWERMEM_RUNTIME_FILE:-$DATA_DIR/runtime.env}"
 PID_FILE="${POWERMEM_PID_FILE:-$DATA_DIR/powermem.pid}"
 LEGACY_PID_FILE="$DATA_DIR/server.pid"
 LOG_FILE="${POWERMEM_LOG_FILE:-$DATA_DIR/powermem-server.log}"
+USTC_PYTHON_INSTALL_MIRROR="https://mirrors.ustc.edu.cn/github-release/astral-sh/python-build-standalone/"
 
 mkdir -p "$DATA_DIR"
 
@@ -46,6 +47,7 @@ ensure_bootstrap_python() {
     }
   else
     ensure_uv
+    configure_uv_python_install_mirror
     echo "Ensuring Python 3.11 is available through uv."
     "$UV_BIN" python install 3.11
     BOOTSTRAP_PYTHON=$("$UV_BIN" python find 3.11) || {
@@ -61,6 +63,42 @@ ensure_bootstrap_python() {
   POWERMEM_BOOTSTRAP_PYTHON=$BOOTSTRAP_PYTHON
   export BOOTSTRAP_PYTHON
   export POWERMEM_BOOTSTRAP_PYTHON
+}
+
+configure_uv_python_install_mirror() {
+  if [ "${POWERMEM_UV_PYTHON_INSTALL_MIRROR_CONFIGURED:-0}" = "1" ]; then
+    return
+  fi
+  POWERMEM_UV_PYTHON_INSTALL_MIRROR_CONFIGURED=1
+  export POWERMEM_UV_PYTHON_INSTALL_MIRROR_CONFIGURED
+
+  if [ -n "${POWERMEM_UV_PYTHON_INSTALL_MIRROR:-}" ]; then
+    UV_PYTHON_INSTALL_MIRROR=$POWERMEM_UV_PYTHON_INSTALL_MIRROR
+    export UV_PYTHON_INSTALL_MIRROR
+    echo "uv Python install mirror: $UV_PYTHON_INSTALL_MIRROR"
+    return
+  fi
+
+  if [ -n "${UV_PYTHON_INSTALL_MIRROR:-}" ]; then
+    export UV_PYTHON_INSTALL_MIRROR
+    echo "uv Python install mirror: $UV_PYTHON_INSTALL_MIRROR"
+    return
+  fi
+
+  country=$(detect_public_ip_country || true)
+  case "$country" in
+    CN)
+      UV_PYTHON_INSTALL_MIRROR=$USTC_PYTHON_INSTALL_MIRROR
+      export UV_PYTHON_INSTALL_MIRROR
+      echo "Detected public IP country: CN; uv python install will use $UV_PYTHON_INSTALL_MIRROR"
+      ;;
+    "")
+      echo "Public IP country detection failed; uv python install will use the default Python download source."
+      ;;
+    *)
+      echo "Detected public IP country: $country; uv python install will use the default Python download source."
+      ;;
+  esac
 }
 
 python_version() {

--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -14,7 +14,6 @@ RUNTIME_FILE="${POWERMEM_RUNTIME_FILE:-$DATA_DIR/runtime.env}"
 PID_FILE="${POWERMEM_PID_FILE:-$DATA_DIR/powermem.pid}"
 LEGACY_PID_FILE="$DATA_DIR/server.pid"
 LOG_FILE="${POWERMEM_LOG_FILE:-$DATA_DIR/powermem-server.log}"
-VENV_DIR="${POWERMEM_VENV_DIR:-$DATA_DIR/venv}"
 
 mkdir -p "$DATA_DIR"
 
@@ -44,6 +43,137 @@ python_version() {
 import sys
 print(".".join(map(str, sys.version_info[:3])))
 PY
+}
+
+detect_public_ip_country() {
+  py=${POWERMEM_BOOTSTRAP_PYTHON:-}
+  if [ -z "$py" ]; then
+    py=$(choose_python) || return 1
+  fi
+  "$py" - <<'PY'
+import urllib.request
+
+endpoints = [
+    "https://ipapi.co/country/",
+    "https://ifconfig.co/country-iso",
+    "https://ipinfo.io/country",
+]
+
+for url in endpoints:
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "powermem-init/1.0"})
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            value = resp.read(64).decode(errors="replace").strip().upper()
+        if len(value) == 2 and value.isalpha():
+            print(value)
+            raise SystemExit(0)
+    except Exception:
+        pass
+
+raise SystemExit(1)
+PY
+}
+
+install_uv_from_url() {
+  installer_url=$1
+  download_url=${2:-}
+
+  if command -v curl >/dev/null 2>&1; then
+    if [ -n "$download_url" ]; then
+      curl -sL "$installer_url" | env UV_DOWNLOAD_URL="$download_url" sh
+    else
+      curl -LsSf "$installer_url" | sh
+    fi
+    return
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    if [ -n "$download_url" ]; then
+      wget -qO- "$installer_url" | env UV_DOWNLOAD_URL="$download_url" sh
+    else
+      wget -qO- "$installer_url" | sh
+    fi
+    return
+  fi
+
+  echo "Neither curl nor wget is available; install uv manually and retry." >&2
+  return 1
+}
+
+ensure_uv() {
+  if [ -n "${POWERMEM_UV_BIN:-}" ] && command -v "$POWERMEM_UV_BIN" >/dev/null 2>&1; then
+    UV_BIN=$(command -v "$POWERMEM_UV_BIN")
+    export UV_BIN
+    return
+  fi
+
+  if command -v uv >/dev/null 2>&1; then
+    UV_BIN=$(command -v uv)
+    export UV_BIN
+    return
+  fi
+
+  country=$(detect_public_ip_country || true)
+  case "$country" in
+    CN)
+      echo "uv not found; installing uv from the USTC mirror for CN networks."
+      install_uv_from_url \
+        "https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/uv-installer.sh" \
+        "https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/"
+      ;;
+    "")
+      echo "uv not found; region detection failed, installing uv from the official Astral installer."
+      install_uv_from_url "https://astral.sh/uv/install.sh"
+      ;;
+    *)
+      echo "uv not found; installing uv from the official Astral installer."
+      install_uv_from_url "https://astral.sh/uv/install.sh"
+      ;;
+  esac
+
+  PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+  export PATH
+  if command -v uv >/dev/null 2>&1; then
+    UV_BIN=$(command -v uv)
+    export UV_BIN
+    return
+  fi
+
+  echo "uv installer finished, but uv is not on PATH. Add ~/.local/bin to PATH and retry." >&2
+  return 1
+}
+
+configure_uv_index() {
+  if [ "${POWERMEM_UV_INDEX_CONFIGURED:-0}" = "1" ]; then
+    return
+  fi
+  POWERMEM_UV_INDEX_CONFIGURED=1
+  export POWERMEM_UV_INDEX_CONFIGURED
+
+  country=$(detect_public_ip_country || true)
+  case "$country" in
+    CN)
+      POWERMEM_UV_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple"
+      export POWERMEM_UV_INDEX_URL
+      echo "Detected public IP country: CN; uvx will use --default-index $POWERMEM_UV_INDEX_URL"
+      ;;
+    "")
+      echo "Public IP country detection failed; uvx will use the default PyPI index."
+      ;;
+    *)
+      echo "Detected public IP country: $country; uvx will use the default PyPI index."
+      ;;
+  esac
+}
+
+uvx_run() {
+  ensure_uv
+  configure_uv_index
+  if [ -n "${POWERMEM_UV_INDEX_URL:-}" ]; then
+    "$UV_BIN" tool run --default-index "$POWERMEM_UV_INDEX_URL" "$@"
+  else
+    "$UV_BIN" tool run "$@"
+  fi
 }
 
 runtime_base_url() {
@@ -178,14 +308,6 @@ pid_uses_env_file() {
   environ="/proc/$pid/environ"
   [ -r "$environ" ] || return 0
   tr '\000' '\n' < "$environ" | grep -Fx "POWERMEM_ENV_FILE=$ENV_FILE" >/dev/null
-}
-
-venv_python() {
-  printf '%s/bin/python\n' "$VENV_DIR"
-}
-
-venv_powermem_server() {
-  printf '%s/bin/powermem-server\n' "$VENV_DIR"
 }
 
 port_free() {

--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -439,6 +439,39 @@ pid_uses_env_file() {
   tr '\000' '\n' < "$environ" | grep -Fx "POWERMEM_ENV_FILE=$ENV_FILE" >/dev/null
 }
 
+local_port_from_base_url() {
+  printf '%s\n' "$1" \
+    | sed -n -E 's#^http://(localhost|127\.0\.0\.1|\[::1\]):([0-9]+)(/.*)?$#\2#p'
+}
+
+listener_pids_for_port() {
+  port=$1
+  {
+    if command -v lsof >/dev/null 2>&1; then
+      lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true
+    fi
+    if command -v ss >/dev/null 2>&1; then
+      ss -H -ltnp "sport = :$port" 2>/dev/null \
+        | sed -n -E 's/.*pid=([0-9]+).*/\1/p' || true
+    fi
+    if command -v fuser >/dev/null 2>&1; then
+      fuser -n tcp "$port" 2>/dev/null || true
+    fi
+  } | tr ' ' '\n' | sed -n -E '/^[0-9]+$/p' | sort -u
+}
+
+powermem_server_pids_for_port() {
+  port=$1
+  listener_pids_for_port "$port" | while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    args=$(process_args "$pid")
+    [ -n "$args" ] || continue
+    printf '%s\n' "$args" | grep -q 'powermem-server' || continue
+    pid_uses_env_file "$pid" || continue
+    printf '%s\n' "$pid"
+  done
+}
+
 port_free() {
   py=${POWERMEM_BOOTSTRAP_PYTHON:-python3}
   "$py" - "$1" <<'PY'

--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -38,6 +38,31 @@ PY
   return 1
 }
 
+ensure_bootstrap_python() {
+  if [ -n "${POWERMEM_INIT_PYTHON:-}" ]; then
+    BOOTSTRAP_PYTHON=$(choose_python) || {
+      echo "POWERMEM_INIT_PYTHON must point to Python >= 3.11." >&2
+      return 1
+    }
+  else
+    ensure_uv
+    echo "Ensuring Python 3.11 is available through uv."
+    "$UV_BIN" python install 3.11
+    BOOTSTRAP_PYTHON=$("$UV_BIN" python find 3.11) || {
+      echo "uv could not locate Python 3.11 after installation." >&2
+      return 1
+    }
+    if [ -z "$BOOTSTRAP_PYTHON" ]; then
+      echo "uv returned an empty Python 3.11 path." >&2
+      return 1
+    fi
+  fi
+
+  POWERMEM_BOOTSTRAP_PYTHON=$BOOTSTRAP_PYTHON
+  export BOOTSTRAP_PYTHON
+  export POWERMEM_BOOTSTRAP_PYTHON
+}
+
 python_version() {
   "$1" - <<'PY'
 import sys
@@ -45,55 +70,103 @@ print(".".join(map(str, sys.version_info[:3])))
 PY
 }
 
-detect_public_ip_country() {
-  py=${POWERMEM_BOOTSTRAP_PYTHON:-}
-  if [ -z "$py" ]; then
-    py=$(choose_python) || return 1
+find_uv_bin() {
+  if [ -n "${POWERMEM_UV_BIN:-}" ] && command -v "$POWERMEM_UV_BIN" >/dev/null 2>&1; then
+    command -v "$POWERMEM_UV_BIN"
+    return
   fi
-  "$py" - <<'PY'
-import urllib.request
 
-endpoints = [
-    "https://ipapi.co/country/",
-    "https://ifconfig.co/country-iso",
-    "https://ipinfo.io/country",
-]
+  if command -v uv >/dev/null 2>&1; then
+    command -v uv
+    return
+  fi
 
-for url in endpoints:
-    try:
-        req = urllib.request.Request(url, headers={"User-Agent": "powermem-init/1.0"})
-        with urllib.request.urlopen(req, timeout=3) as resp:
-            value = resp.read(64).decode(errors="replace").strip().upper()
-        if len(value) == 2 and value.isalpha():
-            print(value)
-            raise SystemExit(0)
-    except Exception:
-        pass
+  if [ -n "${HOME:-}" ]; then
+    for candidate in "$HOME/.local/bin/uv" "$HOME/.cargo/bin/uv"; do
+      if [ -x "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done
+  fi
 
-raise SystemExit(1)
-PY
+  return 1
+}
+
+fetch_public_ip_country_url() {
+  url=$1
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL -m 3 -A "powermem-init/1.0" "$url"
+    return
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO- -T 3 --user-agent="powermem-init/1.0" "$url"
+    return
+  fi
+
+  return 1
+}
+
+detect_public_ip_country() {
+  for url in \
+    "https://ipapi.co/country/" \
+    "https://ifconfig.co/country-iso" \
+    "https://ipinfo.io/country"
+  do
+    country=$(
+      fetch_public_ip_country_url "$url" 2>/dev/null \
+        | tr -d '[:space:]' \
+        | tr '[:lower:]' '[:upper:]' \
+        | cut -c 1-2 \
+        || true
+    )
+    case "$country" in
+      [A-Z][A-Z])
+        printf '%s\n' "$country"
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
 }
 
 install_uv_from_url() {
   installer_url=$1
   download_url=${2:-}
+  installer_tmp="${TMPDIR:-/tmp}/powermem-uv-installer.$$.sh"
 
   if command -v curl >/dev/null 2>&1; then
-    if [ -n "$download_url" ]; then
-      curl -sL "$installer_url" | env UV_DOWNLOAD_URL="$download_url" sh
+    if curl -fsSL "$installer_url" -o "$installer_tmp"; then
+      if [ -n "$download_url" ]; then
+        env UV_DOWNLOAD_URL="$download_url" sh "$installer_tmp"
+      else
+        sh "$installer_tmp"
+      fi
+      status=$?
+      rm -f "$installer_tmp"
+      return "$status"
     else
-      curl -LsSf "$installer_url" | sh
+      rm -f "$installer_tmp"
+      return 1
     fi
-    return
   fi
 
   if command -v wget >/dev/null 2>&1; then
-    if [ -n "$download_url" ]; then
-      wget -qO- "$installer_url" | env UV_DOWNLOAD_URL="$download_url" sh
+    if wget -qO "$installer_tmp" "$installer_url"; then
+      if [ -n "$download_url" ]; then
+        env UV_DOWNLOAD_URL="$download_url" sh "$installer_tmp"
+      else
+        sh "$installer_tmp"
+      fi
+      status=$?
+      rm -f "$installer_tmp"
+      return "$status"
     else
-      wget -qO- "$installer_url" | sh
+      rm -f "$installer_tmp"
+      return 1
     fi
-    return
   fi
 
   echo "Neither curl nor wget is available; install uv manually and retry." >&2
@@ -101,14 +174,7 @@ install_uv_from_url() {
 }
 
 ensure_uv() {
-  if [ -n "${POWERMEM_UV_BIN:-}" ] && command -v "$POWERMEM_UV_BIN" >/dev/null 2>&1; then
-    UV_BIN=$(command -v "$POWERMEM_UV_BIN")
-    export UV_BIN
-    return
-  fi
-
-  if command -v uv >/dev/null 2>&1; then
-    UV_BIN=$(command -v uv)
+  if UV_BIN=$(find_uv_bin); then
     export UV_BIN
     return
   fi
@@ -119,7 +185,10 @@ ensure_uv() {
       echo "uv not found; installing uv from the USTC mirror for CN networks."
       install_uv_from_url \
         "https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/uv-installer.sh" \
-        "https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/"
+        "https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/" || {
+          echo "USTC uv mirror install failed; falling back to the official Astral installer." >&2
+          install_uv_from_url "https://astral.sh/uv/install.sh"
+        }
       ;;
     "")
       echo "uv not found; region detection failed, installing uv from the official Astral installer."
@@ -200,6 +269,28 @@ write_runtime_base_url() {
     printf 'POWERMEM_ENV_FILE=%s\n' "$ENV_FILE"
   } > "$tmp"
   mv "$tmp" "$RUNTIME_FILE"
+}
+
+export_env_file_vars() {
+  env_file=$1
+  [ -f "$env_file" ] || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      ""|\#*) continue ;;
+      *=*)
+        key=${line%%=*}
+        case "$key" in
+          [A-Za-z_]*)
+            case "$key" in
+              *[!A-Za-z0-9_]*) continue ;;
+            esac
+            export "$line"
+            ;;
+        esac
+        ;;
+    esac
+  done < "$env_file"
 }
 
 health_url() {

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -10,11 +10,7 @@ echo "Data dir: $DATA_DIR"
 
 base_url=$(runtime_base_url)
 
-BOOTSTRAP_PYTHON=$(choose_python) || {
-  echo "No Python >= 3.11 interpreter found. Set POWERMEM_INIT_PYTHON=/path/to/python3.11 and retry." >&2
-  exit 1
-}
-export POWERMEM_BOOTSTRAP_PYTHON=$BOOTSTRAP_PYTHON
+ensure_bootstrap_python || exit 1
 echo "Bootstrap Python: $BOOTSTRAP_PYTHON ($(python_version "$BOOTSTRAP_PYTHON"))"
 
 create_env_file() {
@@ -367,6 +363,8 @@ lines.extend(
         "# Logging",
         f"LOGGING_LEVEL={logging_level}",
         "LOGGING_FORMAT=json",
+        f"LOGGING_FILE={path_value('powermem.log')}",
+        f"AUDIT_LOG_FILE={path_value('audit.log')}",
         "",
         "# Vector store tuning",
         "VECTOR_STORE_BATCH_SIZE=50",
@@ -606,6 +604,7 @@ fi
 
 ensure_uv
 configure_uv_index
+export_env_file_vars "$ENV_FILE"
 echo "Backend package: $PACKAGE"
 echo "Backend launcher: uvx --from '$PACKAGE' powermem-server"
 

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -521,62 +521,6 @@ except Exception as e:
 PY
 }
 
-detect_public_ip_country() {
-  "$BOOTSTRAP_PYTHON" - <<'PY'
-import urllib.request
-
-endpoints = [
-    "https://ipapi.co/country/",
-    "https://ifconfig.co/country-iso",
-    "https://ipinfo.io/country",
-]
-
-for url in endpoints:
-    try:
-        req = urllib.request.Request(url, headers={"User-Agent": "powermem-init/1.0"})
-        with urllib.request.urlopen(req, timeout=3) as resp:
-            value = resp.read(64).decode(errors="replace").strip().upper()
-        if len(value) == 2 and value.isalpha():
-            print(value)
-            raise SystemExit(0)
-    except Exception:
-        pass
-
-raise SystemExit(1)
-PY
-}
-
-configure_pip_index() {
-  if [ "${POWERMEM_PIP_INDEX_CONFIGURED:-0}" = "1" ]; then
-    return
-  fi
-  POWERMEM_PIP_INDEX_CONFIGURED=1
-  export POWERMEM_PIP_INDEX_CONFIGURED
-
-  country=$(detect_public_ip_country || true)
-  case "$country" in
-    CN)
-      POWERMEM_PIP_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple"
-      export POWERMEM_PIP_INDEX_URL
-      echo "Detected public IP country: CN; pip install will append -i $POWERMEM_PIP_INDEX_URL"
-      ;;
-    "")
-      echo "Public IP country detection failed; pip install will use the default PyPI index."
-      ;;
-    *)
-      echo "Detected public IP country: $country; pip install will use the default PyPI index."
-      ;;
-  esac
-}
-
-pip_install() {
-  if [ -n "${POWERMEM_PIP_INDEX_URL:-}" ]; then
-    "$PYTHON" -m pip install "$@" -i "$POWERMEM_PIP_INDEX_URL"
-  else
-    "$PYTHON" -m pip install "$@"
-  fi
-}
-
 stop_unhealthy_managed_server() {
   pid=$(managed_pid 2>/dev/null || true)
   if [ -n "$pid" ]; then
@@ -634,31 +578,7 @@ if ! validate_llm_config; then
   exit 1
 fi
 
-if [ ! -x "$(venv_powermem_server)" ]; then
-  echo "Preparing plugin virtualenv."
-  if [ ! -d "$VENV_DIR" ]; then
-    "$BOOTSTRAP_PYTHON" -m venv "$VENV_DIR"
-  fi
-  PYTHON=$(venv_python)
-  echo "Venv Python: $PYTHON ($(python_version "$PYTHON"))"
-  configure_pip_index
-  pip_install -U pip setuptools wheel
-  PACKAGE=${POWERMEM_INIT_PACKAGE:-powermem[server,seekdb]}
-  echo "Installing $PACKAGE"
-  pip_install "$PACKAGE"
-else
-  echo "Using existing plugin virtualenv: $VENV_DIR"
-  PYTHON=$(venv_python)
-  echo "Venv Python: $PYTHON ($(python_version "$PYTHON"))"
-fi
-
-if [ "${POWERMEM_INIT_PRELOAD_MODEL:-0}" = "1" ] || [ "${POWERMEM_INIT_PRELOAD_MODEL:-}" = "true" ]; then
-  echo "Preloading default local embedding model."
-  configure_pip_index
-  sh "$SCRIPT_DIR/preload-model.sh" "$PYTHON"
-else
-  echo "Skipping model preload. Set POWERMEM_INIT_PRELOAD_MODEL=1 to download via ModelScope and bridge to HuggingFace cache."
-fi
+PACKAGE=${POWERMEM_INIT_PACKAGE:-powermem[server,seekdb]}
 
 if pid_alive; then
   echo "Managed PowerMem server process is running: $(managed_pid)"
@@ -680,8 +600,20 @@ if is_healthy "$base_url"; then
   write_runtime_base_url "$base_url"
   echo "External PowerMem backend is healthy: $base_url"
   announce_dashboard_url "$base_url"
-  echo "Plugin config and venv are ready. Not starting a managed server."
+  echo "Plugin config is ready. Not starting a managed server."
   exit 0
+fi
+
+ensure_uv
+configure_uv_index
+echo "Backend package: $PACKAGE"
+echo "Backend launcher: uvx --from '$PACKAGE' powermem-server"
+
+if [ "${POWERMEM_INIT_PRELOAD_MODEL:-0}" = "1" ] || [ "${POWERMEM_INIT_PRELOAD_MODEL:-}" = "true" ]; then
+  echo "Preloading default local embedding model through uvx."
+  sh "$SCRIPT_DIR/preload-model.sh" "$BOOTSTRAP_PYTHON"
+else
+  echo "Skipping model preload. Set POWERMEM_INIT_PRELOAD_MODEL=1 to download via ModelScope and bridge to HuggingFace cache."
 fi
 
 if [ -n "${POWERMEM_INIT_PORT:-}" ]; then
@@ -703,9 +635,19 @@ else
   }
 fi
 
-server=$(venv_powermem_server)
-echo "Starting PowerMem server on port $port"
-POWERMEM_ENV_FILE="$ENV_FILE" nohup "$server" --host 127.0.0.1 --port "$port" >> "$LOG_FILE" 2>&1 &
+echo "Starting PowerMem server on port $port with uvx"
+if [ -n "${POWERMEM_UV_INDEX_URL:-}" ]; then
+  POWERMEM_ENV_FILE="$ENV_FILE" nohup "$UV_BIN" tool run \
+    --python "$BOOTSTRAP_PYTHON" \
+    --default-index "$POWERMEM_UV_INDEX_URL" \
+    --from "$PACKAGE" \
+    powermem-server --host 127.0.0.1 --port "$port" >> "$LOG_FILE" 2>&1 &
+else
+  POWERMEM_ENV_FILE="$ENV_FILE" nohup "$UV_BIN" tool run \
+    --python "$BOOTSTRAP_PYTHON" \
+    --from "$PACKAGE" \
+    powermem-server --host 127.0.0.1 --port "$port" >> "$LOG_FILE" 2>&1 &
+fi
 pid=$!
 write_managed_pid "$pid"
 echo "Recorded managed server PID $pid in $PID_FILE"
@@ -713,8 +655,16 @@ echo "Recorded managed server PID $pid in $PID_FILE"
 base_url="http://localhost:$port"
 
 echo "Waiting for backend health: $base_url"
+health_timeout=${POWERMEM_INIT_HEALTH_TIMEOUT_SECONDS:-300}
+case "$health_timeout" in
+  ""|*[!0-9]*) health_timeout=300 ;;
+esac
+max_checks=$((health_timeout / 2))
+if [ "$max_checks" -lt 1 ]; then
+  max_checks=1
+fi
 i=0
-while [ "$i" -lt 60 ]; do
+while [ "$i" -lt "$max_checks" ]; do
   if is_healthy "$base_url"; then
     write_runtime_base_url "$base_url"
     echo "PowerMem backend is healthy: $base_url"
@@ -723,11 +673,19 @@ while [ "$i" -lt 60 ]; do
     echo "Log: $LOG_FILE"
     exit 0
   fi
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "PowerMem server process exited before it became healthy." >&2
+    echo "Check log: $LOG_FILE" >&2
+    tail -n 80 "$LOG_FILE" >&2 2>/dev/null || true
+    remove_managed_pid_files
+    describe_port "$port" >&2
+    exit 1
+  fi
   i=$((i + 1))
   sleep 2
 done
 
-echo "PowerMem server did not become healthy within 120 seconds." >&2
+echo "PowerMem server did not become healthy within $((max_checks * 2)) seconds." >&2
 echo "Check log: $LOG_FILE" >&2
 stop_unhealthy_managed_server
 describe_port "$port" >&2

--- a/apps/claude-code-plugin/scripts/preload-model.sh
+++ b/apps/claude-code-plugin/scripts/preload-model.sh
@@ -7,22 +7,15 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 
 PYTHON=${1:-}
 if [ -z "$PYTHON" ]; then
-  if [ -x "$(venv_python)" ]; then
-    PYTHON=$(venv_python)
-  else
-    PYTHON=$(choose_python)
-  fi
+  PYTHON=$(choose_python)
 fi
 
-echo "Preloading all-MiniLM-L6-v2 with Python: $PYTHON ($(python_version "$PYTHON"))"
+MODELSCOPE_PACKAGE=${POWERMEM_MODELSCOPE_PACKAGE:-modelscope}
 
-if [ -n "${POWERMEM_PIP_INDEX_URL:-}" ]; then
-  "$PYTHON" -m pip install -q modelscope -i "$POWERMEM_PIP_INDEX_URL"
-else
-  "$PYTHON" -m pip install -q modelscope
-fi
+echo "Preloading all-MiniLM-L6-v2 with uvx package: $MODELSCOPE_PACKAGE"
+echo "uvx Python: $PYTHON ($(python_version "$PYTHON"))"
 
-"$PYTHON" - <<'PY'
+uvx_run --python "$PYTHON" --from "$MODELSCOPE_PACKAGE" python - <<'PY'
 import json
 import os
 import shutil

--- a/apps/claude-code-plugin/scripts/status.sh
+++ b/apps/claude-code-plugin/scripts/status.sh
@@ -32,11 +32,23 @@ else
   echo "Managed server PID: not running"
 fi
 
-if [ -x "$(venv_python)" ]; then
-  PYTHON=$(venv_python)
-  echo "Venv Python: $PYTHON ($(python_version "$PYTHON"))"
+if [ -n "${POWERMEM_UV_BIN:-}" ] && command -v "$POWERMEM_UV_BIN" >/dev/null 2>&1; then
+  uv_bin=$(command -v "$POWERMEM_UV_BIN")
+elif command -v uv >/dev/null 2>&1; then
+  uv_bin=$(command -v uv)
 else
-  echo "Venv Python: missing"
+  uv_bin=""
+fi
+
+if [ -n "$uv_bin" ]; then
+  echo "uv: $uv_bin ($("$uv_bin" --version 2>/dev/null || echo unknown))"
+  echo "Backend launcher: uvx --from '${POWERMEM_INIT_PACKAGE:-powermem[server,seekdb]}' powermem-server"
+else
+  echo "uv: missing"
+fi
+
+if [ -d "$DATA_DIR/venv" ]; then
+  echo "Legacy venv: $DATA_DIR/venv (unused by uvx init)"
 fi
 
 if is_healthy "$base_url"; then

--- a/apps/claude-code-plugin/scripts/stop.sh
+++ b/apps/claude-code-plugin/scripts/stop.sh
@@ -5,20 +5,46 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/common.sh"
 
-if pid_alive; then
-  pid=$(managed_pid)
-  echo "Stopping PowerMem server PID $pid"
+base_url=$(runtime_base_url)
+stopped=0
+stopped_pids=" "
+
+stop_process() {
+  pid=$1
   kill "$pid" 2>/dev/null || true
   sleep 2
   if kill -0 "$pid" 2>/dev/null; then
     echo "Server still running; sending SIGKILL"
     kill -9 "$pid" 2>/dev/null || true
   fi
-  remove_managed_pid_files
+  stopped=1
+  stopped_pids="${stopped_pids}${pid} "
+}
+
+if pid_alive; then
+  pid=$(managed_pid)
+  echo "Stopping PowerMem server PID $pid"
+  stop_process "$pid"
 else
   if [ -f "$(managed_pid_file)" ]; then
     echo "Removing stale managed server PID file: $(managed_pid_file)"
     remove_managed_pid_files
   fi
+fi
+
+port=$(local_port_from_base_url "$base_url" || true)
+if [ -n "$port" ]; then
+  for pid in $(powermem_server_pids_for_port "$port"); do
+    case "$stopped_pids" in
+      *" $pid "*) continue ;;
+    esac
+    echo "Stopping orphaned PowerMem server PID $pid on port $port"
+    stop_process "$pid"
+  done
+fi
+
+if [ "$stopped" = "1" ]; then
+  remove_managed_pid_files
+else
   echo "No managed PowerMem server is running."
 fi

--- a/apps/claude-code-plugin/skills/init/SKILL.md
+++ b/apps/claude-code-plugin/skills/init/SKILL.md
@@ -16,10 +16,11 @@ Use the plugin scripts as directed by that section:
 - `scripts/status.sh`
 - `scripts/init.sh`
 
-Remember that `scripts/init.sh` installs `powermem` from PyPI by default. If the
-user is testing unpublished backend changes, run the script with
-`POWERMEM_INIT_PACKAGE='powermem @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>'`
-instead of using the default PyPI package.
+Remember that `scripts/init.sh` ensures uv and starts the backend with the
+uvx-style launcher `uvx --from 'powermem[server,seekdb]' powermem-server` by
+default. If the user is testing unpublished backend changes, run the script with
+`POWERMEM_INIT_PACKAGE='powermem[server,seekdb] @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>'`
+so that value is passed to `uvx --from` instead of using the default PyPI package.
 
 If values are missing, ask only for the missing values and pass them through
 `POWERMEM_INIT_*` environment variables. Never print API keys; mask secrets in

--- a/apps/claude-code-plugin/skills/reset/SKILL.md
+++ b/apps/claude-code-plugin/skills/reset/SKILL.md
@@ -2,7 +2,7 @@
 description: Reset PowerMem plugin-local data after explicit user confirmation.
 ---
 
-Reset is destructive. First tell the user it will stop the plugin-managed server and delete the plugin data directory containing `.env`, runtime state, logs, and venv. Only after explicit confirmation, run:
+Reset is destructive. First tell the user it will stop the plugin-managed server and delete the plugin data directory containing `.env`, runtime state, logs, pid files, and seekdb data. Only after explicit confirmation, run:
 
 `POWERMEM_RESET_CONFIRM=delete sh "${CLAUDE_PLUGIN_ROOT}/scripts/reset.sh"`
 

--- a/apps/claude-code-plugin/uv-init-flow.svg
+++ b/apps/claude-code-plugin/uv-init-flow.svg
@@ -1,0 +1,173 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1780" viewBox="0 0 1600 1780" role="img" aria-labelledby="title desc">
+  <title id="title">PowerMem Claude Code 插件 uvx 初始化流程</title>
+  <desc id="desc">展示 Claude Code 插件安装后，通过 init skill 自动准备 uv、使用 uvx 启动 PowerMem 后端，并让 hooks 读 runtime.env 生效的流程。</desc>
+  <defs>
+    <style>
+      .bg { fill: #f7f9fc; }
+      .title { font: 700 38px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #172033; }
+      .subtitle { font: 400 18px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #556074; }
+      .lane-title { font: 700 19px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #172033; }
+      .node-title { font: 700 18px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #172033; }
+      .node-text { font: 400 15px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #465166; }
+      .small { font: 400 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #59667a; }
+      .mono { font: 500 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; fill: #293244; }
+      .lane { fill: #ffffff; stroke: #d8e0ee; stroke-width: 2; rx: 18; }
+      .start { fill: #e9f7ef; stroke: #48a868; stroke-width: 2; rx: 18; }
+      .process { fill: #ffffff; stroke: #8ea4c8; stroke-width: 2; rx: 14; }
+      .uv { fill: #edf5ff; stroke: #4279d8; stroke-width: 2; rx: 14; }
+      .storage { fill: #fff7e8; stroke: #d3942d; stroke-width: 2; rx: 14; }
+      .hook { fill: #f2efff; stroke: #7b61d1; stroke-width: 2; rx: 14; }
+      .decision { fill: #fff; stroke: #3f526d; stroke-width: 2; }
+      .end { fill: #e9f7ef; stroke: #48a868; stroke-width: 2; rx: 18; }
+      .arrow { fill: none; stroke: #40506a; stroke-width: 2.4; marker-end: url(#arrow); }
+      .arrow-soft { fill: none; stroke: #8a96aa; stroke-width: 2; marker-end: url(#arrow-soft); stroke-dasharray: 7 6; }
+      .label { font: 700 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #2d3a50; }
+    </style>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#40506a"/>
+    </marker>
+    <marker id="arrow-soft" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#8a96aa"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="9" flood-color="#14213d" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+
+  <rect class="bg" x="0" y="0" width="1600" height="1780"/>
+  <text x="80" y="76" class="title">PowerMem Claude Code 插件：uvx 初始化与运行流程</text>
+  <text x="80" y="112" class="subtitle">目标：插件只负责连接器与 hooks；后端由 init skill 通过 uvx 按需解析并启动。</text>
+
+  <rect class="lane" x="70" y="155" width="420" height="1470" filter="url(#shadow)"/>
+  <rect class="lane" x="590" y="155" width="420" height="1470" filter="url(#shadow)"/>
+  <rect class="lane" x="1110" y="155" width="420" height="1470" filter="url(#shadow)"/>
+  <text x="280" y="197" text-anchor="middle" class="lane-title">Claude Code / 插件</text>
+  <text x="800" y="197" text-anchor="middle" class="lane-title">init.sh / uvx 启动</text>
+  <text x="1320" y="197" text-anchor="middle" class="lane-title">PowerMem 后端 / hooks</text>
+
+  <rect class="start" x="145" y="245" width="270" height="84"/>
+  <text x="280" y="281" text-anchor="middle" class="node-title">开始</text>
+  <text x="280" y="306" text-anchor="middle" class="node-text">插件已从 marketplace 安装</text>
+
+  <rect class="process" x="125" y="390" width="310" height="104"/>
+  <text x="280" y="428" text-anchor="middle" class="node-title">运行 init skill</text>
+  <text x="280" y="454" text-anchor="middle" class="mono">/memory-powermem:init</text>
+  <text x="280" y="478" text-anchor="middle" class="node-text">只准备后端，不重复安装插件</text>
+
+  <rect class="process" x="125" y="555" width="310" height="106"/>
+  <text x="280" y="592" text-anchor="middle" class="node-title">定位插件根目录</text>
+  <text x="280" y="619" text-anchor="middle" class="mono">$CLAUDE_PLUGIN_ROOT</text>
+  <text x="280" y="644" text-anchor="middle" class="node-text">然后运行 scripts/status.sh</text>
+
+  <polygon class="decision" points="800,250 956,330 800,410 644,330"/>
+  <text x="800" y="321" text-anchor="middle" class="node-title">.env 已存在？</text>
+  <text x="800" y="348" text-anchor="middle" class="node-text">~/.powermem/.env</text>
+
+  <rect class="process" x="645" y="470" width="310" height="110"/>
+  <text x="800" y="506" text-anchor="middle" class="node-title">收集/复用配置</text>
+  <text x="800" y="533" text-anchor="middle" class="node-text">优先环境变量，再读 Claude settings</text>
+  <text x="800" y="557" text-anchor="middle" class="node-text">缺失时只询问缺失项</text>
+
+  <rect class="process" x="645" y="640" width="310" height="106"/>
+  <text x="800" y="677" text-anchor="middle" class="node-title">校验 LLM 配置</text>
+  <text x="800" y="704" text-anchor="middle" class="node-text">provider / model / key / base URL</text>
+  <text x="800" y="728" text-anchor="middle" class="node-text">失败则停止并提示修正</text>
+
+  <polygon class="decision" points="800,805 956,885 800,965 644,885"/>
+  <text x="800" y="876" text-anchor="middle" class="node-title">uv 已可用？</text>
+  <text x="800" y="902" text-anchor="middle" class="node-text">command -v uv</text>
+
+  <rect class="uv" x="610" y="1030" width="380" height="124"/>
+  <text x="800" y="1068" text-anchor="middle" class="node-title">安装 uv</text>
+  <text x="800" y="1095" text-anchor="middle" class="node-text">非 CN：Astral installer</text>
+  <text x="800" y="1120" text-anchor="middle" class="node-text">CN：USTC GitHub Release mirror</text>
+  <text x="800" y="1143" text-anchor="middle" class="mono">UV_DOWNLOAD_URL=.../LatestRelease/</text>
+
+  <rect class="uv" x="610" y="1215" width="380" height="124"/>
+  <text x="800" y="1252" text-anchor="middle" class="node-title">选择后端来源</text>
+  <text x="800" y="1279" text-anchor="middle" class="mono">uvx --from powermem[server,seekdb]</text>
+  <text x="800" y="1304" text-anchor="middle" class="node-text">可用 POWERMEM_INIT_PACKAGE 指向 Git</text>
+  <text x="800" y="1327" text-anchor="middle" class="node-text">不创建插件本地 venv</text>
+
+  <rect class="uv" x="610" y="1400" width="380" height="126"/>
+  <text x="800" y="1437" text-anchor="middle" class="node-title">准备 uvx 参数</text>
+  <text x="800" y="1464" text-anchor="middle" class="mono">uv tool run --python &lt;3.11+&gt;</text>
+  <text x="800" y="1489" text-anchor="middle" class="mono">--from "$PACKAGE" powermem-server</text>
+  <text x="800" y="1513" text-anchor="middle" class="node-text">CN 时追加 TUNA Python package index</text>
+
+  <rect class="storage" x="1145" y="330" width="350" height="116"/>
+  <text x="1320" y="368" text-anchor="middle" class="node-title">使用 seekdb 存储</text>
+  <text x="1320" y="395" text-anchor="middle" class="node-text">DATABASE_PROVIDER=oceanbase</text>
+  <text x="1320" y="420" text-anchor="middle" class="node-text">OCEANBASE_PATH=seekdb_data</text>
+
+  <polygon class="decision" points="1320,515 1480,595 1320,675 1160,595"/>
+  <text x="1320" y="586" text-anchor="middle" class="node-title">需要预下载模型？</text>
+  <text x="1320" y="612" text-anchor="middle" class="mono">POWERMEM_INIT_PRELOAD_MODEL=1</text>
+
+  <rect class="storage" x="1145" y="735" width="350" height="124"/>
+  <text x="1320" y="772" text-anchor="middle" class="node-title">下载 embedding 模型</text>
+  <text x="1320" y="799" text-anchor="middle" class="node-text">uvx --from modelscope python</text>
+  <text x="1320" y="824" text-anchor="middle" class="node-text">ModelScope + HF cache bridge</text>
+  <text x="1320" y="847" text-anchor="middle" class="mono">all-MiniLM-L6-v2</text>
+
+  <polygon class="decision" points="1320,930 1480,1010 1320,1090 1160,1010"/>
+  <text x="1320" y="1001" text-anchor="middle" class="node-title">后端健康？</text>
+  <text x="1320" y="1027" text-anchor="middle" class="mono">/api/v1/system/health</text>
+
+  <rect class="process" x="1145" y="1150" width="350" height="110"/>
+  <text x="1320" y="1187" text-anchor="middle" class="node-title">uvx 启动托管 server</text>
+  <text x="1320" y="1214" text-anchor="middle" class="mono">uv tool run --from "$PACKAGE"</text>
+  <text x="1320" y="1238" text-anchor="middle" class="node-text">写入 pid 与日志</text>
+
+  <rect class="hook" x="1145" y="1320" width="350" height="116"/>
+  <text x="1320" y="1358" text-anchor="middle" class="node-title">写 runtime.env</text>
+  <text x="1320" y="1385" text-anchor="middle" class="mono">POWERMEM_BASE_URL=http://...</text>
+  <text x="1320" y="1410" text-anchor="middle" class="node-text">hooks 只读取 runtime.env</text>
+
+  <rect class="hook" x="1145" y="1495" width="350" height="118"/>
+  <text x="1320" y="1532" text-anchor="middle" class="node-title">hooks 自动生效</text>
+  <text x="1320" y="1559" text-anchor="middle" class="node-text">UserPromptSubmit：自动 recall</text>
+  <text x="1320" y="1584" text-anchor="middle" class="node-text">SessionEnd/PostCompact：自动 save</text>
+
+  <rect class="end" x="1180" y="1660" width="280" height="76"/>
+  <text x="1320" y="1694" text-anchor="middle" class="node-title">完成</text>
+  <text x="1320" y="1718" text-anchor="middle" class="node-text">之后每个 claude 会话自动使用</text>
+
+  <path class="arrow" d="M280 329 L280 390"/>
+  <path class="arrow" d="M280 494 L280 555"/>
+  <path class="arrow" d="M435 608 C520 608 555 330 644 330"/>
+  <path class="arrow" d="M800 410 L800 470"/>
+  <text x="830" y="445" class="label">否</text>
+  <path class="arrow" d="M956 330 C1040 330 1040 693 955 693"/>
+  <text x="1018" y="505" class="label">是</text>
+  <path class="arrow" d="M800 580 L800 640"/>
+  <path class="arrow" d="M800 746 L800 805"/>
+  <path class="arrow" d="M800 965 L800 1030"/>
+  <text x="830" y="1000" class="label">否</text>
+  <path class="arrow" d="M956 885 C1045 885 1045 1277 990 1277"/>
+  <text x="1018" y="1018" class="label">是</text>
+  <path class="arrow" d="M800 1154 L800 1215"/>
+  <path class="arrow" d="M800 1339 L800 1400"/>
+  <path class="arrow" d="M990 1463 C1050 1463 1080 388 1145 388"/>
+  <path class="arrow" d="M1320 446 L1320 515"/>
+  <path class="arrow" d="M1320 675 L1320 735"/>
+  <text x="1350" y="708" class="label">是</text>
+  <path class="arrow" d="M1480 595 C1530 595 1530 1010 1480 1010"/>
+  <text x="1494" y="788" class="label">否</text>
+  <path class="arrow" d="M1320 859 L1320 930"/>
+  <path class="arrow" d="M1320 1090 L1320 1150"/>
+  <text x="1350" y="1124" class="label">否</text>
+  <path class="arrow" d="M1480 1010 C1528 1010 1528 1378 1495 1378"/>
+  <text x="1495" y="1018" class="label">是</text>
+  <path class="arrow" d="M1320 1260 L1320 1320"/>
+  <path class="arrow" d="M1320 1436 L1320 1495"/>
+  <path class="arrow" d="M1320 1613 L1320 1660"/>
+
+  <path class="arrow-soft" d="M1145 1378 C1010 1378 1000 605 435 605"/>
+  <text x="835" y="1370" class="small">runtime.env 将后端地址提供给插件 hooks</text>
+
+  <rect x="82" y="1650" width="830" height="86" rx="14" fill="#ffffff" stroke="#d8e0ee" stroke-width="2"/>
+  <text x="110" y="1682" class="node-title">关键约束</text>
+  <text x="110" y="1710" class="node-text">1. 插件缓存目录不可写业务状态；持久状态放在 ~/.powermem/。</text>
+  <text x="110" y="1734" class="node-text">2. 后端启动统一走 uvx；CN 网络使用 USTC 下载 uv、TUNA 解析 Python 包。</text>
+</svg>

--- a/docs/integrations/claude_code.md
+++ b/docs/integrations/claude_code.md
@@ -12,7 +12,7 @@ Open Claude Code in your terminal and paste this one line:
 Read and follow apps/claude-code-plugin/SETUP.md to set up PowerMem memory for Claude Code.
 ```
 
-Claude Code reads [`apps/claude-code-plugin/SETUP.md`](https://github.com/oceanbase/powermem/blob/main/apps/claude-code-plugin/SETUP.md) — the canonical automated-setup prompt — which detects whether you are in the PowerMem **source tree** (developer) or anywhere else (**pip user**), asks you for the few required secrets, and wires everything up end-to-end.
+Claude Code reads [`apps/claude-code-plugin/SETUP.md`](https://github.com/oceanbase/powermem/blob/main/apps/claude-code-plugin/SETUP.md) — the canonical automated-setup prompt — which detects whether you are in the PowerMem **source tree** (developer) or anywhere else (**PyPI/MCP user**), asks you for the few required secrets, and wires everything up end-to-end.
 
 Prefer to wire it by hand? The full plugin reference below covers every option.
 
@@ -64,8 +64,9 @@ cd powermem
 Copy the template and set your Anthropic credential. For direct Anthropic API
 access use `LLM_API_KEY`; for a Claude Code-style bearer-token gateway use
 `LLM_AUTH_TOKEN` together with `ANTHROPIC_LLM_BASE_URL`. Storage defaults to the
-embedded **seekdb** (no separate database), and the embedder to a local
-`all-MiniLM-L6-v2` model (no API key, auto-downloaded on first use).
+embedded **seekdb** database (no separate database), and the embedder to a local
+`sentence-transformers/all-MiniLM-L6-v2` model (no API key, auto-downloaded on
+first use).
 
 ```bash
 cp .env.example .env
@@ -83,16 +84,38 @@ cp .env.example .env
 
 Every available setting is documented under [Configuration](#configuration); `pmem config init` can also generate `.env` interactively.
 
-### Step 3 — Install PowerMem and build the hook binaries
+### Step 3 — Install uv
 
-`pip install -e '.[server,seekdb]'` provides the `powermem-server` and `pmem` commands plus the zero-config local seekdb path; `make build-claude-hook` compiles the native Go hook binaries (requires **Go 1.22+**):
+PowerMem uses `uv` for Python environment creation and package installation.
+Install it once:
 
 ```bash
-pip install -e '.[server,seekdb]'
+# Non-CN networks
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# CN networks
+export UV_DOWNLOAD_URL=https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/
+curl -sL https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/uv-installer.sh | sh
+
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+uv --version
+```
+
+### Step 4 — Install PowerMem and build the hook binaries
+
+`uv pip install -e '.[server,seekdb]'` provides the `powermem-server` and
+`pmem` commands plus the zero-config local seekdb path and local embedder.
+`make build-claude-hook` compiles the native Go hook binaries (requires
+**Go 1.22+**):
+
+```bash
+uv venv venv --python python3.11
+source venv/bin/activate
+uv pip install --python "$VIRTUAL_ENV/bin/python" -e '.[server,seekdb]'
 make build-claude-hook        # outputs apps/claude-code-plugin/hooks/bin/
 ```
 
-### Step 4 — Start the HTTP API server
+### Step 5 — Start the HTTP API server
 
 Hooks default to `http://localhost:8848`. Leave this running (or start it as a background service):
 
@@ -100,13 +123,13 @@ Hooks default to `http://localhost:8848`. Leave this running (or start it as a b
 powermem-server --host 0.0.0.0 --port 8848
 ```
 
-### Step 5 — Load the plugin into Claude Code
+### Step 6 — Load the plugin into Claude Code
 
 ```bash
 claude --plugin-dir "$(pwd)/apps/claude-code-plugin"
 ```
 
-### Step 6 — Verify
+### Step 7 — Verify
 
 End the session (or run `/compact`), then look for `POST /api/v1/memories` in the server log; run `/hooks` inside Claude Code to confirm the entries are registered. See [Troubleshooting](#troubleshooting-no-requests-while-vibe-coding) if nothing shows up.
 
@@ -132,21 +155,27 @@ When the PowerMem marketplace entry is available, install it with:
 ```
 
 The marketplace step installs the Claude Code plugin connector. The
-`/memory-powermem:init` step prepares the PowerMem backend in a plugin-local venv
-and installs `powermem` from PyPI by default. The PyPI release must include the
-backend features required by the plugin, including the default local embedding
-dependencies. For branch testing before release, install the marketplace from a
-branch and run init with `POWERMEM_INIT_PACKAGE` pointing at the same Git branch
-or commit:
+`/memory-powermem:init` step prepares the PowerMem backend by ensuring `uv`, then
+starts it with the uvx-style launcher
+`uvx --from 'powermem[server,seekdb]' powermem-server`. The PyPI release must
+include the backend features required by the plugin, including the default local
+embedding dependencies. If `uv` is missing, init installs it automatically:
+non-CN networks use the official Astral installer, while CN networks use the USTC
+mirror at
+`https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/`.
+CN package resolution uses `--default-index https://pypi.tuna.tsinghua.edu.cn/simple`.
+For branch testing before release, install the marketplace from a branch and run
+init with `POWERMEM_INIT_PACKAGE` pointing at the same Git branch or commit; init
+passes it to `uvx --from`:
 
 ```text
-/plugin marketplace add owner/powermem@<branch>
+/plugin marketplace add https://github.com/owner/powermem.git#<branch>
 /plugin install memory-powermem@powermem
 /reload-plugins
 ```
 
 ```bash
-POWERMEM_INIT_PACKAGE='powermem @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>' \
+POWERMEM_INIT_PACKAGE='powermem[server,seekdb] @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>' \
   sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
 ```
 
@@ -203,7 +232,7 @@ The hook binary only **writes** to your PowerMem server; it does not install a s
 |---------------|--------------|
 | **Zip** | Download the new `.zip`, replace the old folder (delete the previous `powermem-claude-code-plugin` tree, unzip the new one to the same or a new path), then start Claude with `--plugin-dir` pointing at the new folder. |
 | **Repo / `git`** | `git pull` (or fetch the release you want), run `make package-claude-plugin` or `bash scripts/package-plugin.sh` if you need a fresh zip, then restart Claude Code. |
-| **Marketplace** | Run `/plugin uninstall memory-powermem@powermem`, reinstall from the marketplace, then run `/reload-plugins`. If the backend package changed, re-run `/memory-powermem:init` so the plugin-local venv installs the new PyPI release. |
+| **Marketplace** | Run `/plugin uninstall memory-powermem@powermem`, reinstall from the marketplace, then run `/reload-plugins`. If the backend package changed, re-run `/memory-powermem:init` so uvx resolves the new PyPI release. |
 
 After updating, restart the Claude Code session (or the whole app) so MCP config, skills, and hooks reload.
 
@@ -258,7 +287,7 @@ After `apply-connection-mode.sh mcp`, edit `.mcp.json` or `config/mcp-mode.mcp.j
 }
 ```
 
-Ensure PowerMem is installed (`pip install "powermem[mcp,seekdb]"`) and a `.env` is available when using stdio.
+Ensure PowerMem is installed (`uv pip install --python "$VIRTUAL_ENV/bin/python" "powermem[mcp,seekdb]"`) and a `.env` is available when using stdio.
 
 ### HTTP mode: REST only (standard)
 

--- a/tests/unit/test_claude_plugin_uv_install.py
+++ b/tests/unit/test_claude_plugin_uv_install.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 COMMON_SH = ROOT / "apps" / "claude-code-plugin" / "scripts" / "common.sh"
 INIT_SH = ROOT / "apps" / "claude-code-plugin" / "scripts" / "init.sh"
+RUN_HOOK_SH = ROOT / "apps" / "claude-code-plugin" / "hooks" / "run-hook.sh"
 SCRIPT_ARG0 = ROOT / "apps" / "claude-code-plugin" / "scripts" / "init.sh"
 
 
@@ -43,7 +44,15 @@ def fake_curl_install_script() -> str:
     return r"""
         #!/usr/bin/env sh
         printf '%s\n' "$*" > "$HOME/curl_args"
-        cat <<'INSTALL'
+        output=
+        while [ "$#" -gt 0 ]; do
+          if [ "$1" = "-o" ]; then
+            shift
+            output=$1
+          fi
+          shift
+        done
+        cat > "$output" <<'INSTALL'
         mkdir -p "$HOME/.local/bin"
         cat > "$HOME/.local/bin/uv" <<'UV'
         #!/usr/bin/env sh
@@ -79,6 +88,27 @@ def test_ensure_uv_reuses_existing_uv(tmp_path: Path) -> None:
     assert not (tmp_path / "curl_args").exists()
 
 
+def test_find_uv_bin_detects_user_local_uv_without_path(tmp_path: Path) -> None:
+    uv_bin = tmp_path / ".local" / "bin" / "uv"
+    write_executable(
+        uv_bin,
+        """
+        #!/usr/bin/env sh
+        echo local-uv
+        """,
+    )
+
+    result = run_common(
+        """
+        find_uv_bin
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(uv_bin)
+
+
 def test_ensure_uv_installs_from_ustc_for_cn(tmp_path: Path) -> None:
     bin_dir = tmp_path / "bin"
     write_executable(bin_dir / "curl", fake_curl_install_script())
@@ -99,6 +129,85 @@ def test_ensure_uv_installs_from_ustc_for_cn(tmp_path: Path) -> None:
     assert f"UV_BIN={tmp_path}/.local/bin/uv" in result.stdout
     assert "mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/uv-installer.sh" in result.stdout
     assert "DOWNLOAD=https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/" in result.stdout
+
+
+def test_ensure_uv_falls_back_to_astral_when_ustc_installer_fails(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    write_executable(
+        bin_dir / "curl",
+        r"""
+        #!/usr/bin/env sh
+        printf '%s\n' "$*" >> "$HOME/curl_calls"
+        output=
+        args=$*
+        while [ "$#" -gt 0 ]; do
+          if [ "$1" = "-o" ]; then
+            shift
+            output=$1
+          fi
+          shift
+        done
+        case "$args" in
+          *mirrors.ustc.edu.cn*)
+            cat > "$output" <<'INSTALL'
+        exit 42
+        INSTALL
+            ;;
+          *)
+            cat > "$output" <<'INSTALL'
+        mkdir -p "$HOME/.local/bin"
+        cat > "$HOME/.local/bin/uv" <<'UV'
+        #!/usr/bin/env sh
+        echo fake-uv
+        UV
+        chmod +x "$HOME/.local/bin/uv"
+        printf '%s\n' "${UV_DOWNLOAD_URL:-}" > "$HOME/uv_download_url"
+        INSTALL
+            ;;
+        esac
+        """,
+    )
+
+    result = run_common(
+        """
+        detect_public_ip_country() { printf 'CN\n'; }
+        ensure_uv
+        printf 'UV_BIN=%s\n' "$UV_BIN"
+        cat "$HOME/curl_calls"
+        printf 'DOWNLOAD=%s\n' "$(cat "$HOME/uv_download_url")"
+        """,
+        tmp_path,
+        bin_dir=bin_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"UV_BIN={tmp_path}/.local/bin/uv" in result.stdout
+    assert "mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/uv-installer.sh" in result.stdout
+    assert "https://astral.sh/uv/install.sh" in result.stdout
+    assert "DOWNLOAD=" in result.stdout
+    assert "USTC uv mirror install failed" in result.stderr
+
+
+def test_detect_public_ip_country_uses_curl_without_python(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    write_executable(
+        bin_dir / "curl",
+        """
+        #!/usr/bin/env sh
+        printf 'cn\n'
+        """,
+    )
+
+    result = run_common(
+        """
+        detect_public_ip_country
+        """,
+        tmp_path,
+        bin_dir=bin_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "CN"
 
 
 def test_ensure_uv_installs_from_astral_for_non_cn(tmp_path: Path) -> None:
@@ -152,11 +261,125 @@ def test_uvx_run_uses_tuna_index_for_cn(tmp_path: Path) -> None:
     )
 
 
+def test_export_env_file_vars_exports_generated_server_config(tmp_path: Path) -> None:
+    env_file = tmp_path / ".powermem" / ".env"
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text(
+        "\n".join(
+            [
+                "# comment",
+                "POWERMEM_SERVER_AUTH_ENABLED=false",
+                "POWERMEM_SERVER_API_KEYS=",
+                "INVALID-NAME=ignored",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = run_common(
+        f"""
+        export_env_file_vars "{env_file}"
+        printf 'AUTH=%s\\n' "$POWERMEM_SERVER_AUTH_ENABLED"
+        printf 'KEYS=%s\\n' "${{POWERMEM_SERVER_API_KEYS-set}}"
+        printf 'INVALID=%s\\n' "${{INVALID-NAME-unset}}"
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "AUTH=false" in result.stdout
+    assert "KEYS=" in result.stdout
+    assert "INVALID=NAME-unset" in result.stdout
+
+
+def test_hook_launcher_exports_runtime_env_to_native_binary(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    hooks_dir = plugin_root / "hooks"
+    bin_dir = hooks_dir / "bin"
+    hooks_dir.mkdir(parents=True)
+    run_hook = hooks_dir / "run-hook.sh"
+    run_hook.write_text(RUN_HOOK_SH.read_text(encoding="utf-8"), encoding="utf-8")
+    run_hook.chmod(0o755)
+    write_executable(
+        bin_dir / "powermem-hook-linux-amd64",
+        """
+        #!/usr/bin/env sh
+        printf 'BASE=%s\n' "${POWERMEM_BASE_URL:-missing}"
+        """,
+    )
+    data_dir = tmp_path / ".powermem"
+    data_dir.mkdir()
+    (data_dir / "runtime.env").write_text("POWERMEM_BASE_URL=http://localhost:18848\n", encoding="utf-8")
+
+    result = subprocess.run(
+        ["sh", str(run_hook)],
+        cwd=tmp_path,
+        env={**os.environ, "HOME": str(tmp_path), "POWERMEM_DATA_DIR": str(data_dir)},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "BASE=http://localhost:18848"
+
+
+def test_bootstrap_python_uses_uv_managed_python_by_default(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    uv_python = tmp_path / "uv-python-3.11"
+    write_executable(
+        bin_dir / "uv",
+        f"""
+        #!/usr/bin/env sh
+        printf '%s\\n' "$*" >> "$HOME/uv_calls"
+        if [ "$1" = "python" ] && [ "$2" = "install" ]; then
+          exit 0
+        fi
+        if [ "$1" = "python" ] && [ "$2" = "find" ]; then
+          printf '%s\\n' "{uv_python}"
+          exit 0
+        fi
+        exit 1
+        """,
+    )
+
+    result = run_common(
+        """
+        ensure_bootstrap_python
+        printf 'BOOTSTRAP_PYTHON=%s\n' "$BOOTSTRAP_PYTHON"
+        printf 'POWERMEM_BOOTSTRAP_PYTHON=%s\n' "$POWERMEM_BOOTSTRAP_PYTHON"
+        cat "$HOME/uv_calls"
+        """,
+        tmp_path,
+        bin_dir=bin_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"BOOTSTRAP_PYTHON={uv_python}" in result.stdout
+    assert f"POWERMEM_BOOTSTRAP_PYTHON={uv_python}" in result.stdout
+    assert "python install 3.11" in result.stdout
+    assert "python find 3.11" in result.stdout
+
+
 def test_init_uses_uvx_launcher_instead_of_plugin_venv_install() -> None:
     script = INIT_SH.read_text(encoding="utf-8")
 
+    assert "ensure_bootstrap_python || exit 1" in script
+    assert "BOOTSTRAP_PYTHON=$(choose_python)" not in script
+    assert 'export_env_file_vars "$ENV_FILE"' in script
     assert 'tool run \\' in script
     assert "--from \"$PACKAGE\"" in script
     assert "powermem-server --host 127.0.0.1 --port \"$port\"" in script
     assert "uv_pip_install" not in script
     assert "venv_powermem_server" not in script
+
+
+def test_init_writes_absolute_sdk_log_paths_to_generated_env() -> None:
+    script = INIT_SH.read_text(encoding="utf-8")
+
+    assert 'f"LOGGING_FILE={path_value(\'powermem.log\')}"' in script
+    assert 'f"AUDIT_LOG_FILE={path_value(\'audit.log\')}"' in script
+    assert "LOGGING_FILE=./logs" not in script
+    assert "AUDIT_LOG_FILE=./logs" not in script

--- a/tests/unit/test_claude_plugin_uv_install.py
+++ b/tests/unit/test_claude_plugin_uv_install.py
@@ -347,6 +347,7 @@ def test_bootstrap_python_uses_uv_managed_python_by_default(tmp_path: Path) -> N
 
     result = run_common(
         """
+        detect_public_ip_country() { printf 'US\n'; }
         ensure_bootstrap_python
         printf 'BOOTSTRAP_PYTHON=%s\n' "$BOOTSTRAP_PYTHON"
         printf 'POWERMEM_BOOTSTRAP_PYTHON=%s\n' "$POWERMEM_BOOTSTRAP_PYTHON"
@@ -361,6 +362,82 @@ def test_bootstrap_python_uses_uv_managed_python_by_default(tmp_path: Path) -> N
     assert f"POWERMEM_BOOTSTRAP_PYTHON={uv_python}" in result.stdout
     assert "python install 3.11" in result.stdout
     assert "python find 3.11" in result.stdout
+
+
+def test_bootstrap_python_uses_ustc_python_install_mirror_for_cn(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    uv_python = tmp_path / "uv-python-3.11"
+    write_executable(
+        bin_dir / "uv",
+        f"""
+        #!/usr/bin/env sh
+        printf '%s MIRROR=%s\\n' "$*" "${{UV_PYTHON_INSTALL_MIRROR:-}}" >> "$HOME/uv_calls"
+        if [ "$1" = "python" ] && [ "$2" = "install" ]; then
+          exit 0
+        fi
+        if [ "$1" = "python" ] && [ "$2" = "find" ]; then
+          printf '%s\\n' "{uv_python}"
+          exit 0
+        fi
+        exit 1
+        """,
+    )
+
+    result = run_common(
+        """
+        detect_public_ip_country() { printf 'CN\n'; }
+        ensure_bootstrap_python
+        cat "$HOME/uv_calls"
+        """,
+        tmp_path,
+        bin_dir=bin_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "python install 3.11 MIRROR="
+        "https://mirrors.ustc.edu.cn/github-release/astral-sh/python-build-standalone/"
+    ) in result.stdout
+    assert "python find 3.11 MIRROR=" in result.stdout
+
+
+def test_bootstrap_python_allows_explicit_python_install_mirror(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    uv_python = tmp_path / "uv-python-3.11"
+    write_executable(
+        bin_dir / "uv",
+        f"""
+        #!/usr/bin/env sh
+        printf '%s MIRROR=%s\\n' "$*" "${{UV_PYTHON_INSTALL_MIRROR:-}}" >> "$HOME/uv_calls"
+        if [ "$1" = "python" ] && [ "$2" = "install" ]; then
+          exit 0
+        fi
+        if [ "$1" = "python" ] && [ "$2" = "find" ]; then
+          printf '%s\\n' "{uv_python}"
+          exit 0
+        fi
+        exit 1
+        """,
+    )
+
+    result = run_common(
+        """
+        POWERMEM_UV_PYTHON_INSTALL_MIRROR=https://example.invalid/python-build-standalone/
+        export POWERMEM_UV_PYTHON_INSTALL_MIRROR
+        detect_public_ip_country() { printf 'CN\n'; }
+        ensure_bootstrap_python
+        cat "$HOME/uv_calls"
+        """,
+        tmp_path,
+        bin_dir=bin_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "python install 3.11 MIRROR="
+        "https://example.invalid/python-build-standalone/"
+    ) in result.stdout
+    assert "mirrors.ustc.edu.cn/github-release/astral-sh/python-build-standalone/" not in result.stdout
 
 
 def test_init_uses_uvx_launcher_instead_of_plugin_venv_install() -> None:

--- a/tests/unit/test_claude_plugin_uv_install.py
+++ b/tests/unit/test_claude_plugin_uv_install.py
@@ -1,0 +1,162 @@
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMMON_SH = ROOT / "apps" / "claude-code-plugin" / "scripts" / "common.sh"
+INIT_SH = ROOT / "apps" / "claude-code-plugin" / "scripts" / "init.sh"
+SCRIPT_ARG0 = ROOT / "apps" / "claude-code-plugin" / "scripts" / "init.sh"
+
+
+def run_common(script: str, tmp_path: Path, *, bin_dir: Path | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["PATH"] = f"{bin_dir or tmp_path / 'bin'}:/usr/bin:/bin"
+    env["POWERMEM_DATA_DIR"] = str(tmp_path / ".powermem")
+    command = textwrap.dedent(
+        f"""
+        set -eu
+        . "{COMMON_SH}"
+        {script}
+        """
+    )
+    return subprocess.run(
+        ["sh", "-c", command, str(SCRIPT_ARG0)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    path.chmod(0o755)
+
+
+def fake_curl_install_script() -> str:
+    return r"""
+        #!/usr/bin/env sh
+        printf '%s\n' "$*" > "$HOME/curl_args"
+        cat <<'INSTALL'
+        mkdir -p "$HOME/.local/bin"
+        cat > "$HOME/.local/bin/uv" <<'UV'
+        #!/usr/bin/env sh
+        echo fake-uv
+        UV
+        chmod +x "$HOME/.local/bin/uv"
+        printf '%s\n' "${UV_DOWNLOAD_URL:-}" > "$HOME/uv_download_url"
+        INSTALL
+    """
+
+
+def test_ensure_uv_reuses_existing_uv(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    write_executable(
+        bin_dir / "uv",
+        """
+        #!/usr/bin/env sh
+        echo existing-uv
+        """,
+    )
+
+    result = run_common(
+        """
+        ensure_uv
+        printf '%s\n' "$UV_BIN"
+        """,
+        tmp_path,
+        bin_dir=bin_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(bin_dir / "uv")
+    assert not (tmp_path / "curl_args").exists()
+
+
+def test_ensure_uv_installs_from_ustc_for_cn(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    write_executable(bin_dir / "curl", fake_curl_install_script())
+
+    result = run_common(
+        """
+        detect_public_ip_country() { printf 'CN\n'; }
+        ensure_uv
+        printf 'UV_BIN=%s\n' "$UV_BIN"
+        cat "$HOME/curl_args"
+        printf 'DOWNLOAD=%s\n' "$(cat "$HOME/uv_download_url")"
+        """,
+        tmp_path,
+        bin_dir=bin_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"UV_BIN={tmp_path}/.local/bin/uv" in result.stdout
+    assert "mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/uv-installer.sh" in result.stdout
+    assert "DOWNLOAD=https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/" in result.stdout
+
+
+def test_ensure_uv_installs_from_astral_for_non_cn(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    write_executable(bin_dir / "curl", fake_curl_install_script())
+
+    result = run_common(
+        """
+        detect_public_ip_country() { printf 'US\n'; }
+        ensure_uv
+        printf 'UV_BIN=%s\n' "$UV_BIN"
+        cat "$HOME/curl_args"
+        printf 'DOWNLOAD=%s\n' "$(cat "$HOME/uv_download_url")"
+        """,
+        tmp_path,
+        bin_dir=bin_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"UV_BIN={tmp_path}/.local/bin/uv" in result.stdout
+    assert "https://astral.sh/uv/install.sh" in result.stdout
+    assert "DOWNLOAD=" in result.stdout
+    assert "mirrors.ustc.edu.cn" not in result.stdout
+
+
+def test_uvx_run_uses_tuna_index_for_cn(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    write_executable(
+        bin_dir / "uv",
+        """
+        #!/usr/bin/env sh
+        printf '%s\n' "$*" > "$HOME/uv_args"
+        """,
+    )
+
+    result = run_common(
+        """
+        detect_public_ip_country() { printf 'CN\n'; }
+        uvx_run --python /tmp/python3.11 --from powermem[server,seekdb] powermem-server --host 127.0.0.1 --port 8848
+        cat "$HOME/uv_args"
+        """,
+        tmp_path,
+        bin_dir=bin_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith(
+        "tool run --default-index https://pypi.tuna.tsinghua.edu.cn/simple "
+        "--python /tmp/python3.11 --from powermem[server,seekdb] "
+        "powermem-server --host 127.0.0.1 --port 8848"
+    )
+
+
+def test_init_uses_uvx_launcher_instead_of_plugin_venv_install() -> None:
+    script = INIT_SH.read_text(encoding="utf-8")
+
+    assert 'tool run \\' in script
+    assert "--from \"$PACKAGE\"" in script
+    assert "powermem-server --host 127.0.0.1 --port \"$port\"" in script
+    assert "uv_pip_install" not in script
+    assert "venv_powermem_server" not in script

--- a/tests/unit/test_claude_plugin_uv_install.py
+++ b/tests/unit/test_claude_plugin_uv_install.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 COMMON_SH = ROOT / "apps" / "claude-code-plugin" / "scripts" / "common.sh"
 INIT_SH = ROOT / "apps" / "claude-code-plugin" / "scripts" / "init.sh"
+STOP_SH = ROOT / "apps" / "claude-code-plugin" / "scripts" / "stop.sh"
 RUN_HOOK_SH = ROOT / "apps" / "claude-code-plugin" / "hooks" / "run-hook.sh"
 SCRIPT_ARG0 = ROOT / "apps" / "claude-code-plugin" / "scripts" / "init.sh"
 
@@ -38,6 +39,33 @@ def write_executable(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(textwrap.dedent(content), encoding="utf-8")
     path.chmod(0o755)
+
+
+def run_stop_script(tmp_path: Path, *, bin_dir: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["PATH"] = f"{bin_dir}:/usr/bin:/bin"
+    env["POWERMEM_DATA_DIR"] = str(tmp_path / ".powermem")
+    command = textwrap.dedent(
+        f"""
+        set -eu
+        kill() {{
+          printf '%s\\n' "$*" >> "$HOME/kill_calls"
+          return 0
+        }}
+        sleep() {{ :; }}
+        . "{STOP_SH}"
+        """
+    )
+    return subprocess.run(
+        ["sh", "-c", command, str(STOP_SH)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
 
 
 def fake_curl_install_script() -> str:
@@ -438,6 +466,79 @@ def test_bootstrap_python_allows_explicit_python_install_mirror(tmp_path: Path) 
         "https://example.invalid/python-build-standalone/"
     ) in result.stdout
     assert "mirrors.ustc.edu.cn/github-release/astral-sh/python-build-standalone/" not in result.stdout
+
+
+def test_stop_script_stops_orphaned_powermem_server_on_runtime_port(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    data_dir = tmp_path / ".powermem"
+    data_dir.mkdir()
+    (data_dir / "runtime.env").write_text("POWERMEM_BASE_URL=http://localhost:18848\n", encoding="utf-8")
+    write_executable(
+        bin_dir / "lsof",
+        """
+        #!/usr/bin/env sh
+        printf '%s\\n' "$*" > "$HOME/lsof_args"
+        printf '4242\\n'
+        """,
+    )
+    write_executable(
+        bin_dir / "ps",
+        """
+        #!/usr/bin/env sh
+        if [ "$1" = "-p" ] && [ "$2" = "4242" ]; then
+          printf '/usr/bin/powermem-server --host 127.0.0.1 --port 18848\\n'
+          exit 0
+        fi
+        exit 1
+        """,
+    )
+    write_executable(bin_dir / "ss", "#!/usr/bin/env sh\nexit 1\n")
+    write_executable(bin_dir / "fuser", "#!/usr/bin/env sh\nexit 1\n")
+
+    result = run_stop_script(tmp_path, bin_dir=bin_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert "Stopping orphaned PowerMem server PID 4242 on port 18848" in result.stdout
+    assert "No managed PowerMem server is running." not in result.stdout
+    assert (tmp_path / "kill_calls").read_text(encoding="utf-8").splitlines() == [
+        "4242",
+        "-0 4242",
+        "-9 4242",
+    ]
+    assert "-tiTCP:18848" in (tmp_path / "lsof_args").read_text(encoding="utf-8")
+
+
+def test_stop_script_ignores_non_powermem_listener_on_runtime_port(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    data_dir = tmp_path / ".powermem"
+    data_dir.mkdir()
+    (data_dir / "runtime.env").write_text("POWERMEM_BASE_URL=http://localhost:18849\n", encoding="utf-8")
+    write_executable(
+        bin_dir / "lsof",
+        """
+        #!/usr/bin/env sh
+        printf '4242\\n'
+        """,
+    )
+    write_executable(
+        bin_dir / "ps",
+        """
+        #!/usr/bin/env sh
+        if [ "$1" = "-p" ] && [ "$2" = "4242" ]; then
+          printf 'python3 -m http.server 18849\\n'
+          exit 0
+        fi
+        exit 1
+        """,
+    )
+    write_executable(bin_dir / "ss", "#!/usr/bin/env sh\nexit 1\n")
+    write_executable(bin_dir / "fuser", "#!/usr/bin/env sh\nexit 1\n")
+
+    result = run_stop_script(tmp_path, bin_dir=bin_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert "No managed PowerMem server is running." in result.stdout
+    assert not (tmp_path / "kill_calls").exists()
 
 
 def test_init_uses_uvx_launcher_instead_of_plugin_venv_install() -> None:


### PR DESCRIPTION
## Summary

- Switch Claude Code plugin marketplace init from plugin-local venv installs to an uvx-style backend launcher using `uv tool run --from powermem[server,seekdb] powermem-server`.
- Keep the default storage path on embedded OceanBase/seekdb, add CN/non-CN uv installation guidance, and use TUNA as the CN default Python package index for uvx resolution.
- Update preload/status/reset/docs/SVG flowcharts and add unit coverage for uv install, CN mirror behavior, uvx invocation, and the no-venv init path.
- Synced the updated uvx section and SVG flowchart to Yuque: https://yuque.antfin.com/go/doc/528703254

## Validation

- `sh -n apps/claude-code-plugin/scripts/common.sh`
- `sh -n apps/claude-code-plugin/scripts/init.sh`
- `sh -n apps/claude-code-plugin/scripts/preload-model.sh`
- `sh -n apps/claude-code-plugin/scripts/status.sh`
- `pytest -q tests/unit/test_claude_plugin_uv_install.py`
- XML parse for `apps/claude-code-plugin/init-flow.svg` and `apps/claude-code-plugin/uv-init-flow.svg`
- `git diff --check -- apps/claude-code-plugin docs/integrations/claude_code.md tests/unit/test_claude_plugin_uv_install.py`
- `claude plugin validate apps/claude-code-plugin`
- `claude plugin validate .`