### PR TITLE
fix: harden regression server restart handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,8 @@ SERVER_HOST := $(or $(ENV_SERVER_HOST),0.0.0.0)
 SERVER_PORT := $(or $(ENV_SERVER_PORT),8848)
 SERVER_WORKERS := $(or $(ENV_SERVER_WORKERS),4)
 SERVER_BROWSER_ARGS ?=
+SERVER_PORT_LISTEN_PIDS = lsof -nP -t -iTCP:$(SERVER_PORT) -sTCP:LISTEN 2>/dev/null || true
+SERVER_PORT_BIND_CHECK = $(PYTHON) -c 'import socket, sys; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); s.bind(("0.0.0.0", int(sys.argv[1]))); s.close()' $(SERVER_PORT)
 
 server-start: ## Start the PowerMem API server
 	@echo "Starting PowerMem API server..."
@@ -277,9 +279,26 @@ server-start: ## Start the PowerMem API server
 		echo "Use 'make server-stop' to stop it first, or 'make server-restart' to restart"; \
 		exit 1; \
 	fi
-	@powermem-server --host $(SERVER_HOST) --port $(SERVER_PORT) --workers $(SERVER_WORKERS) $(SERVER_BROWSER_ARGS) >> server.log 2>&1 & \
-	echo $$! > $(SERVER_PID_FILE); \
-	echo "Server started with PID: $$!"; \
+	@PORT_PID=$$($(SERVER_PORT_LISTEN_PIDS)); \
+	if [ -n "$$PORT_PID" ]; then \
+		echo "Port $(SERVER_PORT) is already in use by PID(s): $$PORT_PID"; \
+		exit 1; \
+	fi; \
+	if ! $(SERVER_PORT_BIND_CHECK) >/dev/null 2>&1; then \
+		echo "Port $(SERVER_PORT) is not available for binding"; \
+		exit 1; \
+	fi; \
+	powermem-server --host $(SERVER_HOST) --port $(SERVER_PORT) --workers $(SERVER_WORKERS) $(SERVER_BROWSER_ARGS) >> server.log 2>&1 & \
+	PID=$$!; \
+	echo $$PID > $(SERVER_PID_FILE); \
+	sleep 1; \
+	if ! kill -0 $$PID 2>/dev/null; then \
+		echo "Server process exited during startup. Last 80 lines of server.log:"; \
+		tail -n 80 server.log 2>/dev/null || true; \
+		rm -f $(SERVER_PID_FILE); \
+		exit 1; \
+	fi; \
+	echo "Server started with PID: $$PID"; \
 	echo "Server running at http://$(SERVER_HOST):$(SERVER_PORT)"; \
 	echo "API docs available at http://$(SERVER_HOST):$(SERVER_PORT)/docs"; \
 	echo "Process output is appended to server.log"; \
@@ -293,9 +312,26 @@ server-start-reload: ## Start the PowerMem API server with auto-reload (developm
 		echo "Use 'make server-stop' to stop it first"; \
 		exit 1; \
 	fi
-	@powermem-server --host $(SERVER_HOST) --port $(SERVER_PORT) --reload $(SERVER_BROWSER_ARGS) >> server.log 2>&1 & \
-	echo $$! > $(SERVER_PID_FILE); \
-	echo "Server started with PID: $$! (auto-reload enabled)"; \
+	@PORT_PID=$$($(SERVER_PORT_LISTEN_PIDS)); \
+	if [ -n "$$PORT_PID" ]; then \
+		echo "Port $(SERVER_PORT) is already in use by PID(s): $$PORT_PID"; \
+		exit 1; \
+	fi; \
+	if ! $(SERVER_PORT_BIND_CHECK) >/dev/null 2>&1; then \
+		echo "Port $(SERVER_PORT) is not available for binding"; \
+		exit 1; \
+	fi; \
+	powermem-server --host $(SERVER_HOST) --port $(SERVER_PORT) --reload $(SERVER_BROWSER_ARGS) >> server.log 2>&1 & \
+	PID=$$!; \
+	echo $$PID > $(SERVER_PID_FILE); \
+	sleep 1; \
+	if ! kill -0 $$PID 2>/dev/null; then \
+		echo "Server process exited during startup. Last 80 lines of server.log:"; \
+		tail -n 80 server.log 2>/dev/null || true; \
+		rm -f $(SERVER_PID_FILE); \
+		exit 1; \
+	fi; \
+	echo "Server started with PID: $$PID (auto-reload enabled)"; \
 	echo "Server running at http://$(SERVER_HOST):$(SERVER_PORT)"; \
 	echo "API docs available at http://$(SERVER_HOST):$(SERVER_PORT)/docs"; \
 	echo "Process output is appended to server.log"; \
@@ -303,45 +339,59 @@ server-start-reload: ## Start the PowerMem API server with auto-reload (developm
 	echo "Use 'make server-stop' to stop the server"
 
 server-stop: ## Stop the PowerMem API server
-	@if [ ! -f $(SERVER_PID_FILE) ]; then \
-		echo "Server PID file not found. Checking for running processes..."; \
-		PID=$$(lsof -t -i:$(SERVER_PORT) 2>/dev/null || echo ""); \
-		if [ -z "$$PID" ]; then \
-			echo "No server process found on port $(SERVER_PORT)"; \
-			exit 0; \
-		else \
-			echo "Found process $$PID on port $(SERVER_PORT), stopping..."; \
-			kill $$PID 2>/dev/null || kill -9 $$PID 2>/dev/null; \
-			echo "Server stopped"; \
-			exit 0; \
-		fi; \
-	fi
-	@PID=$$(cat $(SERVER_PID_FILE) 2>/dev/null || echo ""); \
-	if [ -z "$$PID" ]; then \
-		echo "PID file exists but is empty"; \
-		rm -f $(SERVER_PID_FILE); \
-		exit 0; \
-	fi; \
-	if ps -p $$PID > /dev/null 2>&1; then \
+	@PID=$$(cat $(SERVER_PID_FILE) 2>/dev/null || true); \
+	if [ -n "$$PID" ] && ps -p $$PID > /dev/null 2>&1; then \
 		echo "Stopping server (PID: $$PID)..."; \
-		kill $$PID 2>/dev/null || kill -9 $$PID 2>/dev/null; \
-		sleep 1; \
-		if ps -p $$PID > /dev/null 2>&1; then \
-			echo "Force killing server (PID: $$PID)..."; \
-			kill -9 $$PID 2>/dev/null; \
-		fi; \
-		echo "Server stopped"; \
+		kill $$PID 2>/dev/null || true; \
 	else \
-		echo "Server process (PID: $$PID) not found (stale PID), cleaning up PID file"; \
-		PORT_PID=$$(lsof -t -i:$(SERVER_PORT) 2>/dev/null || echo ""); \
-		if [ -n "$$PORT_PID" ]; then \
-			echo "Found process $$PORT_PID on port $(SERVER_PORT), stopping it..."; \
-			kill $$PORT_PID 2>/dev/null || kill -9 $$PORT_PID 2>/dev/null; \
-			echo "Port $(SERVER_PORT) cleared"; \
+		if [ -f $(SERVER_PID_FILE) ]; then \
+			echo "Server process not found from PID file, checking port $(SERVER_PORT)..."; \
+		else \
+			echo "Server PID file not found. Checking port $(SERVER_PORT)..."; \
 		fi; \
 	fi; \
 	rm -f $(SERVER_PID_FILE); \
-	echo "✓ Server stopped"
+	for attempt in 1 2 3 4 5 6 7 8 9 10; do \
+		PID_ALIVE=0; \
+		if [ -n "$$PID" ] && ps -p $$PID > /dev/null 2>&1; then \
+			PID_ALIVE=1; \
+		fi; \
+		PORT_PID=$$($(SERVER_PORT_LISTEN_PIDS)); \
+		if [ -z "$$PORT_PID" ] && $(SERVER_PORT_BIND_CHECK) >/dev/null 2>&1; then \
+			echo "✓ Server stopped"; \
+			exit 0; \
+		fi; \
+		if [ "$$attempt" = "1" ] && [ -n "$$PORT_PID" ]; then \
+			echo "Found process(es) on port $(SERVER_PORT), stopping: $$PORT_PID"; \
+			kill $$PORT_PID 2>/dev/null || true; \
+		fi; \
+		if [ "$$attempt" = "10" ]; then \
+			if [ "$$PID_ALIVE" = "1" ]; then \
+				echo "Force killing server (PID: $$PID)..."; \
+				kill -9 $$PID 2>/dev/null || true; \
+			fi; \
+			if [ -n "$$PORT_PID" ]; then \
+				echo "Force killing process(es) on port $(SERVER_PORT): $$PORT_PID"; \
+				kill -9 $$PORT_PID 2>/dev/null || true; \
+			fi; \
+		fi; \
+		sleep 1; \
+	done; \
+	PORT_PID=$$($(SERVER_PORT_LISTEN_PIDS)); \
+	if [ -n "$$PORT_PID" ]; then \
+		echo "Force killing process(es) on port $(SERVER_PORT): $$PORT_PID"; \
+		kill -9 $$PORT_PID 2>/dev/null || true; \
+	fi; \
+	for attempt in 1 2 3 4 5; do \
+		PORT_PID=$$($(SERVER_PORT_LISTEN_PIDS)); \
+		if [ -z "$$PORT_PID" ] && $(SERVER_PORT_BIND_CHECK) >/dev/null 2>&1; then \
+			echo "✓ Server stopped"; \
+			exit 0; \
+		fi; \
+		sleep 1; \
+	done; \
+	echo "Error: port $(SERVER_PORT) is still occupied after server-stop"; \
+	exit 1
 
 server-restart: server-stop server-start ## Restart the PowerMem API server
 	@echo "✓ Server restarted"

--- a/src/server/cli/server.py
+++ b/src/server/cli/server.py
@@ -190,6 +190,9 @@ def _assert_bind_available(host: str, port: int) -> None:
     for family, socktype, proto, _canonname, sockaddr in addresses:
         probe = socket.socket(family, socktype, proto)
         try:
+            # Match uvicorn/asyncio TCP bind behavior so restart probes do not
+            # reject ports that are only held by reusable TCP shutdown state.
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             probe.bind(sockaddr)
         except OSError as exc:
             if _is_address_in_use(exc):

--- a/tests/regression/test_api.py
+++ b/tests/regression/test_api.py
@@ -1891,25 +1891,92 @@ class APITester:
 
     def _server_port_accepts_connections(self) -> bool:
         host, port = self._server_host_port()
+        targets = []
+
         try:
-            with socket.create_connection((host, port), timeout=1):
+            infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+            targets.extend((family, socktype, proto, sockaddr) for family, socktype, proto, _, sockaddr in infos)
+        except OSError as exc:
+            print(f"Warning: unable to resolve server host {host!r}: {exc}")
+
+        if host in {"localhost", "0.0.0.0", "::"}:
+            for loopback_host in ("127.0.0.1", "::1"):
+                try:
+                    infos = socket.getaddrinfo(loopback_host, port, type=socket.SOCK_STREAM)
+                    targets.extend((family, socktype, proto, sockaddr) for family, socktype, proto, _, sockaddr in infos)
+                except OSError:
+                    pass
+
+        seen = set()
+        for family, socktype, proto, sockaddr in targets:
+            key = (family, sockaddr)
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                with socket.socket(family, socktype, proto) as sock:
+                    sock.settimeout(1)
+                    sock.connect(sockaddr)
+                    return True
+            except OSError:
+                continue
+
+        return False
+
+    def _server_port_has_listener(self) -> bool:
+        _, port = self._server_host_port()
+        try:
+            result = subprocess.run(
+                ["lsof", "-nP", "-t", f"-iTCP:{port}", "-sTCP:LISTEN"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except FileNotFoundError:
+            return self._server_port_accepts_connections()
+        except subprocess.TimeoutExpired as exc:
+            print(f"Warning: timed out inspecting port {port}: {exc}")
+            return self._server_port_accepts_connections()
+
+        if result.returncode == 0:
+            return bool(result.stdout.strip())
+        if result.returncode == 1:
+            return False
+
+        print(f"Warning: lsof returned {result.returncode} while inspecting port {port}: {result.stderr.strip()}")
+        return self._server_port_accepts_connections()
+
+    def _server_port_can_bind(self) -> bool:
+        host, port = self._server_host_port()
+        bind_host = "0.0.0.0" if host in {"localhost", "127.0.0.1", "0.0.0.0"} else host
+        family = socket.AF_INET6 if ":" in bind_host else socket.AF_INET
+
+        try:
+            with socket.socket(family, socket.SOCK_STREAM) as sock:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                if family == socket.AF_INET6 and hasattr(socket, "IPV6_V6ONLY"):
+                    sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+                sock.bind((bind_host, port))
                 return True
         except OSError:
             return False
 
+    def _server_port_is_released(self) -> bool:
+        return not self._server_port_has_listener() and self._server_port_can_bind()
+
     def _wait_for_server_port_release(self, timeout: int = 20) -> bool:
         deadline = time.time() + timeout
         while time.time() < deadline:
-            if not self._server_port_accepts_connections():
+            if self._server_port_is_released():
                 return True
             time.sleep(0.5)
-        return not self._server_port_accepts_connections()
+        return self._server_port_is_released()
 
     def _kill_processes_on_server_port(self):
         _, port = self._server_host_port()
         try:
             result = subprocess.run(
-                ["lsof", "-t", f"-i:{port}"],
+                ["lsof", "-nP", "-t", f"-iTCP:{port}", "-sTCP:LISTEN"],
                 capture_output=True,
                 text=True,
                 timeout=5,

--- a/tests/unit/server/test_server_cli.py
+++ b/tests/unit/server/test_server_cli.py
@@ -192,6 +192,65 @@ def test_assert_bind_available_rejects_occupied_port():
     assert "choose another --port" in str(exc_info.value)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Windows has different TCP port reuse semantics",
+)
+def test_assert_bind_available_allows_reusable_shutdown_state():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    port = listener.getsockname()[1]
+    client = socket.create_connection(("127.0.0.1", port))
+    accepted, _address = listener.accept()
+
+    accepted.close()
+    client.close()
+    listener.close()
+
+    server_cli._assert_bind_available("127.0.0.1", port)
+
+
+def test_assert_bind_available_matches_uvicorn_reuseaddr(monkeypatch):
+    calls = []
+
+    class ProbeSocket:
+        def setsockopt(self, level, option, value):
+            calls.append(("setsockopt", level, option, value))
+
+        def bind(self, sockaddr):
+            calls.append(("bind", sockaddr))
+
+        def close(self):
+            calls.append(("close",))
+
+    monkeypatch.setattr(
+        server_cli.socket,
+        "getaddrinfo",
+        Mock(
+            return_value=[
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("0.0.0.0", 8848),
+                )
+            ]
+        ),
+    )
+    monkeypatch.setattr(server_cli.socket, "socket", Mock(return_value=ProbeSocket()))
+
+    server_cli._assert_bind_available("0.0.0.0", 8848)
+
+    assert calls == [
+        ("setsockopt", socket.SOL_SOCKET, socket.SO_REUSEADDR, 1),
+        ("bind", ("0.0.0.0", 8848)),
+        ("close",),
+    ]
+
+
 def test_cli_starts_one_browser_waiter_with_reload_and_workers(monkeypatch):
     runner = CliRunner()
     bind_available = Mock()


### PR DESCRIPTION
## Summary

Follow-up fix for the main-branch Regression Tests failure after #1034.

## Root cause

The failing main run still failed in `tests/regression/test_api.py::test_22_health_check_with_auth`. The new `server.log` output from #1034 showed the real startup error: port `8848` was still occupied on `0.0.0.0`.

The first fix waited by probing `localhost`, which can miss an IPv4 listener depending on address resolution. The follow-up check with `lsof LISTEN` still was not enough: during uvicorn graceful shutdown, the old process can stop reporting as a listener while the port is not yet bindable. Also, `make server-start` could return success even when the background server process quickly exited after a bind failure.

The next failed manual run showed one more mismatch: `make server-stop` and the regression helper correctly used a `SO_REUSEADDR` bind probe, but the CLI's `_assert_bind_available()` used a plain probe socket. Uvicorn itself also sets `SO_REUSEADDR`, so the CLI preflight could reject a port that uvicorn would be able to reuse immediately after restart.

## Changes

- Detect server port occupancy with `lsof -nP -iTCP:<port> -sTCP:LISTEN` before treating a stopped server as fully released.
- Verify the server port is actually bindable before restart proceeds.
- Keep socket probing as a fallback when `lsof` is unavailable.
- Make `make server-start` and `make server-start-reload` fail early when the target port is already occupied.
- Make server startup fail if the background process exits immediately, and print the tail of `server.log`.
- Make `make server-stop` run as one shell block, remove stale PID files, stop listeners on the target port, and wait for the port to become bindable.
- Align the CLI bind preflight with uvicorn by setting `SO_REUSEADDR` before probing the configured address.
- Add unit coverage for the reusable TCP shutdown window and for the exact `SO_REUSEADDR` probe behavior.

## Validation

- `python3.11 -m py_compile tests/regression/test_api.py`
- `python3.11 -m pytest tests/unit/server/test_server_cli.py -q`
- `make -n server-start SERVER_PORT=8899`
- `make -n server-stop SERVER_PORT=8899`
- Occupied-port smoke: local listener on `0.0.0.0:<port>` makes `make server-start` fail without leaving `.server.pid`
- Delayed-shutdown smoke: process keeps the port for several seconds after SIGTERM, and `make server-stop` waits until the port is bindable
- Local server smoke: `make server-start SERVER_HOST=127.0.0.1 SERVER_PORT=8899 SERVER_WORKERS=1`, retry health check until `200`, then `make server-stop`
- Restart-window smoke: create and close a TCP connection, then start the real server on the same port and verify `/api/v1/system/health` returns `200`
- `_assert_bind_available` smoke: reusable shutdown state is allowed, active listener is still rejected
- Manual GitHub Actions Regression Tests run: https://github.com/oceanbase/powermem/actions/runs/27608866170 passed (`test1`, `test2`, and `report`)
- `git diff --check`
