### PR TITLE
Merge MCP dependencies into server extra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ bump-version: ## Bump version number (usage: make bump-version VERSION=0.2.0)
 	@$(SED_INPLACE) -E 's/"version": "[0-9]+\.[0-9]+\.[0-9]+"/"version": "$(VERSION)"/g' src/powermem/core/audit.py
 	@# Update powermem-mcp wrapper package version and dependency pin
 	@$(SED_INPLACE) 's/^version = ".*"/version = "$(VERSION)"/' packages/powermem-mcp/pyproject.toml
-	@$(SED_INPLACE) -E 's/powermem\[mcp,seekdb\]==[0-9]+\.[0-9]+\.[0-9]+/powermem[mcp,seekdb]==$(VERSION)/' packages/powermem-mcp/pyproject.toml
+	@$(SED_INPLACE) -E 's/powermem\[server,seekdb\]==[0-9]+\.[0-9]+\.[0-9]+/powermem[server,seekdb]==$(VERSION)/' packages/powermem-mcp/pyproject.toml
 	@$(MAKE) check-package-versions
 	@echo "✓ Version updated to $(VERSION) in all files (excluding examples/)"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -216,34 +216,28 @@ Full framework guide: [AgentScope integration](docs/integrations/agentscope.md).
 
 ## Quick start (Python SDK)
 
-**Prerequisites:** Copy [.env.example](.env.example) to `.env` and set your **LLM** API key — that is the only required credential. For zero-config local storage, install the `seekdb` extra (`pip install "powermem[seekdb]"`, or combine it with `server` / `mcp`) so the default **OceanBase** provider can boot **embedded seekdb** on disk. Without `seekdb`, set `OCEANBASE_HOST` to point at a remote OceanBase cluster, or switch to `sqlite` / `postgres`. The default embedder is a local `all-MiniLM-L6-v2` model (384 dims) that needs no API key and auto-downloads on first use. Need to tune providers or unlock advanced features? Copy [.env.example.full](.env.example.full) instead — it documents every available knob, grouped by component. After install, `pmem config init` walks you through the same setup interactively. See [Getting started](docs/guides/0001-getting_started.md).
+**Prerequisites:** Copy [.env.example](.env.example) to `.env` and set your **LLM** API key — that is the only required credential. For zero-config local storage, install the `seekdb` extra (`pip install "powermem[seekdb]"`, or combine it with `server`) so the default **OceanBase** provider can boot **embedded seekdb** on disk. Without `seekdb`, set `OCEANBASE_HOST` to point at a remote OceanBase cluster, or switch to `sqlite` / `postgres`. The default embedder is a local `all-MiniLM-L6-v2` model (384 dims) that needs no API key and auto-downloads on first use. Need to tune providers or unlock advanced features? Copy [.env.example.full](.env.example.full) instead — it documents every available knob, grouped by component. After install, `pmem config init` walks you through the same setup interactively. See [Getting started](docs/guides/0001-getting_started.md).
 
 ### Install
 
 ```bash
-# Core only (SDK; no optional CLI/server/MCP/seekdb)
+# Core only (SDK; no optional CLI/server/seekdb)
 pip install powermem
 
 # With CLI (pmem / powermem-cli)
 pip install "powermem[cli]"
 
-# With HTTP API server only (powermem-server; does not install seekdb)
+# With HTTP API server and MCP support (powermem-server / powermem-mcp; does not install seekdb)
 pip install "powermem[server]"
-
-# With MCP server only (powermem-mcp; does not install seekdb)
-pip install "powermem[mcp]"
 
 # With seekdb for zero-config local storage/embedder
 pip install "powermem[seekdb]"
 
-# HTTP API server + seekdb
+# HTTP API server + MCP support + seekdb
 pip install "powermem[server,seekdb]"
 
-# MCP server + seekdb
-pip install "powermem[mcp,seekdb]"
-
 # Common full local install
-pip install "powermem[cli,server,mcp,seekdb]"
+pip install "powermem[cli,server,seekdb]"
 ```
 
 For zero-install MCP clients such as Cursor, Codex, Claude Desktop, Cline, or
@@ -254,7 +248,7 @@ uvx powermem-mcp
 ```
 
 The `powermem-mcp` wrapper is version-locked to the main `powermem` release and
-installs `powermem[mcp,seekdb]` for the same version. If `uv` has cached an older
+installs `powermem[server,seekdb]` for the same version. If `uv` has cached an older
 tool environment, refresh it explicitly:
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -207,34 +207,28 @@ pip install powermem langchain langchain-openai
 
 ## 快速开始（Python SDK）
 
-**前置条件：** 将 [.env.example](.env.example) 复制为 `.env`，仅需配置 **LLM** 的 API key。如需零配置本地存储，请安装 `seekdb` extra（`pip install "powermem[seekdb]"`，或与 `server` / `mcp` 组合安装），这样默认的 **OceanBase** provider 才能在未配置 host 时启动 **嵌入式 seekdb**。未安装 `seekdb` 时，请设置 `OCEANBASE_HOST` 连接远端 OceanBase 集群，或改用 `sqlite` / `postgres`。默认 embedder 是本地的 `all-MiniLM-L6-v2`（384 维），无需 API key，首次使用时自动下载。如需更高性能或开启高级特性，可改用 [.env.example.full](.env.example.full)，其中按组件分组记录了所有可调参数。安装后执行 `pmem config init` 可交互式生成同样的配置。详见 [入门指南](docs/guides/0001-getting_started.md)。
+**前置条件：** 将 [.env.example](.env.example) 复制为 `.env`，仅需配置 **LLM** 的 API key。如需零配置本地存储，请安装 `seekdb` extra（`pip install "powermem[seekdb]"`，或与 `server` 组合安装），这样默认的 **OceanBase** provider 才能在未配置 host 时启动 **嵌入式 seekdb**。未安装 `seekdb` 时，请设置 `OCEANBASE_HOST` 连接远端 OceanBase 集群，或改用 `sqlite` / `postgres`。默认 embedder 是本地的 `all-MiniLM-L6-v2`（384 维），无需 API key，首次使用时自动下载。如需更高性能或开启高级特性，可改用 [.env.example.full](.env.example.full)，其中按组件分组记录了所有可调参数。安装后执行 `pmem config init` 可交互式生成同样的配置。详见 [入门指南](docs/guides/0001-getting_started.md)。
 
 ### 安装
 
 ```bash
-# 仅核心（SDK；不包含 CLI/server/MCP/seekdb）
+# 仅核心（SDK；不包含 CLI/server/seekdb）
 pip install powermem
 
 # 带 CLI（pmem / powermem-cli）
 pip install "powermem[cli]"
 
-# 仅带 HTTP API Server（powermem-server；不安装 seekdb）
+# 带 HTTP API Server 和 MCP 支持（powermem-server / powermem-mcp；不安装 seekdb）
 pip install "powermem[server]"
-
-# 仅带 MCP Server（powermem-mcp；不安装 seekdb）
-pip install "powermem[mcp]"
 
 # 带 seekdb（零配置本地存储 / embedder 必需）
 pip install "powermem[seekdb]"
 
-# HTTP API Server + seekdb
+# HTTP API Server + MCP 支持 + seekdb
 pip install "powermem[server,seekdb]"
 
-# MCP Server + seekdb
-pip install "powermem[mcp,seekdb]"
-
 # 常用本地完整安装
-pip install "powermem[cli,server,mcp,seekdb]"
+pip install "powermem[cli,server,seekdb]"
 ```
 
 ### SDK 用法

--- a/README_JP.md
+++ b/README_JP.md
@@ -207,34 +207,28 @@ pip install powermem langchain langchain-openai
 
 ## クイックスタート（Python SDK）
 
-**前提:** [.env.example](.env.example) を `.env` にコピーし、**LLM** の API キーだけを設定してください。ゼロコンフィグのローカルストレージを使う場合は `seekdb` extra（`pip install "powermem[seekdb]"`、または `server` / `mcp` との組み合わせ）をインストールしてください。これにより、デフォルトの **OceanBase** プロバイダは host 未設定時に **埋め込み seekdb** を起動できます。`seekdb` をインストールしない場合は、`OCEANBASE_HOST` でリモート OceanBase クラスタを指定するか、`sqlite` / `postgres` に切り替えてください。デフォルトの embedder はローカル実行の `all-MiniLM-L6-v2`（384 次元）で、API キー不要・初回利用時に自動ダウンロードされます。プロバイダ切り替えや高度な設定が必要な場合は [.env.example.full](.env.example.full) をコピーしてください。コンポーネントごとに全ての設定項目がまとめられています。インストール後は `pmem config init` で対話的に同じ設定を生成できます。詳しくは [はじめに](docs/guides/0001-getting_started.md) を参照してください。
+**前提:** [.env.example](.env.example) を `.env` にコピーし、**LLM** の API キーだけを設定してください。ゼロコンフィグのローカルストレージを使う場合は `seekdb` extra（`pip install "powermem[seekdb]"`、または `server` との組み合わせ）をインストールしてください。これにより、デフォルトの **OceanBase** プロバイダは host 未設定時に **埋め込み seekdb** を起動できます。`seekdb` をインストールしない場合は、`OCEANBASE_HOST` でリモート OceanBase クラスタを指定するか、`sqlite` / `postgres` に切り替えてください。デフォルトの embedder はローカル実行の `all-MiniLM-L6-v2`（384 次元）で、API キー不要・初回利用時に自動ダウンロードされます。プロバイダ切り替えや高度な設定が必要な場合は [.env.example.full](.env.example.full) をコピーしてください。コンポーネントごとに全ての設定項目がまとめられています。インストール後は `pmem config init` で対話的に同じ設定を生成できます。詳しくは [はじめに](docs/guides/0001-getting_started.md) を参照してください。
 
 ### インストール
 
 ```bash
-# コアのみ（SDK。CLI/server/MCP/seekdb は含まない）
+# コアのみ（SDK。CLI/server/seekdb は含まない）
 pip install powermem
 
 # CLI付き（pmem / powermem-cli）
 pip install "powermem[cli]"
 
-# HTTP API Server のみ（powermem-server。seekdb はインストールしない）
+# HTTP API Server と MCP サポート（powermem-server / powermem-mcp。seekdb はインストールしない）
 pip install "powermem[server]"
-
-# MCP Server のみ（powermem-mcp。seekdb はインストールしない）
-pip install "powermem[mcp]"
 
 # seekdb 付き（ゼロコンフィグのローカルストレージ / embedder に必要）
 pip install "powermem[seekdb]"
 
-# HTTP API Server + seekdb
+# HTTP API Server + MCP サポート + seekdb
 pip install "powermem[server,seekdb]"
 
-# MCP Server + seekdb
-pip install "powermem[mcp,seekdb]"
-
 # 一般的なローカル全部入りインストール
-pip install "powermem[cli,server,mcp,seekdb]"
+pip install "powermem[cli,server,seekdb]"
 ```
 
 ### SDK サンプル

--- a/apps/README.md
+++ b/apps/README.md
@@ -37,9 +37,10 @@ For **OpenClaw**, use the separate [`memory-powermem`](https://github.com/ob-lab
 
 Each setup guide is **idempotent**: re-running it reuses an existing healthy backend and updates the target client config instead of duplicating entries.
 
-For manual installs, `powermem[server]` provides both the HTTP API server and
-the MCP entry point. Add `seekdb` (for example `powermem[server,seekdb]`) when
-you want the default embedded seekdb storage/embedder.
+For manual installs, `powermem[server]` provides the runtime dependencies for
+both the HTTP API server and MCP transports. Add `seekdb` (for example
+`powermem[server,seekdb]`) when you want the default embedded seekdb
+storage/embedder.
 
 ## Backend strategy
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -37,9 +37,9 @@ For **OpenClaw**, use the separate [`memory-powermem`](https://github.com/ob-lab
 
 Each setup guide is **idempotent**: re-running it reuses an existing healthy backend and updates the target client config instead of duplicating entries.
 
-For manual installs, `powermem[server]` provides the HTTP API server and `powermem[mcp]`
-provides the MCP entry point. Add `seekdb` (for example `powermem[server,seekdb]` or
-`powermem[mcp,seekdb]`) when you want the default embedded seekdb storage/embedder.
+For manual installs, `powermem[server]` provides both the HTTP API server and
+the MCP entry point. Add `seekdb` (for example `powermem[server,seekdb]`) when
+you want the default embedded seekdb storage/embedder.
 
 ## Backend strategy
 

--- a/apps/claude-code-plugin/SETUP.md
+++ b/apps/claude-code-plugin/SETUP.md
@@ -236,9 +236,9 @@ writing. Never silently patch `.env`.**
       dependencies, etc.
 
    c. **All four package install locations** affected by (a)-(b):
-      1. `uv pip install --python "$POWERMEM_PYTHON" -e '.[server,mcp,seekdb]'`
+      1. `uv pip install --python "$POWERMEM_PYTHON" -e '.[server,seekdb]'`
       2. `uv pip install --python "$POWERMEM_PYTHON" -q modelscope`
-      3. `uv pip install --python "$POWERMEM_PYTHON" "powermem[mcp,seekdb]"`
+      3. `uv pip install --python "$POWERMEM_PYTHON" "powermem[server,seekdb]"`
       4. `uv pip install --python "$POWERMEM_PYTHON" -q huggingface_hub`
 
 2. COLLECT CONFIG (idempotent). If a .env already exists in the working directory
@@ -346,11 +346,10 @@ writing. Never silently patch `.env`.**
       uv venv venv --python python3.11
       POWERMEM_PYTHON="$(pwd)/venv/bin/python"
       export PATH="$(pwd)/venv/bin:$PATH"
-      uv pip install --python "$POWERMEM_PYTHON" -e '.[server,mcp,seekdb]'
+      uv pip install --python "$POWERMEM_PYTHON" -e '.[server,seekdb]'
       ```
-      ⚠️ All three extras are required: `[server]` adds fastapi/uvicorn; `[mcp]` adds
-      fastmcp, which is checked at import time and calls sys.exit(1) if missing —
-      this kills the HTTP server before it can start even in HTTP-only mode;
+      ⚠️ Both extras are required: `[server]` adds fastapi/uvicorn and
+      fastmcp for the HTTP API plus MCP entry points;
       `[seekdb]` adds the embedded seekdb storage backend (default).
     - Immediately after `uv pip install`, detect which Python interpreter was used. Read
       the shebang from the freshly-installed `powermem-server` entry point — this is
@@ -493,7 +492,7 @@ writing. Never silently patch `.env`.**
       uv venv venv --python python3.11
       POWERMEM_PYTHON="$(pwd)/venv/bin/python"
       export PATH="$(pwd)/venv/bin:$PATH"
-      uv pip install --python "$POWERMEM_PYTHON" "powermem[mcp,seekdb]"
+      uv pip install --python "$POWERMEM_PYTHON" "powermem[server,seekdb]"
       powermem-mcp --help
     - Register the MCP server globally so it persists across sessions (stdio = no
       port), run from the directory holding the .env. Idempotent: if `claude mcp get
@@ -733,12 +732,12 @@ resets initialization and makes startup take even longer.
 
 #### [E009] Server Exits Immediately — `fastapi`, `uvicorn`, or `fastmcp` Missing
 **Problem**: Server exits immediately after launch with "Missing dependencies" error.
-**Cause**: installing only the base project skips optional server/MCP dependencies. `fastmcp` is checked
-at **import time** and calls `sys.exit(1)` if absent — `try/except` cannot catch this,
-so even the HTTP-only server is killed before it starts.
+**Cause**: installing only the base project skips optional server dependencies.
+`powermem[server]` installs fastapi, uvicorn, and fastmcp for the HTTP API plus
+MCP entry points.
 **Fix**:
 ```bash
-uv pip install --python "$POWERMEM_PYTHON" -e '.[server,mcp,seekdb]'
+uv pip install --python "$POWERMEM_PYTHON" -e '.[server,seekdb]'
 ```
 
 #### [E010] Anthropic `temperature` + `top_p` both sent → 400
@@ -861,7 +860,7 @@ source venv/bin/activate
 POWERMEM_PYTHON="$VIRTUAL_ENV/bin/python"
 
 # Install everything with ALL required extras
-uv pip install --python "$POWERMEM_PYTHON" -e '.[server,mcp,seekdb]'
+uv pip install --python "$POWERMEM_PYTHON" -e '.[server,seekdb]'
 
 # Build and stage Claude hooks
 make build-claude-hook
@@ -883,7 +882,7 @@ powermem-server --host 0.0.0.0 --port 8848 &
 uv venv venv --python python3.11
 source venv/bin/activate
 POWERMEM_PYTHON="$VIRTUAL_ENV/bin/python"
-uv pip install --python "$POWERMEM_PYTHON" 'powermem[mcp,seekdb]'
+uv pip install --python "$POWERMEM_PYTHON" 'powermem[server,seekdb]'
 claude mcp remove powermem 2>/dev/null
 claude mcp add powermem -- powermem-mcp stdio
 ```

--- a/apps/claude-code-plugin/SETUP.md
+++ b/apps/claude-code-plugin/SETUP.md
@@ -349,7 +349,7 @@ writing. Never silently patch `.env`.**
       uv pip install --python "$POWERMEM_PYTHON" -e '.[server,seekdb]'
       ```
       ⚠️ Both extras are required: `[server]` adds fastapi/uvicorn and
-      fastmcp for the HTTP API plus MCP entry points;
+      fastmcp for the HTTP API plus MCP transports;
       `[seekdb]` adds the embedded seekdb storage backend (default).
     - Immediately after `uv pip install`, detect which Python interpreter was used. Read
       the shebang from the freshly-installed `powermem-server` entry point — this is
@@ -488,7 +488,7 @@ writing. Never silently patch `.env`.**
       now; every `claude` and `claude -p` loads it automatically.
 
 3b. PYPI/MCP path:
-    - Install the MCP extra in the environment that Claude will use, then:
+    - Install the server extra in the environment that Claude will use, then:
       uv venv venv --python python3.11
       POWERMEM_PYTHON="$(pwd)/venv/bin/python"
       export PATH="$(pwd)/venv/bin:$PATH"
@@ -734,7 +734,7 @@ resets initialization and makes startup take even longer.
 **Problem**: Server exits immediately after launch with "Missing dependencies" error.
 **Cause**: installing only the base project skips optional server dependencies.
 `powermem[server]` installs fastapi, uvicorn, and fastmcp for the HTTP API plus
-MCP entry points.
+MCP transports.
 **Fix**:
 ```bash
 uv pip install --python "$POWERMEM_PYTHON" -e '.[server,seekdb]'

--- a/apps/mcp-client/SETUP.md
+++ b/apps/mcp-client/SETUP.md
@@ -76,10 +76,10 @@ cd "$REPO_ROOT"
 [ -d .venv ] || python3 -m venv .venv
 source .venv/bin/activate
 if command -v uv >/dev/null 2>&1; then
-  uv pip install -e ".[mcp,cli]"
+  uv pip install -e ".[server,cli]"
 else
   python -m pip install -U pip setuptools wheel
-  python -m pip install -e ".[mcp,cli]"
+  python -m pip install -e ".[server,cli]"
 fi
 ```
 

--- a/apps/vscode-extension/SETUP.md
+++ b/apps/vscode-extension/SETUP.md
@@ -207,10 +207,10 @@ if [ "${POWERMEM_BACKEND_READY:-0}" != "1" ]; then
   [ -d .venv ] || python3 -m venv .venv
   source .venv/bin/activate
   if command -v uv >/dev/null 2>&1; then
-    uv pip install -e ".[server,mcp,cli]"
+    uv pip install -e ".[server,cli]"
   else
     python -m pip install -U pip setuptools wheel
-    python -m pip install -e ".[server,mcp,cli]"
+    python -m pip install -e ".[server,cli]"
   fi
 fi
 ```
@@ -786,7 +786,7 @@ Ask **one setting at a time**:
 ```bash
 command -v powermem-server || {
   cd /path/to/powermem
-  pip install -e ".[server,mcp,cli,seekdb]"
+  pip install -e ".[server,cli,seekdb]"
 }
 ```
 

--- a/docs/integrations/agentscope.md
+++ b/docs/integrations/agentscope.md
@@ -14,7 +14,7 @@ AgentScope-specific storage adapter is required.
 - PowerMem installed with MCP support:
 
 ```bash
-pip install "powermem[mcp]"
+pip install "powermem[server]"
 ```
 
 - PowerMem configured with your storage, LLM, and embedding providers.

--- a/docs/integrations/claude_code.md
+++ b/docs/integrations/claude_code.md
@@ -287,7 +287,7 @@ After `apply-connection-mode.sh mcp`, edit `.mcp.json` or `config/mcp-mode.mcp.j
 }
 ```
 
-Ensure PowerMem is installed (`uv pip install --python "$VIRTUAL_ENV/bin/python" "powermem[mcp,seekdb]"`) and a `.env` is available when using stdio.
+Ensure PowerMem is installed (`uv pip install --python "$VIRTUAL_ENV/bin/python" "powermem[server,seekdb]"`) and a `.env` is available when using stdio.
 
 ### HTTP mode: REST only (standard)
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -27,9 +27,8 @@ The agent follows [`apps/vscode-extension/SETUP.md`](https://github.com/oceanbas
   - or `powermem-mcp sse` (default port 8848; same as `powermem-mcp sse 8848`)
 - PowerMem configured with your LLM provider, API key, and model.
 
-Install `powermem[server]` for the HTTP API server. Install `powermem[mcp]` for the
-local MCP command, and add `seekdb` when using the default embedded seekdb
-storage/embedder.
+Install `powermem[server]` for both the HTTP API server and the local MCP
+command, and add `seekdb` when using the default embedded seekdb storage/embedder.
 
 ## Manual setup
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -27,8 +27,9 @@ The agent follows [`apps/vscode-extension/SETUP.md`](https://github.com/oceanbas
   - or `powermem-mcp sse` (default port 8848; same as `powermem-mcp sse 8848`)
 - PowerMem configured with your LLM provider, API key, and model.
 
-Install `powermem[server]` for both the HTTP API server and the local MCP
-command, and add `seekdb` when using the default embedded seekdb storage/embedder.
+Install `powermem[server]` for the HTTP API server and MCP runtime
+dependencies, and add `seekdb` when using the default embedded seekdb
+storage/embedder.
 
 ## Manual setup
 

--- a/docs/integrations/mcp_client.md
+++ b/docs/integrations/mcp_client.md
@@ -4,8 +4,8 @@ Use this guide for Claude Desktop, Cline, Codex, OpenCode, Roo Code, Goose, or a
 
 ## Prerequisites
 
-- PowerMem installed with MCP support. Use `powermem[mcp,seekdb]` for zero-config
-  local seekdb, or `powermem[mcp]` when your `.env` points at non-seekdb
+- PowerMem installed with MCP support. Use `powermem[server,seekdb]` for zero-config
+  local seekdb, or `powermem[server]` when your `.env` points at non-seekdb
   storage/embedder providers.
 - PowerMem configured with your LLM provider, API key, and model.
 

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -32,8 +32,9 @@ The agent follows [`apps/mcp-client/SETUP.md`](https://github.com/oceanbase/powe
   - Preferred for OpenCode MCP tools: `powermem-mcp stdio` or `powermem-mcp streamable-http 8848`
 - PowerMem configured with your LLM provider, API key, and model.
 
-Install `powermem[server]` for both the HTTP API server and the local MCP
-command, and add `seekdb` when using the default embedded seekdb storage/embedder.
+Install `powermem[server]` for the HTTP API server and MCP runtime
+dependencies, and add `seekdb` when using the default embedded seekdb
+storage/embedder.
 
 ## Manual setup
 

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -32,9 +32,8 @@ The agent follows [`apps/mcp-client/SETUP.md`](https://github.com/oceanbase/powe
   - Preferred for OpenCode MCP tools: `powermem-mcp stdio` or `powermem-mcp streamable-http 8848`
 - PowerMem configured with your LLM provider, API key, and model.
 
-Install `powermem[server]` for the HTTP API server. Install `powermem[mcp]` for the
-local MCP command, and add `seekdb` when using the default embedded seekdb
-storage/embedder.
+Install `powermem[server]` for both the HTTP API server and the local MCP
+command, and add `seekdb` when using the default embedded seekdb storage/embedder.
 
 ## Manual setup
 

--- a/docs/integrations/qoder.md
+++ b/docs/integrations/qoder.md
@@ -41,10 +41,10 @@ Use this section only when you want to wire Qoder by hand.
 Install PowerMem with MCP support if you want local stdio MCP:
 
 ```bash
-pip install "powermem[mcp,seekdb]"
+pip install "powermem[server,seekdb]"
 ```
 
-Use `powermem[mcp]` only when your `.env` points at non-seekdb storage/embedder
+Use `powermem[server]` only when your `.env` points at non-seekdb storage/embedder
 providers.
 
 Then run the installed MCP command:

--- a/docs/integrations/vs_code.md
+++ b/docs/integrations/vs_code.md
@@ -27,8 +27,9 @@ The agent follows [`apps/vscode-extension/SETUP.md`](https://github.com/oceanbas
   - `powermem-mcp sse` (port 8848) when you only need MCP.
 - A configured PowerMem `.env` or equivalent environment variables. Set your LLM provider, API key, and model before starting the backend.
 
-Install `powermem[server]` for both the HTTP API server and the local MCP
-command, and add `seekdb` when using the default embedded seekdb storage/embedder.
+Install `powermem[server]` for the HTTP API server and MCP runtime
+dependencies, and add `seekdb` when using the default embedded seekdb
+storage/embedder.
 
 ## Manual setup
 

--- a/docs/integrations/vs_code.md
+++ b/docs/integrations/vs_code.md
@@ -27,9 +27,8 @@ The agent follows [`apps/vscode-extension/SETUP.md`](https://github.com/oceanbas
   - `powermem-mcp sse` (port 8848) when you only need MCP.
 - A configured PowerMem `.env` or equivalent environment variables. Set your LLM provider, API key, and model before starting the backend.
 
-Install `powermem[server]` for the HTTP API server. Install `powermem[mcp]` for the
-local MCP command, and add `seekdb` when using the default embedded seekdb
-storage/embedder.
+Install `powermem[server]` for both the HTTP API server and the local MCP
+command, and add `seekdb` when using the default embedded seekdb storage/embedder.
 
 ## Manual setup
 

--- a/packages/powermem-mcp/README.md
+++ b/packages/powermem-mcp/README.md
@@ -4,7 +4,7 @@ Thin wrapper package for launching the PowerMem MCP server with `uvx`.
 
 This package intentionally uses the same version as the main
 [`powermem`](https://pypi.org/project/powermem/) package. For example,
-`powermem-mcp==1.1.4` depends on `powermem[mcp,seekdb]==1.1.4`.
+`powermem-mcp==1.1.4` depends on `powermem[server,seekdb]==1.1.4`.
 
 Use this package when an MCP client needs a zero-install command such as:
 

--- a/packages/powermem-mcp/pyproject.toml
+++ b/packages/powermem-mcp/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "powermem-mcp"
 version = "1.1.4"
-description = "PowerMem MCP server - thin wrapper that installs powermem[mcp,seekdb] and exposes the powermem-mcp command."
+description = "PowerMem MCP server - thin wrapper that installs powermem[server,seekdb] and exposes the powermem-mcp command."
 readme = "README.md"
 license = "Apache-2.0"
 authors = [
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "powermem[mcp,seekdb]==1.1.4",
+    "powermem[server,seekdb]==1.1.4",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,14 +59,11 @@ cli = [
 ]
 server = [
     "click>=8.0.0",
+    "fastmcp>=1.0",
     "fastapi>=0.100.0",
     "python-multipart>=0.0.6",
-    "uvicorn>=0.23.0",
-    "slowapi>=0.1.9",
-]
-mcp = [
-    "fastmcp>=1.0",
     "uvicorn>=0.27.1",
+    "slowapi>=0.1.9",
 ]
 seekdb = [
     "pyobvector[pyseekdb]>=0.2.24,<0.3.0",

--- a/scripts/check_package_versions.py
+++ b/scripts/check_package_versions.py
@@ -24,7 +24,7 @@ def main() -> int:
     root_version = read_project_version(ROOT_PYPROJECT)
     mcp_text = MCP_PYPROJECT.read_text()
     mcp_version = read_project_version(MCP_PYPROJECT)
-    expected_dependency = f"powermem[mcp,seekdb]=={root_version}"
+    expected_dependency = f"powermem[server,seekdb]=={root_version}"
 
     errors: list[str] = []
     if mcp_version != root_version:

--- a/src/powermem/mcp/__init__.py
+++ b/src/powermem/mcp/__init__.py
@@ -2,5 +2,5 @@
 PowerMem MCP Server
 
 Exposes PowerMem memory operations over the Model Context Protocol (MCP).
-Requires: pip install 'powermem[mcp]'
+Requires: pip install 'powermem[server]'
 """

--- a/src/powermem/mcp/server.py
+++ b/src/powermem/mcp/server.py
@@ -11,7 +11,7 @@ Provides 13 tools for memory and user profile management:
 - 6 user profile tools: add_with_profile, search_with_profile, get_profile,
   list_profiles, delete_profile, delete_memory_with_profile
 
-Requires: pip install 'powermem[mcp]'
+Requires: pip install 'powermem[server]'
 """
 
 def _require_mcp_deps() -> None:
@@ -25,7 +25,7 @@ def _require_mcp_deps() -> None:
     if missing:
         raise ImportError(
             f"Missing dependencies: {', '.join(missing)}. "
-            "Run: pip install 'powermem[mcp]'"
+            "Run: pip install 'powermem[server]'"
         ) from import_error
 
 

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -30,9 +30,9 @@ logger = logging.getLogger("server")
 
 
 def _load_mcp_asgi_app():
-    """Return streamable HTTP MCP ASGI app when powermem[mcp] is installed."""
+    """Return streamable HTTP MCP ASGI app when powermem[server] is installed."""
     if find_spec("fastmcp") is None:
-        logger.warning("MCP extras not installed; /mcp endpoint disabled")
+        logger.warning("MCP server dependencies not installed; /mcp endpoint disabled")
         return None
 
     try:
@@ -40,7 +40,9 @@ def _load_mcp_asgi_app():
 
         return mcp.http_app(path="/mcp", transport="streamable-http")
     except ImportError as exc:
-        logger.warning("MCP extras not installed; /mcp endpoint disabled: %s", exc)
+        logger.warning(
+            "MCP server dependencies not installed; /mcp endpoint disabled: %s", exc
+        )
         return None
 
 
@@ -130,7 +132,7 @@ if dashboard_assets_available():
 # Include API routers
 app.include_router(v1_router)
 
-# Streamable HTTP MCP on the same port as the REST API (requires powermem[mcp])
+# Streamable HTTP MCP on the same port as the REST API (requires powermem[server])
 if mcp_asgi_app is not None:
     app.mount("", mcp_asgi_app)
     logger.info("Mounted PowerMem MCP at /mcp")

--- a/tests/unit/test_optional_dependency_imports.py
+++ b/tests/unit/test_optional_dependency_imports.py
@@ -27,7 +27,7 @@ def test_mcp_missing_fastmcp_raises_import_error_not_system_exit(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", guarded_import)
 
     try:
-        with pytest.raises(ImportError, match="powermem\\[mcp\\]"):
+        with pytest.raises(ImportError, match="powermem\\[server\\]"):
             importlib.import_module(module_name)
     finally:
         _restore_module(module_name, saved_module)


### PR DESCRIPTION
## Summary

Closes #1070.

- Move the MCP runtime dependencies into the `server` extra and remove the separate `mcp` optional dependency group.
- Update `powermem-mcp` wrapper packaging to depend on `powermem[server,seekdb]`.
- Refresh install docs and setup guides so users install `powermem[server]` for both HTTP API and MCP support.
- Update missing-dependency messaging/tests to point at `powermem[server]`.

## Validation

- `python3.11 scripts/check_package_versions.py`
- `python3.11 -m pytest tests/unit/test_optional_dependency_imports.py tests/unit/server/test_main_mcp_optional.py tests/unit/server/test_server_cli.py`
- `python3.11` metadata check that `mcp` extra is absent and `server` includes `fastmcp>=1.0` plus `uvicorn>=0.27.1`
- `git diff --check`