### PR TITLE
Force single worker when MCP is mounted

### DIFF
--- a/src/server/cli/server.py
+++ b/src/server/cli/server.py
@@ -13,6 +13,7 @@ import time
 import urllib.error
 import urllib.request
 import webbrowser
+from importlib.util import find_spec
 from typing import Optional
 
 
@@ -240,6 +241,11 @@ def _is_embedded_storage() -> bool:
     return False
 
 
+def _is_mcp_enabled() -> bool:
+    """Return whether the in-process server will mount the streamable HTTP MCP app."""
+    return find_spec("fastmcp") is not None
+
+
 def _run_server_app(**kwargs) -> None:
     """Start uvicorn after verifying server extras are installed."""
     _require_server_deps()
@@ -293,6 +299,16 @@ def server(host, port, workers, reload, log_level, open_browser):
     if not config.reload and config.workers != 1 and _is_embedded_storage():
         print(
             f"[server] Embedded storage detected (SQLite or seekdb without host). "
+            f"Forcing workers=1 (was {config.workers}).",
+            file=sys.stderr,
+        )
+        config.workers = 1
+
+    # MCP streamable HTTP sessions are process-local, so multiple worker
+    # processes would split session state and break follow-up requests.
+    if not config.reload and config.workers != 1 and _is_mcp_enabled():
+        print(
+            f"[server] MCP streamable HTTP sessions are process-local. "
             f"Forcing workers=1 (was {config.workers}).",
             file=sys.stderr,
         )

--- a/tests/unit/server/test_server_cli.py
+++ b/tests/unit/server/test_server_cli.py
@@ -256,6 +256,8 @@ def test_cli_starts_one_browser_waiter_with_reload_and_workers(monkeypatch):
     bind_available = Mock()
     start_browser = Mock()
     uvicorn_run = Mock()
+    embedded_storage = Mock(return_value=False)
+    mcp_enabled = Mock(return_value=True)
     original = {
         "host": server_cli.config.host,
         "port": server_cli.config.port,
@@ -265,7 +267,8 @@ def test_cli_starts_one_browser_waiter_with_reload_and_workers(monkeypatch):
     monkeypatch.setattr(server_cli, "_should_open_browser", lambda _requested: True)
     monkeypatch.setattr(server_cli, "_assert_bind_available", bind_available)
     monkeypatch.setattr(server_cli, "_start_dashboard_browser", start_browser)
-    monkeypatch.setattr(server_cli, "_is_embedded_storage", lambda: False)
+    monkeypatch.setattr(server_cli, "_is_embedded_storage", embedded_storage)
+    monkeypatch.setattr(server_cli, "_is_mcp_enabled", mcp_enabled)
     monkeypatch.setattr(server_cli, "_setup_server_logging", lambda: None)
     monkeypatch.setattr(server_cli, "_run_server_app", uvicorn_run)
 
@@ -290,8 +293,73 @@ def test_cli_starts_one_browser_waiter_with_reload_and_workers(monkeypatch):
     assert result.exit_code == 0
     bind_available.assert_called_once_with("0.0.0.0", 9988)
     start_browser.assert_called_once_with("0.0.0.0", 9988)
+    embedded_storage.assert_not_called()
+    mcp_enabled.assert_not_called()
     uvicorn_run.assert_called_once()
     assert uvicorn_run.call_args.kwargs["workers"] == 1
+
+
+def test_cli_forces_single_worker_when_mcp_is_enabled(monkeypatch):
+    runner = CliRunner()
+    uvicorn_run = Mock()
+    original = {
+        "host": server_cli.config.host,
+        "port": server_cli.config.port,
+        "workers": server_cli.config.workers,
+        "reload": server_cli.config.reload,
+    }
+    monkeypatch.setattr(server_cli, "_should_open_browser", lambda _requested: False)
+    monkeypatch.setattr(server_cli, "_assert_bind_available", Mock())
+    monkeypatch.setattr(server_cli, "_is_embedded_storage", lambda: False)
+    monkeypatch.setattr(server_cli, "_is_mcp_enabled", lambda: True)
+    monkeypatch.setattr(server_cli, "_setup_server_logging", lambda: None)
+    monkeypatch.setattr(server_cli, "_run_server_app", uvicorn_run)
+
+    try:
+        result = runner.invoke(
+            server_cli.server,
+            ["--workers", "4", "--no-open-browser"],
+        )
+    finally:
+        for name, value in original.items():
+            setattr(server_cli.config, name, value)
+
+    assert result.exit_code == 0
+    assert "MCP streamable HTTP sessions are process-local" in result.stderr
+    assert "Forcing workers=1 (was 4)" in result.stderr
+    uvicorn_run.assert_called_once()
+    assert uvicorn_run.call_args.kwargs["workers"] == 1
+
+
+def test_cli_keeps_multiple_workers_without_process_local_modes(monkeypatch):
+    runner = CliRunner()
+    uvicorn_run = Mock()
+    original = {
+        "host": server_cli.config.host,
+        "port": server_cli.config.port,
+        "workers": server_cli.config.workers,
+        "reload": server_cli.config.reload,
+    }
+    monkeypatch.setattr(server_cli, "_should_open_browser", lambda _requested: False)
+    monkeypatch.setattr(server_cli, "_assert_bind_available", Mock())
+    monkeypatch.setattr(server_cli, "_is_embedded_storage", lambda: False)
+    monkeypatch.setattr(server_cli, "_is_mcp_enabled", lambda: False)
+    monkeypatch.setattr(server_cli, "_setup_server_logging", lambda: None)
+    monkeypatch.setattr(server_cli, "_run_server_app", uvicorn_run)
+
+    try:
+        result = runner.invoke(
+            server_cli.server,
+            ["--workers", "4", "--no-open-browser"],
+        )
+    finally:
+        for name, value in original.items():
+            setattr(server_cli.config, name, value)
+
+    assert result.exit_code == 0
+    assert result.stderr == ""
+    uvicorn_run.assert_called_once()
+    assert uvicorn_run.call_args.kwargs["workers"] == 4
 
 
 def test_cli_no_open_browser_disables_waiter(monkeypatch):


### PR DESCRIPTION
Refs #1056

Note: this PR implements the short-term single-worker guard from #1056. The longer-term stateless MCP session handling needed for true multi-worker support remains tracked there.

Summary:
- Detect when the server CLI can mount the streamable HTTP MCP app.
- Reuse the existing single-worker guard so MCP sessions are not split across multiple worker processes.
- Keep multi-worker startup unchanged when no process-local runtime mode is active, and avoid running the guard checks in reload mode.

Validation:
- Using the project virtual environment, ran `python -m pytest tests/unit/server/test_server_cli.py tests/unit/server/test_main_mcp_optional.py -q` (31 passed, 1 warning from an existing dependency deprecation).
- Using the project virtual environment, ran `python -m py_compile src/server/cli/server.py tests/unit/server/test_server_cli.py`.
- Ran `git diff --check`.
- E2E: with MCP dependencies installed and non-embedded storage configuration, started `powermem-server --host <loopback host> --port <local test port> --workers 2 --no-open-browser`; startup printed the MCP single-worker guard and forced `workers=1` before server initialization. The process was stopped after the guard was observed.
