### PR TITLE
docs: improve .env.example.full reranker and embedding provider documentation

### DIFF
--- a/.env.example.full
+++ b/.env.example.full
@@ -277,10 +277,17 @@ DEEPSEEK_LLM_BASE_URL=https://api.deepseek.com
 #   Recommended:  default   (the built-in local `all-MiniLM-L6-v2`; no API
 #                            key, model auto-downloads to ~/.cache on first
 #                            use — zero-config, runs entirely locally)
-#   Other options: qwen      (cloud; higher recall, needs an API key),
-#                  openai, siliconflow,
+#   Other options: qwen       (cloud; higher recall, needs an API key),
+#                  openai     (OpenAI text-embedding family),
+#                  siliconflow (OpenAI-compatible; CN-friendly),
 #                  huggingface (local sentence-transformers / TEI server),
-#                  ollama / lmstudio (fully local via a separate runtime)
+#                  ollama / lmstudio (fully local via a separate runtime),
+#                  azure_openai (Azure-hosted OpenAI embeddings),
+#                  gemini     (Google GenAI embedding),
+#                  vertexai   (Google Vertex AI embedding),
+#                  together   (Together AI),
+#                  aws_bedrock (AWS Bedrock embedding),
+#                  zai        (Zhipu AI embedding)
 EMBEDDING_PROVIDER=default
 
 # EMBEDDING_API_KEY — credential for the chosen provider. Not used by
@@ -297,8 +304,12 @@ EMBEDDING_PROVIDER=default
 #   For `openai`:                text-embedding-3-large (best, 3072d),
 #                                text-embedding-3-small (cheaper, 1536d),
 #                                text-embedding-ada-002 (legacy)
+#   For `siliconflow`:           BAAI/bge-m3, BAAI/bge-large-zh-v1.5
 #   For `huggingface`:           sentence-transformers/all-MiniLM-L6-v2,
 #                                bge-m3, etc.
+#   For `azure_openai`:          your-deployment-name
+#   For `gemini`:                gemini-embedding-001
+#   For `zai`:                   embedding-3
 EMBEDDING_MODEL=all-MiniLM-L6-v2
 # EMBEDDING_DIMS — output vector dimension. MUST match the model above AND
 # the OCEANBASE_EMBEDDING_MODEL_DIMS in your storage section.
@@ -340,22 +351,46 @@ OLLAMA_EMBEDDING_BASE_URL=
 RERANKER_ENABLED=false
 # RERANKER_PROVIDER — which rerank service to call when enabled.
 #   Recommended:  qwen   (qwen3-rerank; strong CN/EN performance)
-#   Other options: jina (jina-reranker family), zai (Zhipu AI rerank)
+#   Other options: jina    (Jina AI cloud rerank API),
+#                  zai     (Zhipu AI rerank),
+#                  generic (any standard rerank API — SiliconFlow, Xinference,
+#                           vLLM, or other OpenAI-compatible rerank services)
 RERANKER_PROVIDER=qwen
 # RERANKER_MODEL — specific rerank model.
 #   Recommended:  qwen3-rerank   (matches the Qwen provider above)
-#   Other options for `jina`:    jina-reranker-v2-base-multilingual
-#   For `zai`:                   rerank-3-base, rerank-3-large
+#   Other options for `jina`:    jina-reranker-v3 (latest),
+#                                jina-reranker-v2-base-multilingual
+#   For `zai`:                   rerank (default)
+#   For `generic`:               depends on backend — see examples below
 RERANKER_MODEL=qwen3-rerank
 RERANKER_API_KEY=your_api_key_here
-# RERANKER_API_BASE_URL — override only when fronting the provider with a
-# proxy or self-hosted gateway.
+# RERANKER_API_BASE_URL — endpoint for the rerank API.
+#   For `qwen`:    auto-resolved via DashScope SDK (override not needed)
+#   For `jina`:    https://api.jina.ai/v1/rerank (default)
+#   For `zai`:     https://open.bigmodel.cn/api/paas/v4/rerank (default)
+#   For `generic`: REQUIRED — set to your service endpoint, e.g.:
+#                  https://api.siliconflow.cn/v1/rerank (SiliconFlow)
+#                  http://localhost:9997/v1/rerank      (Xinference local)
 # RERANKER_API_BASE_URL=
 
 # Each provider also accepts its native keys / URLs if RERANKER_* is unset:
-#   Qwen:    DASHSCOPE_API_KEY + DASHSCOPE_BASE_URL
-#   Jina:    JINA_API_KEY      + JINA_API_BASE_URL
-#   Zhipu AI: ZAI_API_KEY      + ZAI_API_BASE_URL
+#   Qwen:     DASHSCOPE_API_KEY + DASHSCOPE_BASE_URL
+#   Jina:     JINA_API_KEY      + JINA_API_BASE_URL
+#   Zhipu AI: ZAI_API_KEY       + ZAI_API_BASE_URL
+
+# --- Example: SiliconFlow rerank via `generic` provider ---
+# RERANKER_ENABLED=true
+# RERANKER_PROVIDER=generic
+# RERANKER_MODEL=BAAI/bge-reranker-v2-m3
+# RERANKER_API_BASE_URL=https://api.siliconflow.cn/v1/rerank
+# RERANKER_API_KEY=your_siliconflow_api_key
+
+# --- Example: Local Xinference rerank via `generic` provider ---
+# RERANKER_ENABLED=true
+# RERANKER_PROVIDER=generic
+# RERANKER_MODEL=bge-reranker-v2-m3
+# RERANKER_API_BASE_URL=http://localhost:9997/v1/rerank
+# RERANKER_API_KEY=
 
 # =============================================================================
 # 5. Agent (Optional) — controls how memories are scoped, shared, and


### PR DESCRIPTION
## Summary

While configuring PowerMem I wanted to integrate SiliconFlow and other third-party services as a reranker, but found no guidance in `.env.example.full` on how to do so. The code already supports a `generic` reranker provider and many more embedding providers than documented. This PR improves the configuration reference to match what the code actually supports.

### Changes

- Document the `generic` reranker provider for standard rerank APIs (SiliconFlow, Xinference, vLLM, or any OpenAI-compatible rerank endpoint)
- Add concrete configuration examples for SiliconFlow and local Xinference rerank setups
- Add all code-supported embedding providers (`azure_openai`, `gemini`, `vertexai`, `together`, `aws_bedrock`, `zai`) to the `EMBEDDING_PROVIDER` list
- Add model examples for `siliconflow`, `azure_openai`, `gemini`, `zai` embedding providers
- Fix `RERANKER_MODEL` comment defaults to match actual code: `jina-reranker-v3` (was `jina-reranker-v2-base-multilingual`), `rerank` for zai (was `rerank-3-base, rerank-3-large`)
- Expand `RERANKER_API_BASE_URL` comments with per-provider default URLs

### Why

- Users trying to use SiliconFlow, Xinference, or other rerank services have no configuration guidance
- The `generic` provider is a powerful universal adapter but is completely invisible in the docs
- Several implemented embedding providers are missing from the configuration reference
- Stale model defaults in comments vs code create confusion

Closes #1072

## Validation

- Cross-checked all provider names against `src/powermem/integrations/rerank/config/providers.py` and `src/powermem/integrations/embeddings/config/providers.py`
- Verified default model values match code: `jina-reranker-v3`, `rerank` (zai), `qwen3-rerank`
- Verified default API base URLs match code: `https://api.jina.ai/v1/rerank`, `https://open.bigmodel.cn/api/paas/v4/rerank`
- Verified SiliconFlow rerank API format compatibility with `GenericRerank` implementation (standard `{model, query, documents}` → `{results: [{index, relevance_score}]}`)
- `git diff --check` passes
