### PR TITLE
fix: stabilize regression server restarts

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -160,6 +160,7 @@ jobs:
           set_env_var LLM_API_KEY "${SILICONFLOW_CN_API_KEY}"
           set_env_var EMBEDDING_API_KEY "${QWEN_API_KEY}"
           set_env_var POWERMEM_SERVER_API_KEYS key1,key2,key3
+          set_env_var POWERMEM_SERVER_WORKERS 1
 
       - name: Run regression tests
         id: run_tests
@@ -314,6 +315,7 @@ jobs:
           set_env_var LLM_API_KEY "${SILICONFLOW_CN_API_KEY}"
           set_env_var EMBEDDING_API_KEY "${QWEN_API_KEY}"
           set_env_var POWERMEM_SERVER_API_KEYS key1,key2,key3
+          set_env_var POWERMEM_SERVER_WORKERS 1
 
       - name: Run regression tests
         id: run_tests

--- a/Makefile
+++ b/Makefile
@@ -277,12 +277,13 @@ server-start: ## Start the PowerMem API server
 		echo "Use 'make server-stop' to stop it first, or 'make server-restart' to restart"; \
 		exit 1; \
 	fi
-	@powermem-server --host $(SERVER_HOST) --port $(SERVER_PORT) --workers $(SERVER_WORKERS) $(SERVER_BROWSER_ARGS) > /dev/null 2>&1 & \
+	@powermem-server --host $(SERVER_HOST) --port $(SERVER_PORT) --workers $(SERVER_WORKERS) $(SERVER_BROWSER_ARGS) >> server.log 2>&1 & \
 	echo $$! > $(SERVER_PID_FILE); \
 	echo "Server started with PID: $$!"; \
 	echo "Server running at http://$(SERVER_HOST):$(SERVER_PORT)"; \
 	echo "API docs available at http://$(SERVER_HOST):$(SERVER_PORT)/docs"; \
-	echo "Logs are being written to server.log (configured via POWERMEM_SERVER_LOG_FILE)"; \
+	echo "Process output is appended to server.log"; \
+	echo "Structured logs are configured via POWERMEM_SERVER_LOG_FILE"; \
 	echo "Use 'make server-stop' to stop the server"
 
 server-start-reload: ## Start the PowerMem API server with auto-reload (development mode)
@@ -292,12 +293,13 @@ server-start-reload: ## Start the PowerMem API server with auto-reload (developm
 		echo "Use 'make server-stop' to stop it first"; \
 		exit 1; \
 	fi
-	@powermem-server --host $(SERVER_HOST) --port $(SERVER_PORT) --reload $(SERVER_BROWSER_ARGS) > /dev/null 2>&1 & \
+	@powermem-server --host $(SERVER_HOST) --port $(SERVER_PORT) --reload $(SERVER_BROWSER_ARGS) >> server.log 2>&1 & \
 	echo $$! > $(SERVER_PID_FILE); \
 	echo "Server started with PID: $$! (auto-reload enabled)"; \
 	echo "Server running at http://$(SERVER_HOST):$(SERVER_PORT)"; \
 	echo "API docs available at http://$(SERVER_HOST):$(SERVER_PORT)/docs"; \
-	echo "Logs are being written to server.log (configured via POWERMEM_SERVER_LOG_FILE)"; \
+	echo "Process output is appended to server.log"; \
+	echo "Structured logs are configured via POWERMEM_SERVER_LOG_FILE"; \
 	echo "Use 'make server-stop' to stop the server"
 
 server-stop: ## Stop the PowerMem API server

--- a/tests/regression/test_api.py
+++ b/tests/regression/test_api.py
@@ -12,11 +12,13 @@ Tests basic functionality of all API endpoints, including:
 
 import requests
 import json
+import socket
 import time
 import os
 import subprocess
 from typing import Dict, Any, Optional
 from datetime import datetime
+from urllib.parse import urlparse
 
 
 class APITester:
@@ -1880,7 +1882,71 @@ class APITester:
             self.log_result("Validation Error-Limit Exceeded", False, f"Exception: {str(e)}")
     
     # ==================== Run All Tests ====================
-    
+
+    def _server_host_port(self):
+        parsed_url = urlparse(self.base_url)
+        host = parsed_url.hostname or "localhost"
+        port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
+        return host, port
+
+    def _server_port_accepts_connections(self) -> bool:
+        host, port = self._server_host_port()
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return True
+        except OSError:
+            return False
+
+    def _wait_for_server_port_release(self, timeout: int = 20) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if not self._server_port_accepts_connections():
+                return True
+            time.sleep(0.5)
+        return not self._server_port_accepts_connections()
+
+    def _kill_processes_on_server_port(self):
+        _, port = self._server_host_port()
+        try:
+            result = subprocess.run(
+                ["lsof", "-t", f"-i:{port}"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            print(f"Warning: unable to inspect port {port} processes: {exc}")
+            return
+
+        pids = sorted({pid.strip() for pid in result.stdout.splitlines() if pid.strip()})
+        if not pids:
+            return
+
+        print(f"Port {port} is still occupied by PID(s): {', '.join(pids)}")
+        subprocess.run(["kill", *pids], capture_output=True, text=True, timeout=5)
+        time.sleep(1)
+        subprocess.run(["kill", "-9", *pids], capture_output=True, text=True, timeout=5)
+
+    def _print_server_log_tail(self, makefile_dir: str, lines: int = 120):
+        log_path = os.path.join(makefile_dir, "server.log")
+        if not os.path.exists(log_path):
+            print(f"server.log not found at {log_path}")
+            return
+
+        try:
+            result = subprocess.run(
+                ["tail", "-n", str(lines), log_path],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            print(f"\nLast {lines} lines of server.log:")
+            print(result.stdout)
+            if result.stderr:
+                print(f"tail stderr: {result.stderr}")
+        except Exception as exc:
+            print(f"Warning: failed to read server.log: {exc}")
+
     def restart_server(self):
         """
         Restart server: execute make server-stop and make server-start
@@ -1926,9 +1992,14 @@ class APITester:
                 if result_stop.stdout:
                     print(f"Output: {result_stop.stdout.strip()}")
             
-            # Wait for server to stop
-            print("Waiting for server to stop...")
-            time.sleep(2)
+            # Wait until the old server has actually released the port. In CI,
+            # uvicorn workers may outlive the parent PID for a short window.
+            print("Waiting for server port to be released...")
+            if not self._wait_for_server_port_release(timeout=20):
+                self._kill_processes_on_server_port()
+                if not self._wait_for_server_port_release(timeout=10):
+                    print("Error: server port is still occupied after stop")
+                    return False
             
             # Execute make server-start
             print(f"Executing: make server-start (in directory: {makefile_dir})")
@@ -1944,6 +2015,7 @@ class APITester:
                 print(f"Warning: make server-start returned non-zero exit code: {result_start.returncode}")
                 if result_start.stderr:
                     print(f"Error message: {result_start.stderr}")
+                self._print_server_log_tail(makefile_dir)
                 return False
             else:
                 print("✓ make server-start executed successfully")
@@ -1970,6 +2042,7 @@ class APITester:
                     print(f"Waiting for server to start... (attempt {attempt + 1}/{max_retries}, error: {e})")
             
             print(f"Error: Server failed to start within {max_retries * retry_interval} seconds")
+            self._print_server_log_tail(makefile_dir)
             print("Please manually check server status")
             return False
             


### PR DESCRIPTION
## Summary

Stabilizes the main-branch Regression Tests workflow around API server restarts.

## Root cause

`tests/regression/test_api.py` switches the API server from auth-disabled to auth-enabled mode mid-suite. On CI the server runs with multiple uvicorn workers by default, and `make server-stop` only kills the PID stored in `.server.pid`. A worker can keep the port busy briefly after the parent exits, while the test waits a fixed 2 seconds before starting the server again. When the restart fails, `make server-start` previously redirected process output to `/dev/null`, so the run only showed connection refused.

## Changes

- Set `POWERMEM_SERVER_WORKERS=1` in the Regression Tests jobs to make CI restarts deterministic.
- Make `APITester.restart_server()` wait for the server port to be released before starting again, and clear lingering port holders if needed.
- Print the tail of `server.log` when server start or readiness checks fail.
- Append `powermem-server` process output to `server.log` instead of discarding it.

## Validation

- `python3.11 -m py_compile tests/regression/test_api.py`
- `python3.11 -m pytest tests/unit/server/test_server_cli.py -q`
- `make -n server-start SERVER_PORT=8899`
- Local smoke: `make server-start SERVER_HOST=127.0.0.1 SERVER_PORT=8899 SERVER_WORKERS=1`, health check, then `make server-stop`
- `git diff --check`

`flake8` was not available in the local environment (`No module named flake8`).
