### PR TITLE
Publish release plugin and platform binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,7 +222,7 @@ jobs:
             -f docker/Dockerfile.binaries-centos7 \
             .
 
-      - name: Verify Linux binary package in CentOS 7
+      - name: Verify Linux amd64 binary package in CentOS 7
         run: |
           set -eux
           docker run --rm \
@@ -230,55 +230,10 @@ jobs:
             powermem-binaries-centos7 \
             -lc '
               set -eux
-              cd /powermem/dist-binaries
-              sha256sum -c SHA256SUMS
-              tar -tzf powermem-*-linux-amd64-binaries.tar.gz | tee /tmp/linux-binary-tar-entries.txt
-              grep -E "/bin/powermem$" /tmp/linux-binary-tar-entries.txt
-              grep -E "/bin/powermem-server$" /tmp/linux-binary-tar-entries.txt
-              grep -E "/bin/powermem-mcp$" /tmp/linux-binary-tar-entries.txt
-              rm -rf /tmp/linux-binary-smoke
-              mkdir -p /tmp/linux-binary-smoke
-              tar -xzf powermem-*-linux-amd64-binaries.tar.gz -C /tmp/linux-binary-smoke
-              BIN_ROOT="$(find /tmp/linux-binary-smoke -maxdepth 1 -type d -name "powermem-*-linux-amd64" | head -1)"
-              find "${BIN_ROOT}/bin" -mindepth 1 -maxdepth 1 -printf "%f\n" | sort | tee /tmp/linux-binary-bin-files.txt
-              printf "powermem\npowermem-mcp\npowermem-server\n" >/tmp/linux-binary-expected-bin-files.txt
-              diff -u /tmp/linux-binary-expected-bin-files.txt /tmp/linux-binary-bin-files.txt
-              timeout 10s "${BIN_ROOT}/bin/powermem" --help
-              timeout 10s "${BIN_ROOT}/bin/powermem-server" --help
-              export CI=1
-              export DATABASE_PROVIDER=sqlite
-              export SQLITE_PATH=/tmp/powermem-binary-smoke.db
-              export LLM_PROVIDER=noop
-              export EMBEDDING_PROVIDER=mock
-              export RERANKER_ENABLED=false
-              export POWERMEM_SERVER_LOG_FILE=
-              "${BIN_ROOT}/bin/powermem-server" --host localhost --port 18848 --workers 1 --no-open-browser &
-              server_pid="$!"
-              trap "kill ${server_pid} 2>/dev/null || true" EXIT
-              ready=0
-              for _ in $(seq 1 60); do
-                if curl -fsS http://localhost:18848/api/v1/system/health >/tmp/powermem-health.json \
-                  && curl -fsS http://localhost:18848/dashboard/ >/tmp/powermem-dashboard.html; then
-                  ready=1
-                  break
-                fi
-                if ! kill -0 "${server_pid}" 2>/dev/null; then
-                  wait "${server_pid}"
-                  exit 1
-                fi
-                sleep 1
-              done
-              test "${ready}" -eq 1
-              grep -Eq "\"success\"[[:space:]]*:[[:space:]]*true" /tmp/powermem-health.json
-              grep -Eq "\"status\"[[:space:]]*:[[:space:]]*\"healthy\"" /tmp/powermem-health.json
-              kill "${server_pid}"
-              wait "${server_pid}" || true
-              trap - EXIT
-              set +e
-              timeout 10s "${BIN_ROOT}/bin/powermem-mcp" stdio < /dev/null
-              mcp_status="$?"
-              set -e
-              test "${mcp_status}" -eq 0 -o "${mcp_status}" -eq 124
+              /opt/miniconda3/envs/powermem/bin/python scripts/smoke_binary_package.py \
+                --dist /powermem/dist-binaries \
+                --target-os linux \
+                --target-arch amd64
             '
 
       - name: Copy Linux binaries out of image
@@ -289,22 +244,101 @@ jobs:
             -v "${GITHUB_WORKSPACE}/dist-binaries:/out" \
             --entrypoint /bin/bash \
             powermem-binaries-centos7 \
-            -c 'cp -av /powermem/dist-binaries/*.tar.gz /powermem/dist-binaries/SHA256SUMS /out/'
+            -c 'cp -av /powermem/dist-binaries/*.tar.gz /powermem/dist-binaries/*.sha256 /out/'
 
       - name: Verify copied Linux binary artifacts
         run: |
           set -eux
           cd dist-binaries
-          sha256sum -c SHA256SUMS
-          ls -lh powermem-*-linux-amd64-binaries.tar.gz SHA256SUMS
+          sha256sum -c powermem-*-linux-amd64-binaries.tar.gz.sha256
+          ls -lh powermem-*-linux-amd64-binaries.tar.gz powermem-*-linux-amd64-binaries.tar.gz.sha256
 
       - name: Upload Linux amd64 binaries
         uses: actions/upload-artifact@v7
         with:
-          name: linux-amd64-binaries
+          name: powermem-linux-amd64-binaries
           path: |
             dist-binaries/powermem-*-linux-amd64-binaries.tar.gz
-            dist-binaries/SHA256SUMS
+            dist-binaries/powermem-*-linux-amd64-binaries.tar.gz.sha256
+          if-no-files-found: error
+          retention-days: 30
+
+  build-native-binaries:
+    name: Build ${{ matrix.binary-os }} ${{ matrix.binary-arch }} binaries
+    runs-on: ${{ matrix.runner }}
+    needs: build-dashboard
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+            binary-os: macos
+            binary-arch: amd64
+            python-architecture: x64
+            archive-format: tar.gz
+          - runner: macos-15
+            binary-os: macos
+            binary-arch: aarch64
+            python-architecture: arm64
+            archive-format: tar.gz
+          - runner: windows-2022
+            binary-os: windows
+            binary-arch: amd64
+            python-architecture: x64
+            archive-format: zip
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download dashboard artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: dashboard-dist
+          path: dashboard-dist
+
+      - name: Inject Dashboard into binary package source
+        shell: bash
+        run: |
+          mkdir -p src/server/dashboard
+          cp -r dashboard-dist/* src/server/dashboard/
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          architecture: ${{ matrix.python-architecture }}
+          cache: "pip"
+
+      - name: Install binary build dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install ".[cli,server,mcp,seekdb]" pyinstaller
+          python scripts/check_package_versions.py
+
+      - name: Build native binary package
+        shell: bash
+        env:
+          POWERMEM_BINARY_OS: ${{ matrix.binary-os }}
+          POWERMEM_BINARY_ARCH: ${{ matrix.binary-arch }}
+          POWERMEM_BINARY_FORMAT: ${{ matrix.archive-format }}
+        run: bash scripts/build_binary_package.sh
+
+      - name: Verify native binary package
+        shell: bash
+        run: |
+          python scripts/smoke_binary_package.py \
+            --dist dist-binaries \
+            --target-os "${{ matrix.binary-os }}" \
+            --target-arch "${{ matrix.binary-arch }}"
+
+      - name: Upload native binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: powermem-${{ matrix.binary-os }}-${{ matrix.binary-arch }}-binaries
+          path: |
+            dist-binaries/powermem-*-${{ matrix.binary-os }}-${{ matrix.binary-arch }}-binaries.*
           if-no-files-found: error
           retention-days: 30
 
@@ -316,6 +350,7 @@ jobs:
       - combine-artifacts
       - package-claude-plugin
       - build-linux-binaries-centos7
+      - build-native-binaries
     permissions:
       contents: write
 
@@ -332,11 +367,12 @@ jobs:
           name: powermem-claude-code-plugin-zip
           path: plugin-dist
 
-      - name: Download Linux amd64 binaries
+      - name: Download binary packages
         uses: actions/download-artifact@v8
         with:
-          name: linux-amd64-binaries
-          path: linux-binaries
+          pattern: powermem-*-binaries
+          path: binary-artifacts
+          merge-multiple: true
 
       - name: Create Release
         uses: softprops/action-gh-release@v3
@@ -344,7 +380,7 @@ jobs:
           files: |
             dist/*
             plugin-dist/powermem-claude-code-plugin-*.zip
-            linux-binaries/*
+            binary-artifacts/*
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,6 +242,33 @@ jobs:
               BIN_ROOT="$(find /tmp/linux-binary-smoke -maxdepth 1 -type d -name "powermem-*-linux-amd64" | head -1)"
               "${BIN_ROOT}/bin/powermem" --help
               "${BIN_ROOT}/bin/powermem-server" --help
+              export CI=1
+              export DATABASE_PROVIDER=sqlite
+              export SQLITE_PATH=/tmp/powermem-binary-smoke.db
+              export LLM_PROVIDER=noop
+              export EMBEDDING_PROVIDER=mock
+              export RERANKER_ENABLED=false
+              export POWERMEM_SERVER_LOG_FILE=
+              "${BIN_ROOT}/bin/powermem-server" --host localhost --port 18848 --workers 1 --no-open-browser &
+              server_pid="$!"
+              trap "kill ${server_pid} 2>/dev/null || true" EXIT
+              ready=0
+              for _ in $(seq 1 60); do
+                if curl -fsS http://localhost:18848/ >/tmp/powermem-server-root.json \
+                  && curl -fsS http://localhost:18848/dashboard/ >/tmp/powermem-dashboard.html; then
+                  ready=1
+                  break
+                fi
+                if ! kill -0 "${server_pid}" 2>/dev/null; then
+                  wait "${server_pid}"
+                  exit 1
+                fi
+                sleep 1
+              done
+              test "${ready}" -eq 1
+              kill "${server_pid}"
+              wait "${server_pid}" || true
+              trap - EXIT
               set +e
               timeout 10s "${BIN_ROOT}/bin/powermem-mcp" stdio < /dev/null
               mcp_status="$?"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,7 +313,7 @@ jobs:
       - name: Install binary build dependencies
         shell: bash
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip "setuptools<81" wheel
           python -m pip install ".[cli,server,mcp,seekdb]" pyinstaller
           python scripts/check_package_versions.py
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ on:
           - '3.11'
           - '3.12'
 
+env:
+  GO_VERSION: '1.22.x'
+
 jobs:
   build-dashboard:
     runs-on: ubuntu-latest
@@ -165,11 +168,36 @@ jobs:
           path: dist/*
           retention-days: 30
 
+  package-claude-plugin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Package Claude Code plugin
+        run: bash apps/claude-code-plugin/scripts/package-plugin.sh
+
+      - name: Upload Claude Code plugin zip
+        uses: actions/upload-artifact@v7
+        with:
+          name: powermem-claude-code-plugin-zip
+          path: apps/claude-code-plugin/dist/powermem-claude-code-plugin-*.zip
+          if-no-files-found: error
+          retention-days: 30
+
   build-and-release:
     runs-on: ubuntu-latest
     # Only release on version tags v*; do not run for plugin-only tags (plugins-v*)
     if: startsWith(github.ref, 'refs/tags/v') && !startsWith(github.ref, 'refs/tags/plugins-')
-    needs: combine-artifacts
+    needs:
+      - combine-artifacts
+      - package-claude-plugin
     permissions:
       contents: write
 
@@ -180,10 +208,18 @@ jobs:
           name: dist-packages
           path: dist
 
+      - name: Download Claude Code plugin zip
+        uses: actions/download-artifact@v8
+        with:
+          name: powermem-claude-code-plugin-zip
+          path: plugin-dist
+
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
-          files: dist/*
+          files: |
+            dist/*
+            plugin-dist/powermem-claude-code-plugin-*.zip
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,8 +240,11 @@ jobs:
               mkdir -p /tmp/linux-binary-smoke
               tar -xzf powermem-*-linux-amd64-binaries.tar.gz -C /tmp/linux-binary-smoke
               BIN_ROOT="$(find /tmp/linux-binary-smoke -maxdepth 1 -type d -name "powermem-*-linux-amd64" | head -1)"
-              "${BIN_ROOT}/bin/powermem" --help
-              "${BIN_ROOT}/bin/powermem-server" --help
+              find "${BIN_ROOT}/bin" -mindepth 1 -maxdepth 1 -printf "%f\n" | sort | tee /tmp/linux-binary-bin-files.txt
+              printf "powermem\npowermem-mcp\npowermem-server\n" >/tmp/linux-binary-expected-bin-files.txt
+              diff -u /tmp/linux-binary-expected-bin-files.txt /tmp/linux-binary-bin-files.txt
+              timeout 10s "${BIN_ROOT}/bin/powermem" --help
+              timeout 10s "${BIN_ROOT}/bin/powermem-server" --help
               export CI=1
               export DATABASE_PROVIDER=sqlite
               export SQLITE_PATH=/tmp/powermem-binary-smoke.db
@@ -254,8 +257,7 @@ jobs:
               trap "kill ${server_pid} 2>/dev/null || true" EXIT
               ready=0
               for _ in $(seq 1 60); do
-                root_status="$(curl -sS -o /tmp/powermem-server-root.out -w "%{http_code}" http://localhost:18848/ || true)"
-                if test "${root_status}" != "000" \
+                if curl -fsS http://localhost:18848/api/v1/system/health >/tmp/powermem-health.json \
                   && curl -fsS http://localhost:18848/dashboard/ >/tmp/powermem-dashboard.html; then
                   ready=1
                   break
@@ -267,6 +269,8 @@ jobs:
                 sleep 1
               done
               test "${ready}" -eq 1
+              grep -Eq "\"success\"[[:space:]]*:[[:space:]]*true" /tmp/powermem-health.json
+              grep -Eq "\"status\"[[:space:]]*:[[:space:]]*\"healthy\"" /tmp/powermem-health.json
               kill "${server_pid}"
               wait "${server_pid}" || true
               trap - EXIT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,6 +222,33 @@ jobs:
             -f docker/Dockerfile.binaries-centos7 \
             .
 
+      - name: Verify Linux binary package in CentOS 7
+        run: |
+          set -eux
+          docker run --rm \
+            --entrypoint /bin/bash \
+            powermem-binaries-centos7 \
+            -lc '
+              set -eux
+              cd /powermem/dist-binaries
+              sha256sum -c SHA256SUMS
+              tar -tzf powermem-*-linux-amd64-binaries.tar.gz | tee /tmp/linux-binary-tar-entries.txt
+              grep -E "/bin/powermem$" /tmp/linux-binary-tar-entries.txt
+              grep -E "/bin/powermem-server$" /tmp/linux-binary-tar-entries.txt
+              grep -E "/bin/powermem-mcp$" /tmp/linux-binary-tar-entries.txt
+              rm -rf /tmp/linux-binary-smoke
+              mkdir -p /tmp/linux-binary-smoke
+              tar -xzf powermem-*-linux-amd64-binaries.tar.gz -C /tmp/linux-binary-smoke
+              BIN_ROOT="$(find /tmp/linux-binary-smoke -maxdepth 1 -type d -name "powermem-*-linux-amd64" | head -1)"
+              "${BIN_ROOT}/bin/powermem" --help
+              "${BIN_ROOT}/bin/powermem-server" --help
+              set +e
+              timeout 10s "${BIN_ROOT}/bin/powermem-mcp" stdio < /dev/null
+              mcp_status="$?"
+              set -e
+              test "${mcp_status}" -eq 0 -o "${mcp_status}" -eq 124
+            '
+
       - name: Copy Linux binaries out of image
         run: |
           set -eux
@@ -232,25 +259,12 @@ jobs:
             powermem-binaries-centos7 \
             -c 'cp -av /powermem/dist-binaries/*.tar.gz /powermem/dist-binaries/SHA256SUMS /out/'
 
-      - name: Verify Linux binary package
+      - name: Verify copied Linux binary artifacts
         run: |
           set -eux
           cd dist-binaries
           sha256sum -c SHA256SUMS
-          tar -tzf powermem-*-linux-amd64-binaries.tar.gz | tee "${RUNNER_TEMP}/linux-binary-tar-entries.txt"
-          grep -E '/bin/powermem$' "${RUNNER_TEMP}/linux-binary-tar-entries.txt"
-          grep -E '/bin/powermem-server$' "${RUNNER_TEMP}/linux-binary-tar-entries.txt"
-          grep -E '/bin/powermem-mcp$' "${RUNNER_TEMP}/linux-binary-tar-entries.txt"
-          mkdir -p "${RUNNER_TEMP}/linux-binary-smoke"
-          tar -xzf powermem-*-linux-amd64-binaries.tar.gz -C "${RUNNER_TEMP}/linux-binary-smoke"
-          BIN_ROOT="$(find "${RUNNER_TEMP}/linux-binary-smoke" -maxdepth 1 -type d -name 'powermem-*-linux-amd64' | head -1)"
-          "${BIN_ROOT}/bin/powermem" --help
-          "${BIN_ROOT}/bin/powermem-server" --help
-          set +e
-          timeout 10s "${BIN_ROOT}/bin/powermem-mcp" stdio < /dev/null
-          mcp_status="$?"
-          set -e
-          test "${mcp_status}" -eq 0 -o "${mcp_status}" -eq 124
+          ls -lh powermem-*-linux-amd64-binaries.tar.gz SHA256SUMS
 
       - name: Upload Linux amd64 binaries
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,12 +194,24 @@ jobs:
   build-linux-binaries-centos7:
     name: Build Linux amd64 binaries on CentOS 7
     runs-on: ubuntu-latest
+    needs: build-dashboard
     env:
       DOCKER_BUILDKIT: 1
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Download dashboard artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: dashboard-dist
+          path: dashboard-dist
+
+      - name: Inject Dashboard into binary package source
+        run: |
+          mkdir -p src/server/dashboard
+          cp -r dashboard-dist/* src/server/dashboard/
 
       - name: Docker build Linux binaries on CentOS 7
         run: |
@@ -224,21 +236,28 @@ jobs:
           set -eux
           cd dist-binaries
           sha256sum -c SHA256SUMS
-          tar -tzf powermem-*-linux-amd64-binaries.tar.gz | tee tar-entries.txt
-          grep -E '/bin/powermem$' tar-entries.txt
-          grep -E '/bin/powermem-server$' tar-entries.txt
-          grep -E '/bin/powermem-mcp$' tar-entries.txt
-          tar -xzf powermem-*-linux-amd64-binaries.tar.gz
-          BIN_ROOT="$(find . -maxdepth 1 -type d -name 'powermem-*-linux-amd64' | head -1)"
+          tar -tzf powermem-*-linux-amd64-binaries.tar.gz | tee "${RUNNER_TEMP}/linux-binary-tar-entries.txt"
+          grep -E '/bin/powermem$' "${RUNNER_TEMP}/linux-binary-tar-entries.txt"
+          grep -E '/bin/powermem-server$' "${RUNNER_TEMP}/linux-binary-tar-entries.txt"
+          grep -E '/bin/powermem-mcp$' "${RUNNER_TEMP}/linux-binary-tar-entries.txt"
+          mkdir -p "${RUNNER_TEMP}/linux-binary-smoke"
+          tar -xzf powermem-*-linux-amd64-binaries.tar.gz -C "${RUNNER_TEMP}/linux-binary-smoke"
+          BIN_ROOT="$(find "${RUNNER_TEMP}/linux-binary-smoke" -maxdepth 1 -type d -name 'powermem-*-linux-amd64' | head -1)"
           "${BIN_ROOT}/bin/powermem" --help
           "${BIN_ROOT}/bin/powermem-server" --help
-          "${BIN_ROOT}/bin/powermem-mcp" --help
+          set +e
+          timeout 10s "${BIN_ROOT}/bin/powermem-mcp" stdio < /dev/null
+          mcp_status="$?"
+          set -e
+          test "${mcp_status}" -eq 0 -o "${mcp_status}" -eq 124
 
       - name: Upload Linux amd64 binaries
         uses: actions/upload-artifact@v7
         with:
           name: linux-amd64-binaries
-          path: dist-binaries/*
+          path: |
+            dist-binaries/powermem-*-linux-amd64-binaries.tar.gz
+            dist-binaries/SHA256SUMS
           if-no-files-found: error
           retention-days: 30
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ on:
           - '3.12'
 
 env:
-  GO_VERSION: '1.22.x'
+  GO_VERSION: '1.22.12'
 
 jobs:
   build-dashboard:
@@ -191,6 +191,57 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  build-linux-binaries-centos7:
+    name: Build Linux amd64 binaries on CentOS 7
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Docker build Linux binaries on CentOS 7
+        run: |
+          set -eux
+          docker build \
+            -t powermem-binaries-centos7 \
+            -f docker/Dockerfile.binaries-centos7 \
+            .
+
+      - name: Copy Linux binaries out of image
+        run: |
+          set -eux
+          mkdir -p dist-binaries
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}/dist-binaries:/out" \
+            --entrypoint /bin/bash \
+            powermem-binaries-centos7 \
+            -c 'cp -av /powermem/dist-binaries/*.tar.gz /powermem/dist-binaries/SHA256SUMS /out/'
+
+      - name: Verify Linux binary package
+        run: |
+          set -eux
+          cd dist-binaries
+          sha256sum -c SHA256SUMS
+          tar -tzf powermem-*-linux-amd64-binaries.tar.gz | tee tar-entries.txt
+          grep -E '/bin/powermem$' tar-entries.txt
+          grep -E '/bin/powermem-server$' tar-entries.txt
+          grep -E '/bin/powermem-mcp$' tar-entries.txt
+          tar -xzf powermem-*-linux-amd64-binaries.tar.gz
+          BIN_ROOT="$(find . -maxdepth 1 -type d -name 'powermem-*-linux-amd64' | head -1)"
+          "${BIN_ROOT}/bin/powermem" --help
+          "${BIN_ROOT}/bin/powermem-server" --help
+          "${BIN_ROOT}/bin/powermem-mcp" --help
+
+      - name: Upload Linux amd64 binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-amd64-binaries
+          path: dist-binaries/*
+          if-no-files-found: error
+          retention-days: 30
+
   build-and-release:
     runs-on: ubuntu-latest
     # Only release on version tags v*; do not run for plugin-only tags (plugins-v*)
@@ -198,6 +249,7 @@ jobs:
     needs:
       - combine-artifacts
       - package-claude-plugin
+      - build-linux-binaries-centos7
     permissions:
       contents: write
 
@@ -214,12 +266,19 @@ jobs:
           name: powermem-claude-code-plugin-zip
           path: plugin-dist
 
+      - name: Download Linux amd64 binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-amd64-binaries
+          path: linux-binaries
+
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/*
             plugin-dist/powermem-claude-code-plugin-*.zip
+            linux-binaries/*
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,7 +254,8 @@ jobs:
               trap "kill ${server_pid} 2>/dev/null || true" EXIT
               ready=0
               for _ in $(seq 1 60); do
-                if curl -fsS http://localhost:18848/ >/tmp/powermem-server-root.json \
+                root_status="$(curl -sS -o /tmp/powermem-server-root.out -w "%{http_code}" http://localhost:18848/ || true)"
+                if test "${root_status}" != "000" \
                   && curl -fsS http://localhost:18848/dashboard/ >/tmp/powermem-dashboard.html; then
                   ready=1
                   break

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,9 +145,10 @@ jobs:
     if: success()
 
     steps:
-      - name: Download all artifacts
+      - name: Download package artifacts
         uses: actions/download-artifact@v8
         with:
+          pattern: dist-*
           path: dist-all
 
       - name: Combine distribution files

--- a/docker/Dockerfile.binaries-centos7
+++ b/docker/Dockerfile.binaries-centos7
@@ -1,0 +1,30 @@
+FROM centos:centos7.9.2009
+
+# CentOS 7 is EOL. Use vault by default so GitHub Actions can still resolve yum
+# repositories without relying on the retired mirrorlist service.
+ARG CENTOS_BASEURL_PREFIX=https://vault.centos.org/centos
+ARG MINICONDA_SH=Miniconda3-py311_23.5.2-0-Linux-x86_64.sh
+
+RUN sed -i '/^\[main\]/a retries=10' /etc/yum.conf \
+    && sed -i '/^\[main\]/a minrate=0' /etc/yum.conf \
+    && sed -i '/^\[main\]/a ip_resolve=4' /etc/yum.conf \
+    && sed -i 's/^enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf 2>/dev/null || true \
+    && sed -i 's/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/CentOS-*.repo \
+    && sed -i "s|^#baseurl=http://mirror.centos.org/centos/|baseurl=${CENTOS_BASEURL_PREFIX}/|" /etc/yum.repos.d/CentOS-*.repo \
+    && yum clean all \
+    && yum install -y binutils ca-certificates curl file gcc gcc-c++ gzip make tar \
+    && update-ca-trust
+
+# Miniconda3-latest requires glibc >= 2.28; CentOS 7 has glibc 2.17.
+RUN curl -fsSL "https://repo.anaconda.com/miniconda/${MINICONDA_SH}" -o /tmp/miniconda.sh \
+    && sh /tmp/miniconda.sh -p /opt/miniconda3 -b \
+    && rm -f /tmp/miniconda.sh
+
+WORKDIR /powermem
+COPY ./ ./
+
+RUN /opt/miniconda3/bin/conda create --name powermem python=3.11 -y \
+    && /opt/miniconda3/envs/powermem/bin/python -m pip install --upgrade pip setuptools wheel \
+    && /opt/miniconda3/envs/powermem/bin/pip install ".[cli,server,mcp,seekdb]" pyinstaller \
+    && /opt/miniconda3/envs/powermem/bin/python scripts/check_package_versions.py \
+    && PATH="/opt/miniconda3/envs/powermem/bin:${PATH}" bash scripts/build_linux_binaries.sh

--- a/docker/Dockerfile.binaries-centos7
+++ b/docker/Dockerfile.binaries-centos7
@@ -26,7 +26,7 @@ WORKDIR /powermem
 COPY ./ ./
 
 RUN /opt/miniconda3/bin/conda create --name powermem python=3.11 -y \
-    && /opt/miniconda3/envs/powermem/bin/python -m pip install --upgrade pip setuptools wheel \
+    && /opt/miniconda3/envs/powermem/bin/python -m pip install --upgrade pip "setuptools<81" wheel \
     && /opt/miniconda3/envs/powermem/bin/pip install ".[cli,server,mcp,seekdb]" pyinstaller \
     && /opt/miniconda3/envs/powermem/bin/python scripts/check_package_versions.py \
     && PATH="/opt/miniconda3/envs/powermem/bin:${PATH}" bash scripts/build_linux_binaries.sh

--- a/docker/Dockerfile.binaries-centos7
+++ b/docker/Dockerfile.binaries-centos7
@@ -4,6 +4,7 @@ FROM centos:centos7.9.2009
 # repositories without relying on the retired mirrorlist service.
 ARG CENTOS_BASEURL_PREFIX=https://vault.centos.org/centos
 ARG MINICONDA_SH=Miniconda3-py311_23.5.2-0-Linux-x86_64.sh
+ARG MINICONDA_SHA256=634d76df5e489c44ade4085552b97bebc786d49245ed1a830022b0b406de5817
 
 RUN sed -i '/^\[main\]/a retries=10' /etc/yum.conf \
     && sed -i '/^\[main\]/a minrate=0' /etc/yum.conf \
@@ -17,6 +18,7 @@ RUN sed -i '/^\[main\]/a retries=10' /etc/yum.conf \
 
 # Miniconda3-latest requires glibc >= 2.28; CentOS 7 has glibc 2.17.
 RUN curl -fsSL "https://repo.anaconda.com/miniconda/${MINICONDA_SH}" -o /tmp/miniconda.sh \
+    && echo "${MINICONDA_SHA256}  /tmp/miniconda.sh" | sha256sum -c - \
     && sh /tmp/miniconda.sh -p /opt/miniconda3 -b \
     && rm -f /tmp/miniconda.sh
 

--- a/scripts/build_binary_package.sh
+++ b/scripts/build_binary_package.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Build standalone command binaries for release packaging.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON="${PYTHON:-python}"
+
+detect_os() {
+  case "$(uname -s)" in
+    Linux*) echo "linux" ;;
+    Darwin*) echo "macos" ;;
+    MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64|AMD64) echo "amd64" ;;
+    arm64|aarch64) echo "aarch64" ;;
+    *) uname -m ;;
+  esac
+}
+
+TARGET_OS="${POWERMEM_BINARY_OS:-$(detect_os)}"
+TARGET_ARCH="${POWERMEM_BINARY_ARCH:-$(detect_arch)}"
+ARCHIVE_FORMAT="${POWERMEM_BINARY_FORMAT:-tar.gz}"
+BUILD_NOTE="${POWERMEM_BINARY_BUILD_NOTE:-Built on GitHub Actions ${TARGET_OS} ${TARGET_ARCH}.}"
+
+if [[ "${TARGET_OS}" == "unknown" ]]; then
+  echo "error: unable to detect target OS; set POWERMEM_BINARY_OS" >&2
+  exit 1
+fi
+
+DIST="${ROOT}/dist-binaries"
+BUILD="${ROOT}/build/binaries-${TARGET_OS}-${TARGET_ARCH}"
+ENTRYPOINTS="${BUILD}/entrypoints"
+BIN_DIR="${DIST}/bin"
+EXE_SUFFIX=""
+
+if [[ "${TARGET_OS}" == "windows" ]]; then
+  EXE_SUFFIX=".exe"
+fi
+
+cd "${ROOT}"
+
+VERSION="$("${PYTHON}" - <<'PY'
+import tomllib
+with open("pyproject.toml", "rb") as f:
+    print(tomllib.load(f)["project"]["version"])
+PY
+)"
+
+rm -rf "${BUILD}" "${DIST}"
+mkdir -p "${ENTRYPOINTS}" "${BIN_DIR}"
+
+cat > "${ENTRYPOINTS}/powermem_cli_entry.py" <<'PY'
+from powermem.cli.main import cli
+
+if __name__ == "__main__":
+    cli()
+PY
+
+cat > "${ENTRYPOINTS}/powermem_server_entry.py" <<'PY'
+from server.cli.server import server
+
+if __name__ == "__main__":
+    server()
+PY
+
+cat > "${ENTRYPOINTS}/powermem_mcp_entry.py" <<'PY'
+from powermem.mcp.server import main
+
+if __name__ == "__main__":
+    main()
+PY
+
+COMMON_OPTS=(
+  --onefile
+  --clean
+  --noconfirm
+  --distpath "${BIN_DIR}"
+  --workpath "${BUILD}/pyinstaller"
+  --specpath "${BUILD}/specs"
+  --collect-all powermem
+  --collect-all server
+  --collect-all fastmcp
+  --collect-all pyobvector
+  --copy-metadata powermem
+  --copy-metadata pydantic
+  --copy-metadata pydantic-settings
+  --copy-metadata fastmcp
+  --copy-metadata pyobvector
+)
+
+build_binary() {
+  local name="$1"
+  local entrypoint="$2"
+  local output="${BIN_DIR}/${name}${EXE_SUFFIX}"
+
+  echo "Building ${name} for ${TARGET_OS}-${TARGET_ARCH}"
+  "${PYTHON}" -m PyInstaller "${COMMON_OPTS[@]}" --name "${name}" "${entrypoint}"
+  chmod +x "${output}" 2>/dev/null || true
+
+  if command -v file >/dev/null 2>&1; then
+    file "${output}"
+  fi
+  if [[ "${TARGET_OS}" == "linux" ]] && command -v ldd >/dev/null 2>&1; then
+    ldd "${output}"
+  fi
+}
+
+build_binary powermem "${ENTRYPOINTS}/powermem_cli_entry.py"
+build_binary powermem-server "${ENTRYPOINTS}/powermem_server_entry.py"
+build_binary powermem-mcp "${ENTRYPOINTS}/powermem_mcp_entry.py"
+
+PACKAGE_BASENAME="powermem-${VERSION}-${TARGET_OS}-${TARGET_ARCH}"
+PACKAGE_DIR="${DIST}/${PACKAGE_BASENAME}"
+mkdir -p "${PACKAGE_DIR}/bin"
+
+cp -av \
+  "${BIN_DIR}/powermem${EXE_SUFFIX}" \
+  "${BIN_DIR}/powermem-server${EXE_SUFFIX}" \
+  "${BIN_DIR}/powermem-mcp${EXE_SUFFIX}" \
+  "${PACKAGE_DIR}/bin/"
+
+cat > "${PACKAGE_DIR}/README.md" <<EOF
+# PowerMem ${TARGET_OS} ${TARGET_ARCH} binaries
+
+${BUILD_NOTE}
+
+Included commands:
+
+- powermem
+- powermem-server
+- powermem-mcp
+
+Version: ${VERSION}
+EOF
+
+case "${ARCHIVE_FORMAT}" in
+  tar.gz)
+    ARCHIVE_FILE="${DIST}/${PACKAGE_BASENAME}-binaries.tar.gz"
+    ( cd "${DIST}" && tar -czf "${PACKAGE_BASENAME}-binaries.tar.gz" "${PACKAGE_BASENAME}" )
+    ;;
+  zip)
+    ARCHIVE_FILE="${DIST}/${PACKAGE_BASENAME}-binaries.zip"
+    ( cd "${DIST}" && "${PYTHON}" -m zipfile -c "${PACKAGE_BASENAME}-binaries.zip" "${PACKAGE_BASENAME}" )
+    ;;
+  *)
+    echo "error: unsupported POWERMEM_BINARY_FORMAT=${ARCHIVE_FORMAT}" >&2
+    exit 1
+    ;;
+esac
+
+"${PYTHON}" - "${ARCHIVE_FILE}" > "${ARCHIVE_FILE}.sha256" <<'PY'
+import hashlib
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+print(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}")
+PY
+
+echo "Built ${TARGET_OS}-${TARGET_ARCH} binaries:"
+ls -lh "${BIN_DIR}" "${ARCHIVE_FILE}" "${ARCHIVE_FILE}.sha256"

--- a/scripts/build_linux_binaries.sh
+++ b/scripts/build_linux_binaries.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Build standalone Linux amd64 command binaries for release packaging.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON="${PYTHON:-python}"
+DIST="${ROOT}/dist-binaries"
+BUILD="${ROOT}/build/linux-binaries"
+ENTRYPOINTS="${BUILD}/entrypoints"
+BIN_DIR="${DIST}/bin"
+
+cd "${ROOT}"
+
+VERSION="$("${PYTHON}" - <<'PY'
+import tomllib
+with open("pyproject.toml", "rb") as f:
+    print(tomllib.load(f)["project"]["version"])
+PY
+)"
+
+rm -rf "${BUILD}" "${DIST}"
+mkdir -p "${ENTRYPOINTS}" "${BIN_DIR}"
+
+cat > "${ENTRYPOINTS}/powermem.py" <<'PY'
+from powermem.cli.main import cli
+
+if __name__ == "__main__":
+    cli()
+PY
+
+cat > "${ENTRYPOINTS}/powermem-server.py" <<'PY'
+from server.cli.server import server
+
+if __name__ == "__main__":
+    server()
+PY
+
+cat > "${ENTRYPOINTS}/powermem-mcp.py" <<'PY'
+from powermem.mcp.server import main
+
+if __name__ == "__main__":
+    main()
+PY
+
+COMMON_OPTS=(
+  --onefile
+  --clean
+  --noconfirm
+  --distpath "${BIN_DIR}"
+  --workpath "${BUILD}/pyinstaller"
+  --specpath "${BUILD}/specs"
+  --collect-all powermem
+  --collect-all server
+  --collect-all fastmcp
+  --collect-all pyobvector
+  --copy-metadata powermem
+  --copy-metadata pydantic
+  --copy-metadata pydantic-settings
+  --copy-metadata fastmcp
+  --copy-metadata pyobvector
+)
+
+build_binary() {
+  local name="$1"
+  local entrypoint="${ENTRYPOINTS}/${name}.py"
+  echo "Building ${name}"
+  "${PYTHON}" -m PyInstaller "${COMMON_OPTS[@]}" --name "${name}" "${entrypoint}"
+  chmod +x "${BIN_DIR}/${name}"
+  file "${BIN_DIR}/${name}"
+  ldd "${BIN_DIR}/${name}" || true
+}
+
+build_binary powermem
+build_binary powermem-server
+build_binary powermem-mcp
+
+PACKAGE_DIR="${DIST}/powermem-${VERSION}-linux-amd64"
+mkdir -p "${PACKAGE_DIR}/bin"
+cp -av "${BIN_DIR}/powermem" "${BIN_DIR}/powermem-server" "${BIN_DIR}/powermem-mcp" "${PACKAGE_DIR}/bin/"
+
+cat > "${PACKAGE_DIR}/README.md" <<EOF
+# PowerMem Linux amd64 binaries
+
+Built on CentOS 7 for broader glibc compatibility.
+
+Included commands:
+
+- powermem
+- powermem-server
+- powermem-mcp
+
+Version: ${VERSION}
+EOF
+
+( cd "${DIST}" && tar -czf "powermem-${VERSION}-linux-amd64-binaries.tar.gz" "powermem-${VERSION}-linux-amd64" )
+( cd "${DIST}" && sha256sum "powermem-${VERSION}-linux-amd64-binaries.tar.gz" > SHA256SUMS )
+
+echo "Built Linux amd64 binaries:"
+ls -lh "${BIN_DIR}" "${DIST}/powermem-${VERSION}-linux-amd64-binaries.tar.gz" "${DIST}/SHA256SUMS"

--- a/scripts/build_linux_binaries.sh
+++ b/scripts/build_linux_binaries.sh
@@ -1,99 +1,12 @@
 #!/usr/bin/env bash
-# Build standalone Linux amd64 command binaries for release packaging.
+# Backwards-compatible wrapper for the CentOS 7 Linux amd64 release package.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PYTHON="${PYTHON:-python}"
-DIST="${ROOT}/dist-binaries"
-BUILD="${ROOT}/build/linux-binaries"
-ENTRYPOINTS="${BUILD}/entrypoints"
-BIN_DIR="${DIST}/bin"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-cd "${ROOT}"
+export POWERMEM_BINARY_OS="${POWERMEM_BINARY_OS:-linux}"
+export POWERMEM_BINARY_ARCH="${POWERMEM_BINARY_ARCH:-amd64}"
+export POWERMEM_BINARY_FORMAT="${POWERMEM_BINARY_FORMAT:-tar.gz}"
+export POWERMEM_BINARY_BUILD_NOTE="${POWERMEM_BINARY_BUILD_NOTE:-Built on CentOS 7 for broader glibc compatibility.}"
 
-VERSION="$("${PYTHON}" - <<'PY'
-import tomllib
-with open("pyproject.toml", "rb") as f:
-    print(tomllib.load(f)["project"]["version"])
-PY
-)"
-
-rm -rf "${BUILD}" "${DIST}"
-mkdir -p "${ENTRYPOINTS}" "${BIN_DIR}"
-
-cat > "${ENTRYPOINTS}/powermem_cli_entry.py" <<'PY'
-from powermem.cli.main import cli
-
-if __name__ == "__main__":
-    cli()
-PY
-
-cat > "${ENTRYPOINTS}/powermem_server_entry.py" <<'PY'
-from server.cli.server import server
-
-if __name__ == "__main__":
-    server()
-PY
-
-cat > "${ENTRYPOINTS}/powermem_mcp_entry.py" <<'PY'
-from powermem.mcp.server import main
-
-if __name__ == "__main__":
-    main()
-PY
-
-COMMON_OPTS=(
-  --onefile
-  --clean
-  --noconfirm
-  --distpath "${BIN_DIR}"
-  --workpath "${BUILD}/pyinstaller"
-  --specpath "${BUILD}/specs"
-  --collect-all powermem
-  --collect-all server
-  --collect-all fastmcp
-  --collect-all pyobvector
-  --copy-metadata powermem
-  --copy-metadata pydantic
-  --copy-metadata pydantic-settings
-  --copy-metadata fastmcp
-  --copy-metadata pyobvector
-)
-
-build_binary() {
-  local name="$1"
-  local entrypoint="$2"
-  echo "Building ${name}"
-  "${PYTHON}" -m PyInstaller "${COMMON_OPTS[@]}" --name "${name}" "${entrypoint}"
-  chmod +x "${BIN_DIR}/${name}"
-  file "${BIN_DIR}/${name}"
-  ldd "${BIN_DIR}/${name}"
-}
-
-build_binary powermem "${ENTRYPOINTS}/powermem_cli_entry.py"
-build_binary powermem-server "${ENTRYPOINTS}/powermem_server_entry.py"
-build_binary powermem-mcp "${ENTRYPOINTS}/powermem_mcp_entry.py"
-
-PACKAGE_DIR="${DIST}/powermem-${VERSION}-linux-amd64"
-mkdir -p "${PACKAGE_DIR}/bin"
-cp -av "${BIN_DIR}/powermem" "${BIN_DIR}/powermem-server" "${BIN_DIR}/powermem-mcp" "${PACKAGE_DIR}/bin/"
-
-cat > "${PACKAGE_DIR}/README.md" <<EOF
-# PowerMem Linux amd64 binaries
-
-Built on CentOS 7 for broader glibc compatibility.
-
-Included commands:
-
-- powermem
-- powermem-server
-- powermem-mcp
-
-Version: ${VERSION}
-EOF
-
-( cd "${DIST}" && tar -czf "powermem-${VERSION}-linux-amd64-binaries.tar.gz" "powermem-${VERSION}-linux-amd64" )
-( cd "${DIST}" && sha256sum "powermem-${VERSION}-linux-amd64-binaries.tar.gz" > SHA256SUMS )
-
-echo "Built Linux amd64 binaries:"
-ls -lh "${BIN_DIR}" "${DIST}/powermem-${VERSION}-linux-amd64-binaries.tar.gz" "${DIST}/SHA256SUMS"
+exec bash "${SCRIPT_DIR}/build_binary_package.sh"

--- a/scripts/build_linux_binaries.sh
+++ b/scripts/build_linux_binaries.sh
@@ -21,21 +21,21 @@ PY
 rm -rf "${BUILD}" "${DIST}"
 mkdir -p "${ENTRYPOINTS}" "${BIN_DIR}"
 
-cat > "${ENTRYPOINTS}/powermem.py" <<'PY'
+cat > "${ENTRYPOINTS}/powermem_cli_entry.py" <<'PY'
 from powermem.cli.main import cli
 
 if __name__ == "__main__":
     cli()
 PY
 
-cat > "${ENTRYPOINTS}/powermem-server.py" <<'PY'
+cat > "${ENTRYPOINTS}/powermem_server_entry.py" <<'PY'
 from server.cli.server import server
 
 if __name__ == "__main__":
     server()
 PY
 
-cat > "${ENTRYPOINTS}/powermem-mcp.py" <<'PY'
+cat > "${ENTRYPOINTS}/powermem_mcp_entry.py" <<'PY'
 from powermem.mcp.server import main
 
 if __name__ == "__main__":
@@ -62,17 +62,17 @@ COMMON_OPTS=(
 
 build_binary() {
   local name="$1"
-  local entrypoint="${ENTRYPOINTS}/${name}.py"
+  local entrypoint="$2"
   echo "Building ${name}"
   "${PYTHON}" -m PyInstaller "${COMMON_OPTS[@]}" --name "${name}" "${entrypoint}"
   chmod +x "${BIN_DIR}/${name}"
   file "${BIN_DIR}/${name}"
-  ldd "${BIN_DIR}/${name}" || true
+  ldd "${BIN_DIR}/${name}"
 }
 
-build_binary powermem
-build_binary powermem-server
-build_binary powermem-mcp
+build_binary powermem "${ENTRYPOINTS}/powermem_cli_entry.py"
+build_binary powermem-server "${ENTRYPOINTS}/powermem_server_entry.py"
+build_binary powermem-mcp "${ENTRYPOINTS}/powermem_mcp_entry.py"
 
 PACKAGE_DIR="${DIST}/powermem-${VERSION}-linux-amd64"
 mkdir -p "${PACKAGE_DIR}/bin"

--- a/scripts/smoke_binary_package.py
+++ b/scripts/smoke_binary_package.py
@@ -241,7 +241,7 @@ def _smoke_server(server_binary: Path, port: int) -> None:
                 _terminate_process_tree(process)
 
         if failure is not None:
-            output = log_path.read_text(encoding="utf-8", errors="replace")
+            output = server_output_path.read_text(encoding="utf-8", errors="replace")
             _fail(f"{failure}\n{output}")
 
 

--- a/scripts/smoke_binary_package.py
+++ b/scripts/smoke_binary_package.py
@@ -87,6 +87,13 @@ def _verify_tar_members(tar: tarfile.TarFile, target: Path) -> None:
             _fail(f"unsafe tar member link: {member.name}")
 
 
+def _temporary_directory(prefix: str) -> tempfile.TemporaryDirectory[str]:
+    return tempfile.TemporaryDirectory(
+        prefix=prefix,
+        ignore_cleanup_errors=os.name == "nt",
+    )
+
+
 def _run_checked(
     command: list[str],
     *,
@@ -128,9 +135,44 @@ def _fetch(url: str) -> bytes:
         return response.read()
 
 
+def _read_process_output(process: subprocess.Popen[str]) -> str:
+    if process.stdout is None:
+        return ""
+    try:
+        return process.stdout.read()
+    except OSError as exc:
+        return f"<failed to read process output: {exc}>"
+
+
+def _terminate_process_tree(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+
+    if os.name == "nt":
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+                check=False,
+                timeout=15,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            process.kill()
+    else:
+        process.terminate()
+
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=15)
+
+
 def _smoke_server(server_binary: Path, port: int) -> None:
     env = os.environ.copy()
-    with tempfile.TemporaryDirectory(prefix="powermem-server-smoke-") as tmp:
+    with _temporary_directory(prefix="powermem-server-smoke-") as tmp:
         env.update(
             {
                 "CI": "1",
@@ -159,46 +201,53 @@ def _smoke_server(server_binary: Path, port: int) -> None:
             text=True,
         )
 
+        failure: str | None = None
         try:
-            deadline = time.monotonic() + 60
+            ready_timeout = 180 if os.name == "nt" else 60
+            deadline = time.monotonic() + ready_timeout
             health_body: bytes | None = None
             dashboard_body: bytes | None = None
             while time.monotonic() < deadline:
                 if process.poll() is not None:
-                    output = process.stdout.read() if process.stdout else ""
-                    _fail(
+                    failure = (
                         "powermem-server exited before becoming ready "
-                        f"with code {process.returncode}\n{output}"
+                        f"with code {process.returncode}"
                     )
+                    break
                 try:
                     health_body = _fetch(f"http://localhost:{port}/api/v1/system/health")
                     dashboard_body = _fetch(f"http://localhost:{port}/dashboard/")
                     break
                 except urllib.error.HTTPError as exc:
                     if exc.code == 404:
-                        _fail("dashboard endpoint returned 404")
+                        failure = "dashboard endpoint returned 404"
+                        break
                     time.sleep(1)
                 except (OSError, urllib.error.URLError):
                     time.sleep(1)
 
-            if health_body is None or dashboard_body is None:
-                _fail("powermem-server did not become ready before timeout")
+            if failure is None and (health_body is None or dashboard_body is None):
+                failure = (
+                    "powermem-server did not become ready before timeout "
+                    f"({ready_timeout} seconds)"
+                )
 
-            health = json.loads(health_body.decode("utf-8"))
-            if health.get("success") is not True:
-                _fail(f"health response did not report success=true: {health}")
-            if health.get("data", {}).get("status") != "healthy":
-                _fail(f"health response did not report status=healthy: {health}")
-            if not dashboard_body.strip():
-                _fail("dashboard response body is empty")
+            if failure is None:
+                assert health_body is not None
+                assert dashboard_body is not None
+                health = json.loads(health_body.decode("utf-8"))
+                if health.get("success") is not True:
+                    failure = f"health response did not report success=true: {health}"
+                elif health.get("data", {}).get("status") != "healthy":
+                    failure = f"health response did not report status=healthy: {health}"
+                elif not dashboard_body.strip():
+                    failure = "dashboard response body is empty"
         finally:
-            if process.poll() is None:
-                process.terminate()
-                try:
-                    process.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=10)
+            _terminate_process_tree(process)
+
+        if failure is not None:
+            output = _read_process_output(process)
+            _fail(f"{failure}\n{output}")
 
 
 def _smoke_mcp(mcp_binary: Path) -> None:
@@ -238,7 +287,7 @@ def main() -> None:
     )
     _verify_checksum(archive)
 
-    with tempfile.TemporaryDirectory(prefix="powermem-binary-smoke-") as tmp:
+    with _temporary_directory(prefix="powermem-binary-smoke-") as tmp:
         extract_root = Path(tmp)
         _extract(archive, extract_root)
         package_root = extract_root / _package_name(archive)

--- a/scripts/smoke_binary_package.py
+++ b/scripts/smoke_binary_package.py
@@ -181,6 +181,7 @@ def _smoke_server(server_binary: Path, port: int) -> None:
                 "LLM_PROVIDER": "noop",
                 "EMBEDDING_PROVIDER": "mock",
                 "RERANKER_ENABLED": "false",
+                "AGENT_MEMORY_MODE": "multi_user",
                 "POWERMEM_SERVER_LOG_FILE": "",
             }
         )

--- a/scripts/smoke_binary_package.py
+++ b/scripts/smoke_binary_package.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Smoke test a packaged PowerMem binary archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+
+def _fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def _find_one(dist: Path, patterns: list[str]) -> Path:
+    matches: list[Path] = []
+    for pattern in patterns:
+        matches.extend(dist.glob(pattern))
+    if not matches:
+        _fail(f"no archive found in {dist} for patterns: {', '.join(patterns)}")
+    if len(matches) > 1:
+        _fail(f"multiple archives found: {', '.join(str(path) for path in matches)}")
+    return matches[0]
+
+
+def _package_name(archive: Path) -> str:
+    if archive.name.endswith(".tar.gz"):
+        name = archive.name[: -len(".tar.gz")]
+        return _strip_suffix(name, "-binaries")
+    if archive.name.endswith(".zip"):
+        name = archive.name[: -len(".zip")]
+        return _strip_suffix(name, "-binaries")
+    _fail(f"unsupported archive format: {archive.name}")
+
+
+def _strip_suffix(value: str, suffix: str) -> str:
+    if value.endswith(suffix):
+        return value[: -len(suffix)]
+    return value
+
+
+def _verify_checksum(archive: Path) -> None:
+    checksum_path = archive.with_name(f"{archive.name}.sha256")
+    if not checksum_path.is_file():
+        _fail(f"missing checksum file: {checksum_path.name}")
+
+    expected = checksum_path.read_text(encoding="utf-8").split()[0]
+    actual = hashlib.sha256(archive.read_bytes()).hexdigest()
+    if actual != expected:
+        _fail(f"checksum mismatch for {archive.name}: expected {expected}, got {actual}")
+
+
+def _extract(archive: Path, target: Path) -> None:
+    if archive.name.endswith(".tar.gz"):
+        with tarfile.open(archive, "r:gz") as tar:
+            try:
+                tar.extractall(target, filter="data")
+            except TypeError:
+                _verify_tar_members(tar, target)
+                tar.extractall(target)
+        return
+
+    if archive.name.endswith(".zip"):
+        with zipfile.ZipFile(archive) as zip_file:
+            zip_file.extractall(target)
+        return
+
+    _fail(f"unsupported archive format: {archive.name}")
+
+
+def _verify_tar_members(tar: tarfile.TarFile, target: Path) -> None:
+    root = target.resolve()
+    for member in tar.getmembers():
+        member_path = (target / member.name).resolve()
+        if root != member_path and root not in member_path.parents:
+            _fail(f"unsafe tar member path: {member.name}")
+        if member.issym() or member.islnk():
+            _fail(f"unsafe tar member link: {member.name}")
+
+
+def _run_help(binary: Path) -> None:
+    subprocess.run(
+        [str(binary), "--help"],
+        check=True,
+        timeout=10,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+
+def _fetch(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=2) as response:
+        return response.read()
+
+
+def _smoke_server(server_binary: Path, port: int) -> None:
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory(prefix="powermem-server-smoke-") as tmp:
+        env.update(
+            {
+                "CI": "1",
+                "DATABASE_PROVIDER": "sqlite",
+                "SQLITE_PATH": str(Path(tmp) / "powermem-binary-smoke.db"),
+                "LLM_PROVIDER": "noop",
+                "EMBEDDING_PROVIDER": "mock",
+                "RERANKER_ENABLED": "false",
+                "POWERMEM_SERVER_LOG_FILE": "",
+            }
+        )
+        process = subprocess.Popen(
+            [
+                str(server_binary),
+                "--host",
+                "localhost",
+                "--port",
+                str(port),
+                "--workers",
+                "1",
+                "--no-open-browser",
+            ],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        try:
+            deadline = time.monotonic() + 60
+            health_body: bytes | None = None
+            dashboard_body: bytes | None = None
+            while time.monotonic() < deadline:
+                if process.poll() is not None:
+                    output = process.stdout.read() if process.stdout else ""
+                    _fail(
+                        "powermem-server exited before becoming ready "
+                        f"with code {process.returncode}\n{output}"
+                    )
+                try:
+                    health_body = _fetch(f"http://localhost:{port}/api/v1/system/health")
+                    dashboard_body = _fetch(f"http://localhost:{port}/dashboard/")
+                    break
+                except urllib.error.HTTPError as exc:
+                    if exc.code == 404:
+                        _fail("dashboard endpoint returned 404")
+                    time.sleep(1)
+                except (OSError, urllib.error.URLError):
+                    time.sleep(1)
+
+            if health_body is None or dashboard_body is None:
+                _fail("powermem-server did not become ready before timeout")
+
+            health = json.loads(health_body.decode("utf-8"))
+            if health.get("success") is not True:
+                _fail(f"health response did not report success=true: {health}")
+            if health.get("data", {}).get("status") != "healthy":
+                _fail(f"health response did not report status=healthy: {health}")
+            if not dashboard_body.strip():
+                _fail("dashboard response body is empty")
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=10)
+
+
+def _smoke_mcp(mcp_binary: Path) -> None:
+    try:
+        result = subprocess.run(
+            [str(mcp_binary), "stdio"],
+            input=b"",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return
+
+    if result.returncode != 0:
+        _fail(
+            "powermem-mcp stdio exited with non-zero status "
+            f"{result.returncode}: {result.stderr.decode(errors='replace')}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dist", default="dist-binaries", type=Path)
+    parser.add_argument("--target-os", required=True)
+    parser.add_argument("--target-arch", required=True)
+    parser.add_argument("--port", default=18848, type=int)
+    args = parser.parse_args()
+
+    dist = args.dist.resolve()
+    archive = _find_one(
+        dist,
+        [
+            f"powermem-*-{args.target_os}-{args.target_arch}-binaries.tar.gz",
+            f"powermem-*-{args.target_os}-{args.target_arch}-binaries.zip",
+        ],
+    )
+    _verify_checksum(archive)
+
+    with tempfile.TemporaryDirectory(prefix="powermem-binary-smoke-") as tmp:
+        extract_root = Path(tmp)
+        _extract(archive, extract_root)
+        package_root = extract_root / _package_name(archive)
+        bin_dir = package_root / "bin"
+        if not bin_dir.is_dir():
+            _fail(f"missing bin directory: {bin_dir}")
+
+        exe_suffix = ".exe" if args.target_os == "windows" else ""
+        expected = {
+            f"powermem{exe_suffix}",
+            f"powermem-server{exe_suffix}",
+            f"powermem-mcp{exe_suffix}",
+        }
+        actual = {path.name for path in bin_dir.iterdir() if path.is_file()}
+        if actual != expected:
+            _fail(f"unexpected bin contents: expected {sorted(expected)}, got {sorted(actual)}")
+
+        binaries = {
+            name: bin_dir / f"{name}{exe_suffix}"
+            for name in ("powermem", "powermem-server", "powermem-mcp")
+        }
+        for binary in binaries.values():
+            if args.target_os != "windows" and not os.access(binary, os.X_OK):
+                _fail(f"binary is not executable: {binary}")
+
+        _run_help(binaries["powermem"])
+        _run_help(binaries["powermem-server"])
+        _smoke_server(binaries["powermem-server"], args.port)
+        _smoke_mcp(binaries["powermem-mcp"])
+
+    print(f"Smoke test passed for {archive.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_binary_package.py
+++ b/scripts/smoke_binary_package.py
@@ -87,14 +87,39 @@ def _verify_tar_members(tar: tarfile.TarFile, target: Path) -> None:
             _fail(f"unsafe tar member link: {member.name}")
 
 
+def _run_checked(
+    command: list[str],
+    *,
+    timeout: int,
+    description: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            command,
+            timeout=timeout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except subprocess.TimeoutExpired as exc:
+        output = exc.stdout or ""
+        if isinstance(output, bytes):
+            output = output.decode(errors="replace")
+        _fail(f"{description} timed out after {timeout} seconds\n{output}")
+
+    if result.returncode != 0:
+        _fail(
+            f"{description} exited with status {result.returncode}\n"
+            f"{result.stdout}"
+        )
+    return result
+
+
 def _run_help(binary: Path) -> None:
-    subprocess.run(
+    _run_checked(
         [str(binary), "--help"],
-        check=True,
-        timeout=10,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
+        timeout=60,
+        description=f"{binary.name} --help",
     )
 
 

--- a/scripts/smoke_binary_package.py
+++ b/scripts/smoke_binary_package.py
@@ -135,15 +135,6 @@ def _fetch(url: str) -> bytes:
         return response.read()
 
 
-def _read_process_output(process: subprocess.Popen[str]) -> str:
-    if process.stdout is None:
-        return ""
-    try:
-        return process.stdout.read()
-    except OSError as exc:
-        return f"<failed to read process output: {exc}>"
-
-
 def _terminate_process_tree(process: subprocess.Popen[str]) -> None:
     if process.poll() is not None:
         return
@@ -173,6 +164,7 @@ def _terminate_process_tree(process: subprocess.Popen[str]) -> None:
 def _smoke_server(server_binary: Path, port: int) -> None:
     env = os.environ.copy()
     with _temporary_directory(prefix="powermem-server-smoke-") as tmp:
+        log_path = Path(tmp) / "powermem-server-smoke.log"
         env.update(
             {
                 "CI": "1",
@@ -185,69 +177,71 @@ def _smoke_server(server_binary: Path, port: int) -> None:
                 "POWERMEM_SERVER_LOG_FILE": "",
             }
         )
-        process = subprocess.Popen(
-            [
-                str(server_binary),
-                "--host",
-                "localhost",
-                "--port",
-                str(port),
-                "--workers",
-                "1",
-                "--no-open-browser",
-            ],
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
 
-        failure: str | None = None
-        try:
-            ready_timeout = 180 if os.name == "nt" else 60
-            deadline = time.monotonic() + ready_timeout
-            health_body: bytes | None = None
-            dashboard_body: bytes | None = None
-            while time.monotonic() < deadline:
-                if process.poll() is not None:
-                    failure = (
-                        "powermem-server exited before becoming ready "
-                        f"with code {process.returncode}"
-                    )
-                    break
-                try:
-                    health_body = _fetch(f"http://localhost:{port}/api/v1/system/health")
-                    dashboard_body = _fetch(f"http://localhost:{port}/dashboard/")
-                    break
-                except urllib.error.HTTPError as exc:
-                    if exc.code == 404:
-                        failure = "dashboard endpoint returned 404"
+        with log_path.open("w", encoding="utf-8", errors="replace") as server_output:
+            process = subprocess.Popen(
+                [
+                    str(server_binary),
+                    "--host",
+                    "localhost",
+                    "--port",
+                    str(port),
+                    "--workers",
+                    "1",
+                    "--no-open-browser",
+                ],
+                env=env,
+                stdout=server_output,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            failure: str | None = None
+            try:
+                ready_timeout = 180 if os.name == "nt" else 60
+                deadline = time.monotonic() + ready_timeout
+                health_body: bytes | None = None
+                dashboard_body: bytes | None = None
+                while time.monotonic() < deadline:
+                    if process.poll() is not None:
+                        failure = (
+                            "powermem-server exited before becoming ready "
+                            f"with code {process.returncode}"
+                        )
                         break
-                    time.sleep(1)
-                except (OSError, urllib.error.URLError):
-                    time.sleep(1)
+                    try:
+                        health_body = _fetch(f"http://localhost:{port}/api/v1/system/health")
+                        dashboard_body = _fetch(f"http://localhost:{port}/dashboard/")
+                        break
+                    except urllib.error.HTTPError as exc:
+                        if exc.code == 404:
+                            failure = "dashboard endpoint returned 404"
+                            break
+                        time.sleep(1)
+                    except (OSError, urllib.error.URLError):
+                        time.sleep(1)
 
-            if failure is None and (health_body is None or dashboard_body is None):
-                failure = (
-                    "powermem-server did not become ready before timeout "
-                    f"({ready_timeout} seconds)"
-                )
+                if failure is None and (health_body is None or dashboard_body is None):
+                    failure = (
+                        "powermem-server did not become ready before timeout "
+                        f"({ready_timeout} seconds)"
+                    )
 
-            if failure is None:
-                assert health_body is not None
-                assert dashboard_body is not None
-                health = json.loads(health_body.decode("utf-8"))
-                if health.get("success") is not True:
-                    failure = f"health response did not report success=true: {health}"
-                elif health.get("data", {}).get("status") != "healthy":
-                    failure = f"health response did not report status=healthy: {health}"
-                elif not dashboard_body.strip():
-                    failure = "dashboard response body is empty"
-        finally:
-            _terminate_process_tree(process)
+                if failure is None:
+                    assert health_body is not None
+                    assert dashboard_body is not None
+                    health = json.loads(health_body.decode("utf-8"))
+                    if health.get("success") is not True:
+                        failure = f"health response did not report success=true: {health}"
+                    elif health.get("data", {}).get("status") != "healthy":
+                        failure = f"health response did not report status=healthy: {health}"
+                    elif not dashboard_body.strip():
+                        failure = "dashboard response body is empty"
+            finally:
+                _terminate_process_tree(process)
 
         if failure is not None:
-            output = _read_process_output(process)
+            output = log_path.read_text(encoding="utf-8", errors="replace")
             _fail(f"{failure}\n{output}")
 
 

--- a/scripts/smoke_binary_package.py
+++ b/scripts/smoke_binary_package.py
@@ -164,7 +164,7 @@ def _terminate_process_tree(process: subprocess.Popen[str]) -> None:
 def _smoke_server(server_binary: Path, port: int) -> None:
     env = os.environ.copy()
     with _temporary_directory(prefix="powermem-server-smoke-") as tmp:
-        log_path = Path(tmp) / "powermem-server-smoke.log"
+        server_output_path = Path(tmp) / "powermem-server-smoke-output.txt"
         env.update(
             {
                 "CI": "1",
@@ -178,7 +178,7 @@ def _smoke_server(server_binary: Path, port: int) -> None:
             }
         )
 
-        with log_path.open("w", encoding="utf-8", errors="replace") as server_output:
+        with server_output_path.open("w", encoding="utf-8", errors="replace") as server_output:
             process = subprocess.Popen(
                 [
                     str(server_binary),

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_binary_builder_verifies_miniconda_installer_checksum() -> None:
+    dockerfile = (ROOT / "docker" / "Dockerfile.binaries-centos7").read_text()
+
+    assert "ARG MINICONDA_SHA256=" in dockerfile
+    assert "634d76df5e489c44ade4085552b97bebc786d49245ed1a830022b0b406de5817" in dockerfile
+    assert 'echo "${MINICONDA_SHA256}  /tmp/miniconda.sh" | sha256sum -c -' in dockerfile
+
+
+def test_release_binary_help_smokes_are_bounded() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
+
+    assert 'timeout 10s "${BIN_ROOT}/bin/powermem" --help' in workflow
+    assert 'timeout 10s "${BIN_ROOT}/bin/powermem-server" --help' in workflow
+
+
+def test_release_binary_tarball_bin_contents_are_exact() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
+
+    assert 'find "${BIN_ROOT}/bin" -mindepth 1 -maxdepth 1 -printf "%f\\n"' in workflow
+    assert 'printf "powermem\\npowermem-mcp\\npowermem-server\\n"' in workflow
+    assert "diff -u /tmp/linux-binary-expected-bin-files.txt /tmp/linux-binary-bin-files.txt" in workflow
+
+
+def test_release_binary_server_smoke_checks_health_json_and_dashboard() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
+
+    assert "http://localhost:18848/api/v1/system/health" in workflow
+    assert "http://localhost:18848/dashboard/" in workflow
+    assert '"success\\"[[:space:]]*:[[:space:]]*true"' in workflow
+    assert '"status\\"[[:space:]]*:[[:space:]]*\\"healthy\\""' in workflow

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -36,6 +36,9 @@ def test_release_binary_server_smoke_checks_health_json_and_dashboard() -> None:
 
     assert "/api/v1/system/health" in smoke_script
     assert "/dashboard/" in smoke_script
+    assert 'ready_timeout = 180 if os.name == "nt" else 60' in smoke_script
+    assert '"taskkill", "/F", "/T", "/PID"' in smoke_script
+    assert "ignore_cleanup_errors=os.name == \"nt\"" in smoke_script
     assert 'health.get("success") is not True' in smoke_script
     assert 'health.get("data", {}).get("status") != "healthy"' in smoke_script
 

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from scripts.smoke_binary_package import _package_name
+
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -13,24 +15,68 @@ def test_binary_builder_verifies_miniconda_installer_checksum() -> None:
 
 
 def test_release_binary_help_smokes_are_bounded() -> None:
-    workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
+    smoke_script = (ROOT / "scripts" / "smoke_binary_package.py").read_text()
 
-    assert 'timeout 10s "${BIN_ROOT}/bin/powermem" --help' in workflow
-    assert 'timeout 10s "${BIN_ROOT}/bin/powermem-server" --help' in workflow
+    assert "[str(binary), \"--help\"]" in smoke_script
+    assert "timeout=10" in smoke_script
 
 
 def test_release_binary_tarball_bin_contents_are_exact() -> None:
-    workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
+    smoke_script = (ROOT / "scripts" / "smoke_binary_package.py").read_text()
 
-    assert 'find "${BIN_ROOT}/bin" -mindepth 1 -maxdepth 1 -printf "%f\\n"' in workflow
-    assert 'printf "powermem\\npowermem-mcp\\npowermem-server\\n"' in workflow
-    assert "diff -u /tmp/linux-binary-expected-bin-files.txt /tmp/linux-binary-bin-files.txt" in workflow
+    assert 'f"powermem{exe_suffix}"' in smoke_script
+    assert 'f"powermem-server{exe_suffix}"' in smoke_script
+    assert 'f"powermem-mcp{exe_suffix}"' in smoke_script
+    assert "actual != expected" in smoke_script
 
 
 def test_release_binary_server_smoke_checks_health_json_and_dashboard() -> None:
+    smoke_script = (ROOT / "scripts" / "smoke_binary_package.py").read_text()
+
+    assert "/api/v1/system/health" in smoke_script
+    assert "/dashboard/" in smoke_script
+    assert 'health.get("success") is not True' in smoke_script
+    assert 'health.get("data", {}).get("status") != "healthy"' in smoke_script
+
+
+def test_release_binary_builder_accepts_platform_and_arch_targets() -> None:
+    builder = (ROOT / "scripts" / "build_binary_package.sh").read_text()
+
+    assert "POWERMEM_BINARY_OS" in builder
+    assert "POWERMEM_BINARY_ARCH" in builder
+    assert "PACKAGE_BASENAME=\"powermem-${VERSION}-${TARGET_OS}-${TARGET_ARCH}\"" in builder
+    assert "POWERMEM_BINARY_FORMAT" in builder
+    assert ".sha256" in builder
+
+
+def test_release_binary_matrix_includes_supported_macos_and_windows_arches() -> None:
     workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
 
-    assert "http://localhost:18848/api/v1/system/health" in workflow
-    assert "http://localhost:18848/dashboard/" in workflow
-    assert '"success\\"[[:space:]]*:[[:space:]]*true"' in workflow
-    assert '"status\\"[[:space:]]*:[[:space:]]*\\"healthy\\""' in workflow
+    assert "build-native-binaries:" in workflow
+    assert "macos-15-intel" in workflow
+    assert "macos-15" in workflow
+    assert "windows-2022" in workflow
+    assert "windows-11-arm" not in workflow
+    assert "binary-arch: amd64" in workflow
+    assert "binary-arch: aarch64" in workflow
+    assert 'python -m pip install ".[cli,server,mcp,seekdb]" pyinstaller' in workflow
+
+
+def test_release_uploads_arch_named_binary_assets() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
+
+    assert "name: powermem-linux-amd64-binaries" in workflow
+    assert "name: powermem-${{ matrix.binary-os }}-${{ matrix.binary-arch }}-binaries" in workflow
+    assert "pattern: powermem-*-binaries" in workflow
+    assert "binary-artifacts/*" in workflow
+
+
+def test_smoke_script_maps_archive_names_to_package_dirs() -> None:
+    assert (
+        _package_name(Path("powermem-1.1.4-linux-amd64-binaries.tar.gz"))
+        == "powermem-1.1.4-linux-amd64"
+    )
+    assert (
+        _package_name(Path("powermem-1.1.4-windows-aarch64-binaries.zip"))
+        == "powermem-1.1.4-windows-aarch64"
+    )

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -39,7 +39,7 @@ def test_release_binary_server_smoke_checks_health_json_and_dashboard() -> None:
     assert 'ready_timeout = 180 if os.name == "nt" else 60' in smoke_script
     assert '"taskkill", "/F", "/T", "/PID"' in smoke_script
     assert "ignore_cleanup_errors=os.name == \"nt\"" in smoke_script
-    assert "powermem-server-smoke.log" in smoke_script
+    assert "powermem-server-smoke-output.txt" in smoke_script
     assert "stdout=server_output" in smoke_script
     assert '"AGENT_MEMORY_MODE": "multi_user"' in smoke_script
     assert 'health.get("success") is not True' in smoke_script

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -39,6 +39,8 @@ def test_release_binary_server_smoke_checks_health_json_and_dashboard() -> None:
     assert 'ready_timeout = 180 if os.name == "nt" else 60' in smoke_script
     assert '"taskkill", "/F", "/T", "/PID"' in smoke_script
     assert "ignore_cleanup_errors=os.name == \"nt\"" in smoke_script
+    assert "powermem-server-smoke.log" in smoke_script
+    assert "stdout=server_output" in smoke_script
     assert '"AGENT_MEMORY_MODE": "multi_user"' in smoke_script
     assert 'health.get("success") is not True' in smoke_script
     assert 'health.get("data", {}).get("status") != "healthy"' in smoke_script

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -39,6 +39,7 @@ def test_release_binary_server_smoke_checks_health_json_and_dashboard() -> None:
     assert 'ready_timeout = 180 if os.name == "nt" else 60' in smoke_script
     assert '"taskkill", "/F", "/T", "/PID"' in smoke_script
     assert "ignore_cleanup_errors=os.name == \"nt\"" in smoke_script
+    assert '"AGENT_MEMORY_MODE": "multi_user"' in smoke_script
     assert 'health.get("success") is not True' in smoke_script
     assert 'health.get("data", {}).get("status") != "healthy"' in smoke_script
 

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -18,7 +18,8 @@ def test_release_binary_help_smokes_are_bounded() -> None:
     smoke_script = (ROOT / "scripts" / "smoke_binary_package.py").read_text()
 
     assert "[str(binary), \"--help\"]" in smoke_script
-    assert "timeout=10" in smoke_script
+    assert "timeout=60" in smoke_script
+    assert "_run_checked(" in smoke_script
 
 
 def test_release_binary_tarball_bin_contents_are_exact() -> None:
@@ -59,7 +60,14 @@ def test_release_binary_matrix_includes_supported_macos_and_windows_arches() -> 
     assert "windows-11-arm" not in workflow
     assert "binary-arch: amd64" in workflow
     assert "binary-arch: aarch64" in workflow
+    assert 'python -m pip install --upgrade pip "setuptools<81" wheel' in workflow
     assert 'python -m pip install ".[cli,server,mcp,seekdb]" pyinstaller' in workflow
+
+
+def test_linux_binary_dockerfile_pins_pyinstaller_setuptools_runtime_api() -> None:
+    dockerfile = (ROOT / "docker" / "Dockerfile.binaries-centos7").read_text()
+
+    assert 'python -m pip install --upgrade pip "setuptools<81" wheel' in dockerfile
 
 
 def test_release_uploads_arch_named_binary_assets() -> None:

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -41,6 +41,8 @@ def test_release_binary_server_smoke_checks_health_json_and_dashboard() -> None:
     assert "ignore_cleanup_errors=os.name == \"nt\"" in smoke_script
     assert "powermem-server-smoke-output.txt" in smoke_script
     assert "stdout=server_output" in smoke_script
+    assert "log_path" not in smoke_script
+    assert "server_output_path.read_text" in smoke_script
     assert '"AGENT_MEMORY_MODE": "multi_user"' in smoke_script
     assert 'health.get("success") is not True' in smoke_script
     assert 'health.get("data", {}).get("status") != "healthy"' in smoke_script


### PR DESCRIPTION
## Summary
- Publish the Claude Code plugin zip as part of version releases.
- Publish standalone binary packages with platform and architecture in the artifact names.
- Keep Linux amd64 on the CentOS 7 build path and add native macOS amd64, macOS AArch64, and Windows amd64 packages.
- Smoke-test binary archives for checksums, exact `bin/` contents, bounded CLI help, server health/dashboard, and MCP stdio.

Fixes #1059.
Fixes #1061.
Fixes #1062.
Fixes #1063.
Fixes #1065.
Fixes #1066.

Windows AArch64 is tracked separately in #1077 because the current CPython 3.11 dependency chain does not provide the required `win_arm64` wheels.

## Validation
- Unit tests for release binary workflow safeguards.
- Linux amd64 local binary package build and archive smoke test.
- Dependency wheel checks for the native platform matrix.
- GitHub Actions Build Package run passed for Linux amd64, macOS amd64, macOS AArch64, and Windows amd64 binary package jobs.
