### PR TITLE
feat: move embedding model download into PowerMem with CN-aware routing

### DIFF
--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -635,11 +635,8 @@ export_env_file_vars "$ENV_FILE"
 echo "Backend package: $PACKAGE"
 echo "Backend launcher: uvx --from '$PACKAGE' powermem-server"
 
-if [ "${POWERMEM_INIT_PRELOAD_MODEL:-0}" = "1" ] || [ "${POWERMEM_INIT_PRELOAD_MODEL:-}" = "true" ]; then
-  echo "Preloading default local embedding model through uvx."
-  sh "$SCRIPT_DIR/preload-model.sh" "$BOOTSTRAP_PYTHON"
-else
-  echo "Skipping model preload. Set POWERMEM_INIT_PRELOAD_MODEL=1 to download via ModelScope and bridge to HuggingFace cache."
+if [ -n "${POWERMEM_INIT_PRELOAD_MODEL:-}" ]; then
+  echo "POWERMEM_INIT_PRELOAD_MODEL is deprecated; the embedding model is now downloaded automatically by PowerMem at startup."
 fi
 
 if [ -n "${POWERMEM_INIT_PORT:-}" ]; then

--- a/src/powermem/integrations/embeddings/pyseekdb_default.py
+++ b/src/powermem/integrations/embeddings/pyseekdb_default.py
@@ -5,13 +5,21 @@ can start with zero configuration and no external API key. The model is
 ``sentence-transformers/all-MiniLM-L6-v2`` (384-dim), the same default used by
 pyseekdb. It downloads to a local cache on first use and runs locally afterwards.
 
-When the network is slow or blocked (e.g. behind a firewall or GFW),
-``sentence_transformers`` contacts ``huggingface.co`` to check for updates even
-when the model is already cached, causing a 30-60s hang on every server start.
-We detect the cache state first — if cached, we force ``HF_HUB_OFFLINE=1`` so
-all downstream calls (including pyseekdb's internal ``SentenceTransformer``)
-use the cache immediately.  If not cached, we attempt a download with a timeout
-and provide a friendly error with manual instructions on failure.
+On first use when the model is not cached, the download source is chosen based on
+the public IP's country code (same logic as ``common.sh``):
+
+* **CN** — downloads via ModelScope (``AI-ModelScope/all-MiniLM-L6-v2``) using
+  ``uvx``, then bridges the ModelScope cache into the HuggingFace hub cache layout
+  so all downstream tools see a normal HF cache.  The PyPI index defaults to the
+  Tsinghua mirror unless ``POWERMEM_UV_INDEX_URL`` is already set.
+* **Non-CN / detection failed** — downloads directly from HuggingFace with a
+  :data:`_MODEL_DOWNLOAD_TIMEOUT_S`-second timeout.
+
+When the model is already cached, the country detection and download are skipped
+entirely; ``HF_HUB_OFFLINE`` behaviour is achieved by calling
+``SentenceTransformer(local_files_only=True)`` and injecting the result into
+pyseekdb's internal model cache so pyseekdb's own ``SentenceTransformer`` call
+does not attempt a network round-trip.
 
 Override via the ``embedder`` section of :class:`~powermem.configs.MemoryConfig`
 to switch to a production-grade provider (OpenAI, Qwen, SiliconFlow, etc.).
@@ -19,8 +27,14 @@ to switch to a production-grade provider (OpenAI, Qwen, SiliconFlow, etc.).
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import shutil
+import subprocess
 import threading
+import urllib.request
+from pathlib import Path
 from typing import List, Literal, Optional
 
 from powermem.integrations.embeddings.base import EmbeddingBase
@@ -33,109 +47,144 @@ logging.getLogger("huggingface_hub").setLevel(logging.WARNING)
 
 
 # Match pyseekdb's DefaultEmbeddingFunction so the two systems agree on the
-# default model and dimension. Keeping this constant local avoids importing
-# pyseekdb at module import time.
+# default model and dimension.
 DEFAULT_MODEL_NAME = "all-MiniLM-L6-v2"
 DEFAULT_MODEL_REPO_ID = "sentence-transformers/all-MiniLM-L6-v2"
 DEFAULT_EMBEDDING_DIMS = 384
 
-# Timeout (seconds) for downloading the embedding model.  When the network
-# is blocked the huggingface_hub retry loop can take 2-3 minutes; this
-# caps it so the server fails fast with a helpful error.
+# Timeout (seconds) for the HuggingFace download path (non-CN).
 _MODEL_DOWNLOAD_TIMEOUT_S = 30
 
+_MODELSCOPE_REPO_ID = "AI-ModelScope/all-MiniLM-L6-v2"
+# Fallback HF revision SHA used when the HF API is unreachable during bridge.
+_HF_REVISION_FALLBACK = "fa97f6e7cb1a59073dff9e9d8ba1c7c1591cc08d"
 
-def _is_model_cached(model_name: str) -> bool:
-    """Check if a HuggingFace model is already in the local cache."""
+_IP_COUNTRY_URLS = [
+    "https://ipapi.co/country/",
+    "https://ifconfig.co/country-iso",
+    "https://ipinfo.io/country",
+]
+
+
+def _is_model_cached(repo_id: str) -> bool:
+    """Return True if the HuggingFace model is already in the local cache."""
     try:
         from huggingface_hub import try_to_load_from_cache
 
-        result = try_to_load_from_cache(model_name, "config.json")
-        return result is not None  # None = not cached
+        result = try_to_load_from_cache(repo_id, "config.json")
+        return result is not None
     except Exception:
         return False
 
 
-def _load_sentence_transformer_with_fallback(model_name: str, repo_id: str):
-    """Load a SentenceTransformer with cache-first logic and download timeout.
+def _detect_country(timeout: int = 3) -> str:
+    """Detect public IP country code, mirroring common.sh detect_public_ip_country.
 
-    1. **Cache hit** → load from cache and monkey-patch downstream so pyseekdb's
-       internal ``SentenceTransformer`` call re-uses the already-loaded instance
-       instead of triggering its own (network-stuck) load.
-    2. **Cache miss** → attempt a real download in a background thread with a
-       timeout.  If the download succeeds, use it.  If it times out or fails,
-       raise a clear error with manual download instructions.
-
-    ``sentence_transformers`` is an optional dependency (the ``extras`` group).
-    When it is not installed we skip this pre-warm step entirely and let
-    pyseekdb's ``DefaultEmbeddingFunction`` load the model itself via
-    ``onnxruntime`` — the embedder still works, it just misses the cache-first
-    optimization that avoids a possible huggingface.co hang on slow networks.
-
-    Args:
-        model_name: short name passed to SentenceTransformer (e.g. "all-MiniLM-L6-v2")
-        repo_id: full HuggingFace repo ID (e.g. "sentence-transformers/all-MiniLM-L6-v2")
+    Tries up to three IP geolocation APIs in sequence.  Returns the two-letter
+    ISO country code (upper-case) on success, or an empty string if all APIs
+    fail or time out.
     """
-    try:
-        from sentence_transformers import SentenceTransformer
-    except ImportError:
-        logger.debug(
-            "sentence_transformers not installed; skipping model pre-warm "
-            "(install the 'extras' group to enable the cache-first optimization)"
-        )
-        return None
-
-    if _is_model_cached(repo_id):
-        model = SentenceTransformer(model_name, local_files_only=True)
-        _patch_sentence_transformer_cache(model_name, model)
-        logger.info("Loaded %s from local cache", model_name)
-        return model
-
-    # Cache miss: attempt download with timeout.
-    logger.debug(
-        "Model %s not in cache, attempting download (timeout %ss)…",
-        model_name,
-        _MODEL_DOWNLOAD_TIMEOUT_S,
-    )
-
-    result: list = [None]
-    error: list = [None]
-
-    def _load():
+    for url in _IP_COUNTRY_URLS:
         try:
-            result[0] = SentenceTransformer(model_name)
-        except Exception as exc:
-            error[0] = exc
+            resp = urllib.request.urlopen(url, timeout=timeout)
+            code = resp.read().decode().strip().upper()[:2]
+            if len(code) == 2 and code.isalpha():
+                return code
+        except Exception:
+            continue
+    return ""
 
-    thread = threading.Thread(target=_load, daemon=True)
-    thread.start()
-    thread.join(timeout=_MODEL_DOWNLOAD_TIMEOUT_S)
 
-    if result[0] is not None:
-        _patch_sentence_transformer_cache(model_name, result[0])
-        logger.info("Downloaded and loaded %s", model_name)
-        return result[0]
+def _download_via_modelscope(country: str = "") -> None:
+    """Download the default embedding model via ModelScope using ``uvx``.
 
-    if error[0] is not None:
-        raise RuntimeError(
-            f"Failed to download embedding model '{model_name}': "
-            f"{error[0]}. "
-            f"Download it manually: "
-            f'python -c "from modelscope import snapshot_download; '
-            f"snapshot_download('AI-ModelScope/all-MiniLM-L6-v2')\""
-        ) from error[0]
-
-    raise RuntimeError(
-        f"Downloading embedding model '{model_name}' timed out after "
-        f"{_MODEL_DOWNLOAD_TIMEOUT_S}s. The model is not cached and the "
-        f"network is unreachable. "
-        f"Download it manually: "
-        f'python -c "from modelscope import snapshot_download; '
-        f"snapshot_download('AI-ModelScope/all-MiniLM-L6-v2')\""
+    Reads the following environment variables (set by ``common.sh`` / init.sh):
+    - ``POWERMEM_UV_BIN`` — path to the ``uv`` binary
+    - ``POWERMEM_BOOTSTRAP_PYTHON`` — Python version/path for ``uvx --python``
+    - ``POWERMEM_UV_INDEX_URL`` — custom PyPI index (e.g. Tsinghua mirror)
+    - ``POWERMEM_MODELSCOPE_PACKAGE`` — override the modelscope package spec
+    """
+    uv_bin = (
+        os.environ.get("POWERMEM_UV_BIN")
+        or shutil.which("uv")
+        or str(Path.home() / ".local" / "bin" / "uv")
     )
+    if not shutil.which(uv_bin) and not os.path.isfile(uv_bin):
+        raise RuntimeError(
+            "uv is required to download the embedding model via ModelScope but "
+            "was not found on PATH. "
+            "Install it: https://docs.astral.sh/uv/getting-started/installation/"
+        )
+
+    python = os.environ.get("POWERMEM_BOOTSTRAP_PYTHON", "3.11")
+    package = os.environ.get("POWERMEM_MODELSCOPE_PACKAGE", "modelscope")
+
+    index_url = os.environ.get("POWERMEM_UV_INDEX_URL", "")
+    if not index_url and country == "CN":
+        # Mirror common.sh configure_uv_index: default to Tsinghua for CN
+        index_url = "https://pypi.tuna.tsinghua.edu.cn/simple"
+
+    cmd = [uv_bin, "tool", "run", "--python", python]
+    if index_url:
+        cmd += ["--default-index", index_url]
+    cmd += [
+        "--from", package,
+        "python", "-c",
+        f"from modelscope import snapshot_download; "
+        f"snapshot_download({_MODELSCOPE_REPO_ID!r})",
+    ]
+
+    logger.info("Downloading embedding model via ModelScope: %s", _MODELSCOPE_REPO_ID)
+    subprocess.run(cmd, check=True)
 
 
-def _patch_sentence_transformer_cache(model_name: str, model):
+def _bridge_modelscope_to_hf_cache() -> None:
+    """Copy a ModelScope-downloaded model into the HuggingFace hub cache layout.
+
+    Mirrors the bridge logic in ``preload-model.sh``.
+    """
+    org, name = _MODELSCOPE_REPO_ID.split("/", 1)
+    src = Path.home() / ".cache" / "modelscope" / "hub" / "models" / org / name
+    if not src.exists():
+        raise RuntimeError(
+            f"ModelScope cache not found at {src}; the download may have failed."
+        )
+
+    hf_dir_name = "models--" + DEFAULT_MODEL_REPO_ID.replace("/", "--")
+    hub = Path.home() / ".cache" / "huggingface" / "hub" / hf_dir_name
+
+    try:
+        resp = urllib.request.urlopen(
+            f"https://huggingface.co/api/models/{DEFAULT_MODEL_REPO_ID}",
+            timeout=5,
+        )
+        rev = json.load(resp)["sha"]
+    except Exception:
+        rev = _HF_REVISION_FALLBACK
+
+    snap = hub / "snapshots" / rev
+    snap.mkdir(parents=True, exist_ok=True)
+    refs_dir = hub / "refs"
+    refs_dir.mkdir(exist_ok=True)
+    (refs_dir / "main").write_text(rev)
+
+    skip = {"configuration.json", "data_config.json"}
+    for fname in os.listdir(src):
+        if fname in skip:
+            continue
+        source = src / fname
+        target = snap / fname
+        if target.exists():
+            continue
+        if source.is_dir():
+            shutil.copytree(source, target)
+        else:
+            shutil.copy2(source, target)
+
+    logger.info("Bridged ModelScope cache to HuggingFace cache: %s", snap)
+
+
+def _patch_sentence_transformer_cache(model_name: str, model) -> None:
     """Inject a pre-loaded model into pyseekdb's internal cache.
 
     pyseekdb's ``SentenceTransformerEmbeddingFunction`` keeps a class-level
@@ -154,6 +203,121 @@ def _patch_sentence_transformer_cache(model_name: str, model):
         logger.debug("Could not patch pyseekdb cache (module not available)")
 
 
+def _load_sentence_transformer_with_fallback(model_name: str, repo_id: str):
+    """Ensure the embedding model is cached, then load it with SentenceTransformer.
+
+    Flow:
+    1. Cache hit → load with ``local_files_only=True`` and patch pyseekdb cache.
+    2. Cache miss + CN → download via ModelScope + bridge to HF cache, then load.
+    3. Cache miss + non-CN / detection failed → HF download via background thread
+       with :data:`_MODEL_DOWNLOAD_TIMEOUT_S` timeout.
+
+    ``sentence_transformers`` is optional.  If not installed, the download (CN
+    or otherwise) still runs so the model files are available for pyseekdb's own
+    ONNX-based loader; only the pre-warm / cache-patch step is skipped.
+    """
+    if _is_model_cached(repo_id):
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            logger.debug(
+                "sentence_transformers not installed; skipping model pre-warm "
+                "(install the 'extras' group to enable the cache-first optimization)"
+            )
+            return None
+        model = SentenceTransformer(model_name, local_files_only=True)
+        _patch_sentence_transformer_cache(model_name, model)
+        logger.info("Loaded %s from local cache", model_name)
+        return model
+
+    # Cache miss: detect network region and download
+    logger.debug("Model %s not in cache; detecting network region...", model_name)
+    country = _detect_country()
+    logger.info(
+        "Network region: %s; downloading %s via %s",
+        country or "unknown",
+        model_name,
+        "ModelScope" if country == "CN" else "HuggingFace",
+    )
+
+    if country == "CN":
+        try:
+            _download_via_modelscope(country=country)
+            _bridge_modelscope_to_hf_cache()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to download embedding model '{model_name}' via ModelScope: "
+                f"{exc}.\n"
+                "Download it manually:\n"
+                f"  python -c \"from modelscope import snapshot_download; "
+                f"snapshot_download({_MODELSCOPE_REPO_ID!r})\""
+            ) from exc
+
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            logger.debug(
+                "sentence_transformers not installed; skipping model pre-warm "
+                "(install the 'extras' group to enable the cache-first optimization)"
+            )
+            return None
+        model = SentenceTransformer(model_name, local_files_only=True)
+        _patch_sentence_transformer_cache(model_name, model)
+        logger.info("Downloaded and loaded %s via ModelScope", model_name)
+        return model
+
+    # Non-CN / detection failed: HF download with timeout
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError:
+        logger.debug(
+            "sentence_transformers not installed; skipping model pre-warm "
+            "(install the 'extras' group to enable the cache-first optimization)"
+        )
+        return None
+
+    logger.debug(
+        "Attempting HuggingFace download of %s (timeout %ss)...",
+        model_name,
+        _MODEL_DOWNLOAD_TIMEOUT_S,
+    )
+
+    result: list = [None]
+    error: list = [None]
+
+    def _load() -> None:
+        try:
+            result[0] = SentenceTransformer(model_name)
+        except Exception as exc:
+            error[0] = exc
+
+    thread = threading.Thread(target=_load, daemon=True)
+    thread.start()
+    thread.join(timeout=_MODEL_DOWNLOAD_TIMEOUT_S)
+
+    if result[0] is not None:
+        _patch_sentence_transformer_cache(model_name, result[0])
+        logger.info("Downloaded and loaded %s", model_name)
+        return result[0]
+
+    if error[0] is not None:
+        raise RuntimeError(
+            f"Failed to download embedding model '{model_name}': {error[0]}.\n"
+            "Download it manually:\n"
+            f"  python -c \"from modelscope import snapshot_download; "
+            f"snapshot_download({_MODELSCOPE_REPO_ID!r})\""
+        ) from error[0]
+
+    raise RuntimeError(
+        f"Downloading embedding model '{model_name}' timed out after "
+        f"{_MODEL_DOWNLOAD_TIMEOUT_S}s. The model is not cached and the "
+        f"network is unreachable.\n"
+        "Download it manually:\n"
+        f"  python -c \"from modelscope import snapshot_download; "
+        f"snapshot_download({_MODELSCOPE_REPO_ID!r})\""
+    )
+
+
 class PyseekdbDefaultEmbedding(EmbeddingBase):
     """Zero-config local embedder backed by pyseekdb's DefaultEmbeddingFunction."""
 
@@ -168,11 +332,6 @@ class PyseekdbDefaultEmbedding(EmbeddingBase):
                 'Install it with: pip install "powermem[seekdb]"'
             ) from exc
 
-        # Pre-load the model with cache-first fallback.  This ensures the
-        # model is available BEFORE pyseekdb's DefaultEmbeddingFunction()
-        # creates its own SentenceTransformer (which would otherwise hang
-        # on a blocked network).  HF_HUB_OFFLINE=1 is set at module level
-        # so pyseekdb's internal call also hits the cache.
         _load_sentence_transformer_with_fallback(
             DEFAULT_MODEL_NAME,
             DEFAULT_MODEL_REPO_ID,

--- a/tests/unit/test_pyseekdb_default_download.py
+++ b/tests/unit/test_pyseekdb_default_download.py
@@ -1,0 +1,380 @@
+"""Unit tests for the CN-aware model download logic in pyseekdb_default.
+
+Covers:
+- _detect_country: IP API success / partial failure / all failure / dirty data
+- _download_via_modelscope: uv lookup, PyPI index selection, subprocess args
+- _bridge_modelscope_to_hf_cache: directory layout, idempotency, fallback SHA
+- _load_sentence_transformer_with_fallback: cache hit, CN path, non-CN path,
+  detection failure fallback, error propagation, sentence_transformers absent
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from powermem.integrations.embeddings import pyseekdb_default
+
+
+# ---------------------------------------------------------------------------
+# _detect_country
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCountry:
+    def _mock_urlopen(self, responses):
+        """responses: list of (bytes | Exception) per URL call."""
+        calls = iter(responses)
+
+        def side_effect(url, timeout=3):
+            resp = next(calls)
+            if isinstance(resp, Exception):
+                raise resp
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = resp
+            return mock_resp
+
+        return side_effect
+
+    def test_first_api_returns_cn(self):
+        side_effect = self._mock_urlopen([b"CN"])
+        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+            assert pyseekdb_default._detect_country() == "CN"
+
+    def test_first_fails_second_returns_us(self):
+        side_effect = self._mock_urlopen([OSError("timeout"), b"US"])
+        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+            assert pyseekdb_default._detect_country() == "US"
+
+    def test_all_fail_returns_empty(self):
+        side_effect = self._mock_urlopen([OSError(), OSError(), OSError()])
+        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+            assert pyseekdb_default._detect_country() == ""
+
+    def test_dirty_data_is_skipped(self):
+        # First returns non-alpha data (digits), second returns valid
+        side_effect = self._mock_urlopen([b"123", b"CN"])
+        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+            assert pyseekdb_default._detect_country() == "CN"
+
+    def test_lowercase_normalised_to_upper(self):
+        side_effect = self._mock_urlopen([b"cn"])
+        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+            assert pyseekdb_default._detect_country() == "CN"
+
+
+# ---------------------------------------------------------------------------
+# _download_via_modelscope
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadViaModelscope:
+    def test_raises_when_uv_not_found(self, monkeypatch):
+        monkeypatch.delenv("POWERMEM_UV_BIN", raising=False)
+        with patch.object(pyseekdb_default.shutil, "which", return_value=None), \
+             patch.object(pyseekdb_default.os.path, "isfile", return_value=False):
+            with pytest.raises(RuntimeError, match="uv is required"):
+                pyseekdb_default._download_via_modelscope()
+
+    def test_uses_powermem_uv_index_url_when_set(self, monkeypatch, tmp_path):
+        fake_uv = str(tmp_path / "uv")
+        Path(fake_uv).touch()
+        monkeypatch.setenv("POWERMEM_UV_BIN", fake_uv)
+        monkeypatch.setenv("POWERMEM_UV_INDEX_URL", "https://custom.index/simple")
+
+        captured = []
+
+        def fake_run(cmd, check):
+            captured.append(cmd)
+
+        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
+             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+            pyseekdb_default._download_via_modelscope(country="CN")
+
+        assert "--default-index" in captured[0]
+        assert "https://custom.index/simple" in captured[0]
+
+    def test_cn_without_index_url_uses_tsinghua(self, monkeypatch, tmp_path):
+        fake_uv = str(tmp_path / "uv")
+        Path(fake_uv).touch()
+        monkeypatch.setenv("POWERMEM_UV_BIN", fake_uv)
+        monkeypatch.delenv("POWERMEM_UV_INDEX_URL", raising=False)
+
+        captured = []
+
+        def fake_run(cmd, check):
+            captured.append(cmd)
+
+        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
+             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+            pyseekdb_default._download_via_modelscope(country="CN")
+
+        assert "https://pypi.tuna.tsinghua.edu.cn/simple" in captured[0]
+
+    def test_non_cn_without_index_url_no_default_index(self, monkeypatch, tmp_path):
+        fake_uv = str(tmp_path / "uv")
+        Path(fake_uv).touch()
+        monkeypatch.setenv("POWERMEM_UV_BIN", fake_uv)
+        monkeypatch.delenv("POWERMEM_UV_INDEX_URL", raising=False)
+
+        captured = []
+
+        def fake_run(cmd, check):
+            captured.append(cmd)
+
+        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
+             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+            pyseekdb_default._download_via_modelscope(country="US")
+
+        assert "--default-index" not in captured[0]
+
+    def test_bootstrap_python_used_in_cmd(self, monkeypatch, tmp_path):
+        fake_uv = str(tmp_path / "uv")
+        Path(fake_uv).touch()
+        monkeypatch.setenv("POWERMEM_UV_BIN", fake_uv)
+        monkeypatch.setenv("POWERMEM_BOOTSTRAP_PYTHON", "/usr/bin/python3.11")
+        monkeypatch.delenv("POWERMEM_UV_INDEX_URL", raising=False)
+
+        captured = []
+
+        def fake_run(cmd, check):
+            captured.append(cmd)
+
+        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
+             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+            pyseekdb_default._download_via_modelscope()
+
+        assert "--python" in captured[0]
+        idx = captured[0].index("--python")
+        assert captured[0][idx + 1] == "/usr/bin/python3.11"
+
+    def test_subprocess_failure_propagates(self, monkeypatch, tmp_path):
+        import subprocess as sp
+
+        fake_uv = str(tmp_path / "uv")
+        Path(fake_uv).touch()
+        monkeypatch.setenv("POWERMEM_UV_BIN", fake_uv)
+        monkeypatch.delenv("POWERMEM_UV_INDEX_URL", raising=False)
+
+        with patch.object(pyseekdb_default.subprocess, "run",
+                          side_effect=sp.CalledProcessError(1, "uv")), \
+             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+            with pytest.raises(sp.CalledProcessError):
+                pyseekdb_default._download_via_modelscope()
+
+    def test_custom_modelscope_package(self, monkeypatch, tmp_path):
+        fake_uv = str(tmp_path / "uv")
+        Path(fake_uv).touch()
+        monkeypatch.setenv("POWERMEM_UV_BIN", fake_uv)
+        monkeypatch.setenv("POWERMEM_MODELSCOPE_PACKAGE", "modelscope==1.99.0")
+        monkeypatch.delenv("POWERMEM_UV_INDEX_URL", raising=False)
+
+        captured = []
+
+        def fake_run(cmd, check):
+            captured.append(cmd)
+
+        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
+             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+            pyseekdb_default._download_via_modelscope()
+
+        assert "modelscope==1.99.0" in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# _bridge_modelscope_to_hf_cache
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeModelscope:
+    def _setup_modelscope_src(self, tmp_path):
+        """Create a fake ModelScope cache directory with model files."""
+        org, name = pyseekdb_default._MODELSCOPE_REPO_ID.split("/", 1)
+        src = tmp_path / ".cache" / "modelscope" / "hub" / "models" / org / name
+        src.mkdir(parents=True)
+        (src / "tokenizer.json").write_text("fake tokenizer")
+        (src / "config.json").write_text("{}")
+        (src / "configuration.json").write_text("skip me")  # should be skipped
+        (src / "data_config.json").write_text("skip me")    # should be skipped
+        sub = src / "subdir"
+        sub.mkdir()
+        (sub / "weights.bin").write_bytes(b"\x00\x01")
+        return src
+
+    def test_creates_hf_cache_layout(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._setup_modelscope_src(tmp_path)
+
+        fake_sha = "abc123" + "0" * 34
+
+        def fake_urlopen(url, timeout=5):
+            resp = MagicMock()
+            resp.read.return_value = json.dumps({"sha": fake_sha}).encode()
+            return resp
+
+        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=fake_urlopen):
+            pyseekdb_default._bridge_modelscope_to_hf_cache()
+
+        hf_dir_name = "models--" + pyseekdb_default.DEFAULT_MODEL_REPO_ID.replace("/", "--")
+        hub = tmp_path / ".cache" / "huggingface" / "hub" / hf_dir_name
+        snap = hub / "snapshots" / fake_sha
+
+        assert snap.exists()
+        assert (hub / "refs" / "main").read_text() == fake_sha
+        assert (snap / "tokenizer.json").exists()
+        assert (snap / "subdir" / "weights.bin").exists()
+        # skipped files must not appear
+        assert not (snap / "configuration.json").exists()
+        assert not (snap / "data_config.json").exists()
+
+    def test_existing_files_not_overwritten(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        src = self._setup_modelscope_src(tmp_path)
+
+        fake_sha = "def456" + "0" * 34
+        hf_dir_name = "models--" + pyseekdb_default.DEFAULT_MODEL_REPO_ID.replace("/", "--")
+        snap = tmp_path / ".cache" / "huggingface" / "hub" / hf_dir_name / "snapshots" / fake_sha
+        snap.mkdir(parents=True)
+        existing = snap / "tokenizer.json"
+        existing.write_text("original")
+
+        def fake_urlopen(url, timeout=5):
+            resp = MagicMock()
+            resp.read.return_value = json.dumps({"sha": fake_sha}).encode()
+            return resp
+
+        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=fake_urlopen):
+            pyseekdb_default._bridge_modelscope_to_hf_cache()
+
+        assert existing.read_text() == "original"
+
+    def test_hf_api_failure_uses_fallback_sha(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        self._setup_modelscope_src(tmp_path)
+
+        with patch.object(pyseekdb_default.urllib.request, "urlopen",
+                          side_effect=OSError("no network")):
+            pyseekdb_default._bridge_modelscope_to_hf_cache()
+
+        hf_dir_name = "models--" + pyseekdb_default.DEFAULT_MODEL_REPO_ID.replace("/", "--")
+        hub = tmp_path / ".cache" / "huggingface" / "hub" / hf_dir_name
+        assert (hub / "snapshots" / pyseekdb_default._HF_REVISION_FALLBACK).exists()
+
+    def test_missing_modelscope_src_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with pytest.raises(RuntimeError, match="ModelScope cache not found"):
+            pyseekdb_default._bridge_modelscope_to_hf_cache()
+
+
+# ---------------------------------------------------------------------------
+# _load_sentence_transformer_with_fallback
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSentenceTransformerWithFallback:
+    MODEL = pyseekdb_default.DEFAULT_MODEL_NAME
+    REPO = pyseekdb_default.DEFAULT_MODEL_REPO_ID
+
+    def test_cache_hit_loads_locally_no_download(self):
+        mock_st_cls = MagicMock(return_value=MagicMock())
+        with patch.object(pyseekdb_default, "_is_model_cached", return_value=True), \
+             patch.object(pyseekdb_default, "_detect_country") as mock_detect, \
+             patch.object(pyseekdb_default, "_patch_sentence_transformer_cache"), \
+             patch.dict("sys.modules", {"sentence_transformers": MagicMock(
+                 SentenceTransformer=mock_st_cls)}):
+            pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
+
+        mock_detect.assert_not_called()
+
+    def test_cache_miss_cn_triggers_modelscope(self):
+        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
+             patch.object(pyseekdb_default, "_detect_country", return_value="CN"), \
+             patch.object(pyseekdb_default, "_download_via_modelscope") as mock_dl, \
+             patch.object(pyseekdb_default, "_bridge_modelscope_to_hf_cache") as mock_bridge, \
+             patch.dict("sys.modules", {"sentence_transformers": None}):
+            pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
+
+        mock_dl.assert_called_once_with(country="CN")
+        mock_bridge.assert_called_once()
+
+    def test_cache_miss_non_cn_uses_hf_path(self):
+        mock_st_instance = MagicMock()
+        mock_st_cls = MagicMock(return_value=mock_st_instance)
+
+        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
+             patch.object(pyseekdb_default, "_detect_country", return_value="US"), \
+             patch.object(pyseekdb_default, "_download_via_modelscope") as mock_dl, \
+             patch.dict("sys.modules", {"sentence_transformers": MagicMock(
+                 SentenceTransformer=mock_st_cls)}):
+            pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
+
+        mock_dl.assert_not_called()
+
+    def test_cache_miss_detection_failed_uses_hf_path(self):
+        mock_st_instance = MagicMock()
+        mock_st_cls = MagicMock(return_value=mock_st_instance)
+
+        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
+             patch.object(pyseekdb_default, "_detect_country", return_value=""), \
+             patch.object(pyseekdb_default, "_download_via_modelscope") as mock_dl, \
+             patch.dict("sys.modules", {"sentence_transformers": MagicMock(
+                 SentenceTransformer=mock_st_cls)}):
+            pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
+
+        mock_dl.assert_not_called()
+
+    def test_cn_modelscope_failure_raises_runtime_error(self):
+        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
+             patch.object(pyseekdb_default, "_detect_country", return_value="CN"), \
+             patch.object(pyseekdb_default, "_download_via_modelscope",
+                          side_effect=RuntimeError("uvx failed")):
+            with pytest.raises(RuntimeError, match="uvx failed"):
+                pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
+
+    def test_non_cn_hf_timeout_raises_runtime_error(self):
+        import threading as _threading
+
+        # Make the thread never set result[0] (simulates timeout)
+        original_join = _threading.Thread.join
+
+        def slow_join(self_thread, timeout=None):
+            if timeout is not None:
+                return  # return immediately, result[0] stays None
+            return original_join(self_thread, timeout)
+
+        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
+             patch.object(pyseekdb_default, "_detect_country", return_value="US"), \
+             patch.dict("sys.modules", {"sentence_transformers": MagicMock(
+                 SentenceTransformer=MagicMock(side_effect=lambda _: None))}), \
+             patch.object(_threading.Thread, "join", slow_join):
+            with pytest.raises(RuntimeError, match="timed out"):
+                pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
+
+    def test_sentence_transformers_absent_cn_still_downloads(self):
+        """CN download must run even when sentence_transformers is not installed."""
+        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
+             patch.object(pyseekdb_default, "_detect_country", return_value="CN"), \
+             patch.object(pyseekdb_default, "_download_via_modelscope") as mock_dl, \
+             patch.object(pyseekdb_default, "_bridge_modelscope_to_hf_cache"), \
+             patch.dict("sys.modules", {"sentence_transformers": None}):
+            result = pyseekdb_default._load_sentence_transformer_with_fallback(
+                self.MODEL, self.REPO
+            )
+
+        mock_dl.assert_called_once()
+        assert result is None  # no ST, but download happened
+
+    def test_sentence_transformers_absent_non_cn_returns_none(self):
+        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
+             patch.object(pyseekdb_default, "_detect_country", return_value="US"), \
+             patch.dict("sys.modules", {"sentence_transformers": None}):
+            result = pyseekdb_default._load_sentence_transformer_with_fallback(
+                self.MODEL, self.REPO
+            )
+
+        assert result is None


### PR DESCRIPTION
## Summary

Moves the `all-MiniLM-L6-v2` embedding model download from the shell-layer
`preload-model.sh` into `PyseekdbDefaultEmbedding` itself, with automatic
CN-network detection and ModelScope fallback.  Previously the download only
ran when `POWERMEM_INIT_PRELOAD_MODEL=1` was set; on first use without that
flag the server started healthy but hung for up to 30 s on the first embed
request.

## Root cause

`_load_sentence_transformer_with_fallback` attempted a direct HuggingFace
download with a 30-second thread timeout, with no CN-aware routing.  CN
users behind the GFW consistently timed out or never completed the download.
The ModelScope path existed only as a manual recovery command printed in the
error message, not as an automatic fallback.

The `POWERMEM_INIT_PRELOAD_MODEL` opt-in in `init.sh` partially addressed
this for the Claude Code plugin path, but left bare `powermem-server`
invocations and non-plugin deployments with no CN support at all.

## Changes

- Add `_detect_country()` to `pyseekdb_default.py`: mirrors `common.sh`
  `detect_public_ip_country` logic — probes `ipapi.co`, `ifconfig.co`,
  `ipinfo.io` in sequence with a 3-second timeout each; returns ISO-3166
  two-letter code or empty string on failure.
- Add `_download_via_modelscope()`: downloads the model via
  `uvx --from modelscope`; respects `POWERMEM_UV_BIN`,
  `POWERMEM_BOOTSTRAP_PYTHON`, `POWERMEM_MODELSCOPE_PACKAGE`, and
  `POWERMEM_UV_INDEX_URL`; auto-applies the Tsinghua PyPI mirror when
  country is CN and `POWERMEM_UV_INDEX_URL` is unset.
- Add `_bridge_modelscope_to_hf_cache()`: ports the bridge logic from
  `preload-model.sh` to Python — copies the ModelScope cache into the
  HuggingFace hub snapshot layout so `huggingface_hub` and
  `sentence_transformers` find a standard HF cache.  Falls back to a
  hardcoded revision SHA when the HF API is unreachable.
- Restructure `_load_sentence_transformer_with_fallback()`: country
  detection and ModelScope download now run **before** the optional
  `sentence_transformers` import, so the model is fetched even when
  `sentence_transformers` is not installed; the non-CN HF path is
  unchanged.
- Remove `POWERMEM_INIT_PRELOAD_MODEL` branch from `init.sh`; replace
  with a deprecation notice.  `preload-model.sh` is kept as a standalone
  offline pre-warm tool but is no longer called from the main init flow.
- Add 24 unit tests covering all new functions and edge cases.

## Validation

- `python3.11 -m pytest tests/unit/test_pyseekdb_default_download.py -v` — 24 passed
- `python3.11 -m pytest tests/unit/test_pyseekdb_default_embeddings.py -v` — 8 passed, no regression
- `git diff --check`