### PR TITLE
Fix unit test regressions

### DIFF
--- a/src/powermem/integrations/llm/anthropic.py
+++ b/src/powermem/integrations/llm/anthropic.py
@@ -53,6 +53,11 @@ class AnthropicLLM(LLMBase):
         else:
             client_kwargs["api_key"] = api_key
         self.client = anthropic.Anthropic(**client_kwargs)
+        if not auth_token:
+            # The Anthropic SDK also reads ANTHROPIC_AUTH_TOKEN from the process
+            # environment. PowerMem gives API keys precedence, so clear any SDK
+            # env-derived bearer token when this instance is using an API key.
+            self.client.auth_token = None
 
     def generate_response(
             self,

--- a/tests/unit/server/test_server_cli.py
+++ b/tests/unit/server/test_server_cli.py
@@ -1,6 +1,8 @@
+import os
 import socket
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, Mock
 
 import click
@@ -296,6 +298,13 @@ def test_cli_help_documents_browser_options():
 
 
 def test_cli_module_import_does_not_require_server_extras():
+    src_path = str(Path(__file__).resolve().parents[3] / "src")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
+    )
     script = (
         "import sys; "
         "sys.modules['fastapi'] = None; "
@@ -305,6 +314,7 @@ def test_cli_module_import_does_not_require_server_extras():
 
     result = subprocess.run(
         [sys.executable, "-c", script],
+        env=env,
         capture_output=True,
         text=True,
         check=False,


### PR DESCRIPTION
## Summary

Fix two main-branch unit test regressions that showed up while validating PR #1011.

Changes:
- Make `test_cli_module_import_does_not_require_server_extras` force the subprocess to import this checkout via `PYTHONPATH=<repo>/src`, avoiding accidental imports from an installed `server` package in user site-packages.
- Ensure `AnthropicLLM` really gives API keys precedence over `ANTHROPIC_AUTH_TOKEN` by clearing the Anthropic SDK env-derived bearer token when this instance is configured for API-key auth.

## Validation

- `pytest -q tests/unit/server/test_server_cli.py::test_cli_module_import_does_not_require_server_extras tests/unit/test_anthropic.py::test_anthropic_llm_api_key_from_env_takes_precedence`
- `pytest -q tests/unit/server/test_server_cli.py tests/unit/test_anthropic.py`
- `pytest -q tests/unit`
- `flake8 src/powermem/integrations/llm/anthropic.py tests/unit/server/test_server_cli.py --select=F601,F821,E999`
- `git diff --check`