### PR TITLE
fix: resolve docs dependency and checkout deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run isolated Claude Code hook regression
         run: make test-claude-hook-docker

--- a/docs/website/package-lock.json
+++ b/docs/website/package-lock.json
@@ -9435,9 +9435,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -43,5 +43,8 @@
   },
   "engines": {
     "node": ">=20.0"
+  },
+  "overrides": {
+    "http-proxy-middleware": "2.0.10"
   }
 }


### PR DESCRIPTION
## Summary
- Add a docs website npm override for http-proxy-middleware 2.0.10
- Refresh the docs website lockfile so webpack-dev-server resolves the patched transitive version
- Update the claude-hook-regression checkout step from actions/checkout@v4 to the repository-standard actions/checkout@v6 to avoid the Node.js 20 deprecation warning

## Verification
- npm ci --registry=https://registry.npmjs.org
- npm ls http-proxy-middleware --all
- NPM_CONFIG_REGISTRY=https://registry.npmjs.org npm audit --json | jq '.vulnerabilities["http-proxy-middleware"] // null'
- npm run typecheck
- rg 'actions/checkout@v4' .github
- git diff --check

## Notes
- npm run build currently fails because the Docusaurus current docs folder is missing in docs/website/docs on main; this appears unrelated to the dependency override.