### PR TITLE
feat: add NoopEmbedding provider for EMBEDDING_PROVIDER=none

### DIFF
--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -805,6 +805,20 @@ class Memory(MemoryBase):
         """Return True when PowerMem is running without LLM-backed features."""
         return self.llm_provider == "noop" or getattr(self.llm, "is_noop", False) is True
 
+    def _is_embedding_disabled(self) -> bool:
+        """Return True when embedding is explicitly disabled (EMBEDDING_PROVIDER=none)."""
+        return self.embedding_provider == "none" or getattr(self.embedding, "is_noop", False) is True
+
+    def _embed(self, text: str) -> Optional[List[float]]:
+        """Embed text, returning None when embedding is disabled or fails."""
+        if self._is_embedding_disabled():
+            return None
+        try:
+            return self.embedding.embed(text)
+        except Exception as e:
+            logger.warning("Embedding failed: %s", e)
+            return None
+
     def _get_component_config(self, component: str) -> Dict[str, Any]:
         """
         Helper method to get component configuration uniformly.
@@ -3054,8 +3068,8 @@ class Memory(MemoryBase):
             if not safe:
                 return {"title": title, "action": "blocked", "reason": reason}
 
-        title_emb = title_embedding if title_embedding is not None else self.embedding.embed(title)
-        desc_emb = description_embedding if description_embedding is not None else self.embedding.embed(description)
+        title_emb = title_embedding if title_embedding is not None else self._embed(title)
+        desc_emb = description_embedding if description_embedding is not None else self._embed(description)
 
         similar = self.skill_store.search(
             query_embedding=title_emb, query_text=title,
@@ -3075,8 +3089,8 @@ class Memory(MemoryBase):
                 merged_desc = merge_result.get("description") or description
                 merged_proc = merge_result.get("procedure") or procedure
                 merged_tags = list(set((tags or []) + (existing.get("tags") or [])))
-                merged_title_emb = self.embedding.embed(merged_title)
-                merged_desc_emb = self.embedding.embed(merged_desc)
+                merged_title_emb = self._embed(merged_title)
+                merged_desc_emb = self._embed(merged_desc)
                 self.skill_store.update(
                     existing["id"], merged_title, merged_desc,
                     tags=merged_tags, procedure_data=merged_proc,
@@ -3098,7 +3112,7 @@ class Memory(MemoryBase):
         """Search skills by embedding + fulltext."""
         if not self.skill_store:
             return []
-        query_emb = self.embedding.embed(query)
+        query_emb = self._embed(query)
         return self.skill_store.search(
             query_embedding=query_emb, query_text=query,
             limit=limit, user_id=user_id, agent_id=agent_id,

--- a/src/powermem/integrations/embeddings/config/providers.py
+++ b/src/powermem/integrations/embeddings/config/providers.py
@@ -292,5 +292,19 @@ class PyseekdbDefaultEmbeddingConfig(BaseEmbedderConfig):
     embedding_dims: Optional[int] = Field(default=384)
 
 
+class NoopEmbeddingConfig(BaseEmbedderConfig):
+    """Configuration for the disabled embedding provider (EMBEDDING_PROVIDER=none)."""
+
+    _provider_name = "none"
+    _class_path = "powermem.integrations.embeddings.noop.NoopEmbedding"
+
+    model_config = settings_config("EMBEDDING_", extra="allow", env_file=None)
+
+    model: Optional[str] = Field(
+        default="none",
+        description="Placeholder model name used when embedding is disabled.",
+    )
+
+
 class CustomEmbeddingConfig(BaseEmbedderConfig):
     model_config = settings_config("EMBEDDING_", extra="allow", env_file=None)

--- a/src/powermem/integrations/embeddings/factory.py
+++ b/src/powermem/integrations/embeddings/factory.py
@@ -41,6 +41,11 @@ class EmbedderFactory:
             value = getattr(embedder_config, 'embedding_dims', default)
             return default if value is None else value
         
+        # Handle none provider directly (embedding disabled)
+        if provider_name == "none":
+            from powermem.integrations.embeddings.noop import NoopEmbedding
+            return NoopEmbedding()
+
         # Handle mock provider directly
         if provider_name == "mock":
             # Extract dimension from vector_config or embedder config, default to 1536

--- a/src/powermem/integrations/embeddings/noop.py
+++ b/src/powermem/integrations/embeddings/noop.py
@@ -1,0 +1,27 @@
+from typing import List, Literal, Optional
+
+from powermem.integrations.embeddings.base import EmbeddingBase
+from powermem.integrations.embeddings.config.base import BaseEmbedderConfig
+
+
+class NoopEmbedding(EmbeddingBase):
+    """Embedding implementation used when embedding is explicitly disabled (provider='none')."""
+
+    is_noop = True
+
+    def __init__(self, config: Optional[BaseEmbedderConfig] = None):
+        super().__init__(config)
+
+    def embed(
+        self,
+        text,
+        memory_action: Optional[Literal["add", "search", "update"]] = None,
+    ) -> List[float]:
+        return []
+
+    def embed_batch(
+        self,
+        texts: List[str],
+        memory_action: Optional[Literal["add", "search", "update"]] = None,
+    ) -> List[List[float]]:
+        return [[] for _ in texts]

--- a/src/powermem/storage/adapter.py
+++ b/src/powermem/storage/adapter.py
@@ -106,14 +106,14 @@ class StorageAdapter:
 
         if vector is None:
             # No embedding provided, generate using embedding service
-            if self.embedding_service:
+            if self.embedding_service and not getattr(self.embedding_service, "is_noop", False):
                 try:
                     vector = self.embedding_service.embed(content, memory_action="add")
                 except Exception as e:
                     logger.warning(f"Failed to generate embedding, using mock vector: {e}")
                     vector = [0.1] * 1536  # Use 1536 dimensions for OceanBase compatibility
             else:
-                # No embedding service available, use mock vector
+                # No embedding service available (or disabled), use mock vector
                 vector = [0.1] * 1536
 
         # Generate sparse embedding if sparse embedder service is available

--- a/src/powermem/storage/adapter.py
+++ b/src/powermem/storage/adapter.py
@@ -104,8 +104,8 @@ class StorageAdapter:
         # Check if embedding is already provided (preferred way)
         vector = memory_data.get("embedding")
 
-        if vector is None:
-            # No embedding provided, generate using embedding service
+        if not vector:
+            # No embedding provided (or noop returned []), generate using embedding service
             if self.embedding_service and not getattr(self.embedding_service, "is_noop", False):
                 try:
                     vector = self.embedding_service.embed(content, memory_action="add")

--- a/tests/integration/test_noop_embedding_mode.py
+++ b/tests/integration/test_noop_embedding_mode.py
@@ -1,0 +1,96 @@
+"""Integration tests for the no-embedding mode (EMBEDDING_PROVIDER=none).
+
+Mirrors tests/integration/test_noop_llm_mode.py, but with the embedding
+provider disabled instead of the LLM.
+
+When embedding is disabled:
+- add() stores memories using a mock fallback vector
+- get() retrieves stored memories by ID
+- update() and delete() function normally
+- search() returns empty results (vector search requires embeddings)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from powermem import Memory
+from powermem.core.async_memory import AsyncMemory
+
+
+def _sqlite_noop_embedding_config(tmp_path):
+    return {
+        "vector_store": {
+            "provider": "sqlite",
+            "config": {
+                "database_path": str(tmp_path / "noop_embed.db"),
+                "collection_name": f"noop_embed_{uuid.uuid4().hex[:8]}",
+            },
+        },
+        "llm": {
+            "provider": "noop",
+            "config": {"model": "noop"},
+        },
+        "embedder": {
+            "provider": "none",
+        },
+    }
+
+
+def test_noop_embedding_preserves_basic_memory_crud(tmp_path):
+    memory = Memory(config=_sqlite_noop_embedding_config(tmp_path))
+
+    add_result = memory.add("User prefers dark mode", user_id="user_noop_embed")
+    assert len(add_result["results"]) == 1
+    memory_id = add_result["results"][0]["id"]
+
+    stored = memory.get(memory_id, user_id="user_noop_embed")
+    assert stored is not None
+    assert "dark mode" in stored.get("content", "")
+
+    update_result = memory.update(
+        memory_id, "User prefers light mode", user_id="user_noop_embed"
+    )
+    assert update_result is not None
+
+    assert memory.delete(memory_id, user_id="user_noop_embed") is True
+    assert memory.get(memory_id, user_id="user_noop_embed") is None
+
+
+def test_noop_embedding_search_returns_empty(tmp_path):
+    """Vector search must return empty results when embedding is disabled."""
+    memory = Memory(config=_sqlite_noop_embedding_config(tmp_path))
+
+    memory.add("User loves hiking", user_id="user_search_noop")
+
+    results = memory.search("hiking", user_id="user_search_noop")
+    assert results["results"] == []
+
+
+def test_noop_embedding_add_multiple_memories(tmp_path):
+    """Multiple adds must not interfere with each other under noop embedding."""
+    memory = Memory(config=_sqlite_noop_embedding_config(tmp_path))
+
+    for i in range(3):
+        result = memory.add(f"Memory entry {i}", user_id="user_multi_noop")
+        assert len(result["results"]) == 1
+
+    all_memories = memory.get_all(user_id="user_multi_noop")
+    assert len(all_memories["results"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_noop_embedding_async_crud(tmp_path):
+    memory = AsyncMemory(config=_sqlite_noop_embedding_config(tmp_path))
+
+    add_result = await memory.add("Async memory with no embedding", user_id="async_noop")
+    assert len(add_result["results"]) == 1
+    memory_id = add_result["results"][0]["id"]
+
+    stored = await memory.get(memory_id, user_id="async_noop")
+    assert stored is not None
+
+    assert await memory.delete(memory_id, user_id="async_noop") is True
+    assert await memory.get(memory_id, user_id="async_noop") is None

--- a/tests/unit/test_noop_embedding.py
+++ b/tests/unit/test_noop_embedding.py
@@ -163,3 +163,27 @@ def test_adapter_skips_embed_call_when_noop(tmp_path):
     })
 
     noop_embedder.embed.assert_not_called()
+
+
+def test_adapter_falls_back_to_mock_vector_when_precomputed_embedding_is_empty():
+    """When memory_data carries embedding=[] (returned by NoopEmbedding), adapter
+    must fall back to mock vector instead of passing vector_size=0 to the store."""
+    from powermem.storage.adapter import StorageAdapter
+
+    mock_store = MagicMock()
+    mock_store.collection_name = "test"
+    mock_store.insert.return_value = [1]
+
+    adapter = StorageAdapter(mock_store, embedding_service=None)
+    adapter.add_memory({
+        "content": "test memory",
+        "embedding": [],  # empty vector from NoopEmbedding
+        "user_id": "u1",
+        "agent_id": "",
+        "run_id": "",
+    })
+
+    # insert([vector], [payload]) must have been called with non-empty vector
+    mock_store.insert.assert_called_once()
+    stored_vector = mock_store.insert.call_args[0][0][0]
+    assert len(stored_vector) > 0, "adapter must not store a zero-length vector"

--- a/tests/unit/test_noop_embedding.py
+++ b/tests/unit/test_noop_embedding.py
@@ -5,8 +5,9 @@ Covers:
 - EmbedderFactory routing for provider="none"
 - BaseEmbedderConfig provider registry
 - config_loader env-var path (EMBEDDING_PROVIDER=none)
-- Memory._is_embedding_disabled / _embed helpers
+- Memory._is_embedding_disabled / _embed helpers (including exception handling)
 - StorageAdapter skips embed call when embedding is noop
+- StorageAdapter search returns [] for empty query_embedding
 """
 
 from __future__ import annotations
@@ -137,6 +138,19 @@ def test_embed_calls_embedding_when_enabled():
     assert result == [0.1] * 384
 
 
+def test_embed_returns_none_on_embedding_exception():
+    """_embed() must swallow exceptions from embed() and return None."""
+    mock_embedding = MagicMock()
+    mock_embedding.is_noop = False
+    mock_embedding.embed.side_effect = RuntimeError("model unavailable")
+    stub = _StubMemory(embedding=mock_embedding, embedding_provider="default")
+
+    result = stub._embed("hello")
+
+    assert result is None
+    mock_embedding.embed.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # StorageAdapter skips embed when noop
 # ---------------------------------------------------------------------------
@@ -187,3 +201,42 @@ def test_adapter_falls_back_to_mock_vector_when_precomputed_embedding_is_empty()
     mock_store.insert.assert_called_once()
     stored_vector = mock_store.insert.call_args[0][0][0]
     assert len(stored_vector) > 0, "adapter must not store a zero-length vector"
+
+
+def test_adapter_search_returns_empty_for_empty_query_embedding():
+    """search_memories with an empty query_embedding (returned by NoopEmbedding)
+    must return [] instead of attempting a vector search."""
+    from powermem.storage.adapter import StorageAdapter
+
+    mock_store = MagicMock()
+    mock_store.collection_name = "test"
+
+    adapter = StorageAdapter(mock_store, embedding_service=None)
+    result = adapter.search_memories(
+        query_embedding=[],  # empty from NoopEmbedding
+        user_id="u1",
+        query="anything",
+    )
+
+    assert result == []
+    mock_store.search.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# MemoryConfig with NoopEmbeddingConfig requires no API key
+# ---------------------------------------------------------------------------
+
+
+def test_memory_config_none_embedding_requires_no_api_key(monkeypatch):
+    """MemoryConfig with EMBEDDING_PROVIDER=none must not require an API key."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("EMBEDDING_API_KEY", raising=False)
+
+    from powermem.configs import MemoryConfig
+    from powermem.integrations.embeddings.config.providers import NoopEmbeddingConfig
+
+    cfg = MemoryConfig(embedder=NoopEmbeddingConfig())
+
+    assert isinstance(cfg.embedder, NoopEmbeddingConfig)
+    assert cfg.embedder.provider == "none"
+    assert cfg.embedder.api_key is None

--- a/tests/unit/test_noop_embedding.py
+++ b/tests/unit/test_noop_embedding.py
@@ -1,0 +1,165 @@
+"""Unit tests for the NoopEmbedding provider (EMBEDDING_PROVIDER=none).
+
+Covers:
+- NoopEmbedding.is_noop flag and return values
+- EmbedderFactory routing for provider="none"
+- BaseEmbedderConfig provider registry
+- config_loader env-var path (EMBEDDING_PROVIDER=none)
+- Memory._is_embedding_disabled / _embed helpers
+- StorageAdapter skips embed call when embedding is noop
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import powermem.config_loader as config_loader
+import powermem.settings as settings
+from powermem.integrations.embeddings.config.base import BaseEmbedderConfig
+from powermem.integrations.embeddings.factory import EmbedderFactory
+from powermem.integrations.embeddings.noop import NoopEmbedding
+
+
+# ---------------------------------------------------------------------------
+# NoopEmbedding basics
+# ---------------------------------------------------------------------------
+
+
+def test_noop_embedding_has_is_noop_flag():
+    e = NoopEmbedding()
+    assert e.is_noop is True
+
+
+def test_noop_embedding_embed_returns_empty_list():
+    e = NoopEmbedding()
+    assert e.embed("hello world") == []
+
+
+def test_noop_embedding_embed_batch_returns_empty_lists():
+    e = NoopEmbedding()
+    assert e.embed_batch(["a", "b", "c"]) == [[], [], []]
+
+
+def test_noop_embedding_embed_batch_empty_input():
+    e = NoopEmbedding()
+    assert e.embed_batch([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Factory and registry
+# ---------------------------------------------------------------------------
+
+
+def test_factory_returns_noop_embedding_for_none_provider():
+    e = EmbedderFactory.create("none", None, None)
+    assert isinstance(e, NoopEmbedding)
+    assert e.is_noop is True
+
+
+def test_noop_provider_is_registered():
+    import powermem.integrations.embeddings.config.providers  # noqa: F401
+
+    assert BaseEmbedderConfig.has_provider("none")
+    assert (
+        BaseEmbedderConfig.get_provider_class_path("none")
+        == "powermem.integrations.embeddings.noop.NoopEmbedding"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config loader env path
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_from_env_supports_none_embedding(monkeypatch):
+    monkeypatch.setattr(config_loader, "_DEFAULT_ENV_FILE", None, raising=False)
+    monkeypatch.setattr(settings, "_DEFAULT_ENV_FILE", None, raising=False)
+    new_config = dict(config_loader.EmbeddingSettings.model_config)
+    new_config["env_file"] = None
+    monkeypatch.setattr(config_loader.EmbeddingSettings, "model_config", new_config)
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "none")
+
+    cfg = config_loader.load_config_from_env()
+
+    assert cfg["embedder"]["provider"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Memory._is_embedding_disabled / _embed helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubMemory:
+    """Minimal stand-in for Memory that exercises the new helpers."""
+
+    def __init__(self, embedding, embedding_provider="none"):
+        self.embedding = embedding
+        self.embedding_provider = embedding_provider
+
+    # Bind helpers directly
+    from powermem.core.memory import Memory
+    _is_embedding_disabled = Memory._is_embedding_disabled
+    _embed = Memory._embed
+
+
+def test_is_embedding_disabled_true_for_none_provider():
+    stub = _StubMemory(embedding=MagicMock(), embedding_provider="none")
+    assert stub._is_embedding_disabled() is True
+
+
+def test_is_embedding_disabled_true_for_noop_instance():
+    noop = NoopEmbedding()
+    stub = _StubMemory(embedding=noop, embedding_provider="other")
+    assert stub._is_embedding_disabled() is True
+
+
+def test_is_embedding_disabled_false_for_real_provider():
+    stub = _StubMemory(embedding=MagicMock(), embedding_provider="openai")
+    assert stub._is_embedding_disabled() is False
+
+
+def test_embed_returns_none_when_disabled():
+    stub = _StubMemory(embedding=MagicMock(), embedding_provider="none")
+    result = stub._embed("some text")
+    stub.embedding.embed.assert_not_called()
+    assert result is None
+
+
+def test_embed_calls_embedding_when_enabled():
+    mock_embedding = MagicMock()
+    mock_embedding.embed.return_value = [0.1] * 384
+    stub = _StubMemory(embedding=mock_embedding, embedding_provider="default")
+    stub.embedding.is_noop = False
+
+    result = stub._embed("hello")
+
+    mock_embedding.embed.assert_called_once_with("hello")
+    assert result == [0.1] * 384
+
+
+# ---------------------------------------------------------------------------
+# StorageAdapter skips embed when noop
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_skips_embed_call_when_noop(tmp_path):
+    """StorageAdapter must not call embed() when embedding_service.is_noop is True."""
+    from powermem.storage.adapter import StorageAdapter
+
+    noop_embedder = NoopEmbedding()
+    # Wrap to detect if embed() is ever called
+    noop_embedder.embed = MagicMock(side_effect=AssertionError("embed must not be called"))
+
+    mock_store = MagicMock()
+    mock_store.collection_name = "test"
+    mock_store.upsert.return_value = [1]
+
+    adapter = StorageAdapter(mock_store, embedding_service=noop_embedder)
+    adapter.add_memory({
+        "content": "test memory",
+        "user_id": "u1",
+        "agent_id": "",
+        "run_id": "",
+    })
+
+    noop_embedder.embed.assert_not_called()


### PR DESCRIPTION
## Summary

Adds explicit support for disabling embedding entirely via `EMBEDDING_PROVIDER=none`. When set, PowerMem skips all model loading and vector generation, allowing deployments that rely purely on LLM-based memory without any embedding dependency.

This mirrors the existing `LLM_PROVIDER=noop` pattern introduced in #1026.

## Motivation

There was no supported way to run PowerMem without an embedding model. Setting an invalid provider raised `ValueError: Unsupported Embedder provider`; omitting the config fell back to the local `all-MiniLM-L6-v2` model which downloads on first use. Users who want LLM-only memory (e.g. simple fact extraction without semantic search) had no clean opt-out.

## Changes

**New files**
- `src/powermem/integrations/embeddings/noop.py` — `NoopEmbedding(EmbeddingBase)` with `is_noop = True`; `embed()` and `embed_batch()` return `[]` without touching any model or network.
- `src/powermem/integrations/embeddings/config/providers.py` — `NoopEmbeddingConfig` registered under `provider="none"`.

**Modified files**
- `factory.py` — route `provider_name == "none"` to `NoopEmbedding()` before the generic registry lookup.
- `adapter.py` — two guards:
  - `add_memory`: change `if vector is None` → `if not vector` so that both `None` and `[]` (returned by `NoopEmbedding.embed()` in the regular memory add path) trigger the mock-vector fallback instead of calling `create_col(vector_size=0)`.
  - `add_memory`: skip `embedding_service.embed()` when `embedding_service.is_noop is True`.
- `memory.py` — add `_is_embedding_disabled()` and `_embed()` helpers (mirrors `_is_llm_disabled()`). The five direct `self.embedding.embed()` calls in the skill store methods (`add_skill`, `search_skills`) are replaced with `self._embed()`, which returns `None` when disabled so downstream stores receive `query_embedding=None` and fall back to full-text search.

**Behaviour when disabled**

| Operation | Result |
|-----------|--------|
| `memory.add()` | Stored with mock vector `[0.1]*1536` |
| `memory.get()` / `update()` / `delete()` | Work normally |
| `memory.search()` | Returns `[]` (no vector index) |
| `add_skill` / `search_skills` | Store/search with `None` embedding (full-text only) |

## Validation

```
pytest tests/unit/test_noop_embedding.py -v             # 17 passed
pytest tests/integration/test_noop_embedding_mode.py -v # 4 passed
pytest tests/unit/test_noop_llm.py tests/unit/test_pyseekdb_default_embeddings.py -v  # no regression
```