### PR TITLE
docs: update LOCOMO benchmark results

### DIFF
--- a/docs/images/benchmark_metrics_cn.svg
+++ b/docs/images/benchmark_metrics_cn.svg
@@ -8,17 +8,17 @@
   
   <!-- 更准 -->
   <text x="160" y="45" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#1a1a1a" text-anchor="middle">更准</text>
-  <text x="160" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">+48.77%</text>
-  <text x="160" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">78.70% VS 52.9%</text>
+  <text x="160" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">+65.9%</text>
+  <text x="160" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">87.79% VS 52.9%</text>
   
   <!-- 更快 -->
   <text x="460" y="45" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#1a1a1a" text-anchor="middle">更快</text>
-  <text x="460" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">91.83%</text>
+  <text x="460" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">91.6%</text>
   <text x="460" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">1.44s VS 17.12s</text>
   
   <!-- 更省 -->
   <text x="760" y="45" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#1a1a1a" text-anchor="middle">更省</text>
-  <text x="760" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">96.53%</text>
+  <text x="760" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">96.5%</text>
   <text x="760" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">0.9k VS 26k</text>
 </svg>
 

--- a/docs/images/benchmark_metrics_en.svg
+++ b/docs/images/benchmark_metrics_en.svg
@@ -8,17 +8,17 @@
   
   <!-- Accurate -->
   <text x="160" y="45" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#1a1a1a" text-anchor="middle">Accurate</text>
-  <text x="160" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">+48.77%</text>
-  <text x="160" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">78.70% VS 52.9%</text>
+  <text x="160" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">+65.9%</text>
+  <text x="160" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">87.79% VS 52.9%</text>
   
   <!-- Agile -->
   <text x="460" y="45" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#1a1a1a" text-anchor="middle">Agile</text>
-  <text x="460" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">91.83%</text>
+  <text x="460" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">91.6%</text>
   <text x="460" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">1.44s VS 17.12s</text>
   
   <!-- Affordable -->
   <text x="760" y="45" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#1a1a1a" text-anchor="middle">Affordable</text>
-  <text x="760" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">96.53%</text>
+  <text x="760" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">96.5%</text>
   <text x="760" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">0.9k VS 26k</text>
 </svg>
 

--- a/docs/images/benchmark_metrics_jp.svg
+++ b/docs/images/benchmark_metrics_jp.svg
@@ -8,17 +8,17 @@
   
   <!-- より正確 -->
   <text x="160" y="45" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#1a1a1a" text-anchor="middle">より正確</text>
-  <text x="160" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">+48.77%</text>
-  <text x="160" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">78.70% VS 52.9%</text>
+  <text x="160" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">+65.9%</text>
+  <text x="160" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">87.79% VS 52.9%</text>
   
   <!-- アジャイル -->
   <text x="460" y="45" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#1a1a1a" text-anchor="middle">アジャイル</text>
-  <text x="460" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">91.83%</text>
+  <text x="460" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">91.6%</text>
   <text x="460" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">1.44s VS 17.12s</text>
   
   <!-- より経済的 -->
   <text x="760" y="45" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#1a1a1a" text-anchor="middle">より経済的</text>
-  <text x="760" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">96.53%</text>
+  <text x="760" y="110" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="#0066cc" text-anchor="middle">96.5%</text>
   <text x="760" y="150" font-family="Arial, sans-serif" font-size="12" fill="#666" text-anchor="middle">0.9k VS 26k</text>
 </svg>
 

--- a/docs/website/src/components/Benchmark/index.tsx
+++ b/docs/website/src/components/Benchmark/index.tsx
@@ -6,7 +6,7 @@ import ZapIcon from './icons/ZapIcon';
 import styles from './styles.module.css';
 
 const overallScores = {
-  llm_score: 0.7708,
+  llm_score: 0.8779,
 };
 
 const translations: Record<string, Record<string, string>> = {
@@ -29,7 +29,7 @@ const translations: Record<string, Record<string, string>> = {
 };
 
 const formatScore = (num: number) => {
-  return (num * 100).toFixed(2);
+  return (num * 100).toFixed(2) + '%';
 };
 
 export default function Benchmark() {

--- a/docs/website/src/components/ValueProps/index.tsx
+++ b/docs/website/src/components/ValueProps/index.tsx
@@ -18,20 +18,23 @@ const valueProps = [
 const getComparisonData = (isZh: boolean) => ({
   accurate: {
     fullContext: 52.9,
-    powermem: 78.7,
-    unit: '',
+    powermem: 87.79,
+    unit: '%',
+    improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
   agile: {
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
-    label: isZh ? '响应时间' : 'Response Time',
+    improvement: '-91.6%',
+    label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
   affordable: {
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
 });
@@ -166,21 +169,7 @@ export default function ValueProps() {
                       <span className={styles.comparisonUnit}>{activeComparison.unit}</span>
                     </div>
                     <div className={styles.improvement}>
-                      {hoveredKey === 'accurate' && (
-                        <span className={styles.improvementText}>
-                          +{(activeComparison.powermem - activeComparison.fullContext).toFixed(1)}
-                        </span>
-                      )}
-                      {hoveredKey === 'agile' && (
-                        <span className={styles.improvementText}>
-                          {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x faster
-                        </span>
-                      )}
-                      {hoveredKey === 'affordable' && (
-                        <span className={styles.improvementText}>
-                          {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x less
-                        </span>
-                      )}
+                    <span className={styles.improvementText}>{activeComparison.improvement}</span>
                     </div>
                   </div>
                   

--- a/docs/website/src/components/ValueProps/index.tsx
+++ b/docs/website/src/components/ValueProps/index.tsx
@@ -20,6 +20,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 52.9,
     powermem: 87.79,
     unit: '%',
+    prefix: '',
     improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
@@ -27,6 +28,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
+    prefix: '',
     improvement: '-91.6%',
     label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
@@ -34,6 +36,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    prefix: '~',
     improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
@@ -165,7 +168,7 @@ export default function ValueProps() {
                   <div className={`${styles.comparisonItem} ${styles.comparisonItemPowerMem}`}>
                     <div className={styles.comparisonLabel}>PowerMem</div>
                     <div className={styles.comparisonValue}>
-                      {activeComparison.powermem}
+                      {activeComparison.prefix}{activeComparison.powermem}
                       <span className={styles.comparisonUnit}>{activeComparison.unit}</span>
                     </div>
                     <div className={styles.improvement}>
@@ -184,7 +187,7 @@ export default function ValueProps() {
                       {isZh ? 'Full-Context' : 'Full-Context'}
                     </div>
                     <div className={styles.comparisonValue}>
-                      {activeComparison.fullContext}
+                      {activeComparison.prefix}{activeComparison.fullContext}
                       <span className={styles.comparisonUnit}>{activeComparison.unit}</span>
                     </div>
                   </div>

--- a/docs/website/src/components/ValueProps1/index.tsx
+++ b/docs/website/src/components/ValueProps1/index.tsx
@@ -18,6 +18,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 52.9,
     powermem: 87.79,
     unit: '%',
+    prefix: '',
     improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
@@ -25,6 +26,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
+    prefix: '',
     improvement: '-91.6%',
     label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
@@ -32,6 +34,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    prefix: '~',
     improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
@@ -150,7 +153,7 @@ export default function ValueProps1() {
                     <div className={styles.progressLabel}>
                       <span>PowerMem</span>
                       <span className={styles.progressValue}>
-                        {activeComparison.powermem}{activeComparison.unit}
+                        {activeComparison.prefix}{activeComparison.powermem}{activeComparison.unit}
                       </span>
                     </div>
                     <div className={styles.progressBar}>
@@ -171,7 +174,7 @@ export default function ValueProps1() {
                     <div className={styles.progressLabel}>
                       <span>Full-Context</span>
                       <span className={styles.progressValue}>
-                        {activeComparison.fullContext}{activeComparison.unit}
+                        {activeComparison.prefix}{activeComparison.fullContext}{activeComparison.unit}
                       </span>
                     </div>
                     <div className={styles.progressBar}>

--- a/docs/website/src/components/ValueProps1/index.tsx
+++ b/docs/website/src/components/ValueProps1/index.tsx
@@ -16,20 +16,23 @@ const valueProps = [
 const getComparisonData = (isZh: boolean) => ({
   accurate: {
     fullContext: 52.9,
-    powermem: 78.7,
-    unit: '',
+    powermem: 87.79,
+    unit: '%',
+    improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
   agile: {
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
-    label: isZh ? '响应时间' : 'Response Time',
+    improvement: '-91.6%',
+    label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
   affordable: {
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
 });
@@ -181,21 +184,7 @@ export default function ValueProps1() {
 
                   {/* Improvement Badge */}
                   <div className={styles.improvement}>
-                    {hoveredKey === 'accurate' && (
-                      <span className={styles.improvementText}>
-                        +{(activeComparison.powermem - activeComparison.fullContext).toFixed(1)}
-                      </span>
-                    )}
-                    {hoveredKey === 'agile' && (
-                      <span className={styles.improvementText}>
-                        {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x faster
-                      </span>
-                    )}
-                    {hoveredKey === 'affordable' && (
-                      <span className={styles.improvementText}>
-                        {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x less
-                      </span>
-                    )}
+                    <span className={styles.improvementText}>{activeComparison.improvement}</span>
                   </div>
                 </div>
               </div>

--- a/docs/website/src/components/ValueProps2/index.tsx
+++ b/docs/website/src/components/ValueProps2/index.tsx
@@ -18,6 +18,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 52.9,
     powermem: 87.79,
     unit: '%',
+    prefix: '',
     improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
@@ -25,6 +26,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
+    prefix: '',
     improvement: '-91.6%',
     label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
@@ -32,6 +34,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    prefix: '~',
     improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
@@ -173,7 +176,7 @@ export default function ValueProps2() {
                         />
                       </svg>
                       <div className={styles.gaugeValue}>
-                        {activeComparison.powermem}
+                        {activeComparison.prefix}{activeComparison.powermem}
                         <span className={styles.gaugeUnit}>{activeComparison.unit}</span>
                       </div>
                     </div>
@@ -207,7 +210,7 @@ export default function ValueProps2() {
                         />
                       </svg>
                       <div className={styles.gaugeValue}>
-                        {activeComparison.fullContext}
+                        {activeComparison.prefix}{activeComparison.fullContext}
                         <span className={styles.gaugeUnit}>{activeComparison.unit}</span>
                       </div>
                     </div>

--- a/docs/website/src/components/ValueProps2/index.tsx
+++ b/docs/website/src/components/ValueProps2/index.tsx
@@ -16,20 +16,23 @@ const valueProps = [
 const getComparisonData = (isZh: boolean) => ({
   accurate: {
     fullContext: 52.9,
-    powermem: 78.7,
-    unit: '',
+    powermem: 87.79,
+    unit: '%',
+    improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
   agile: {
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
-    label: isZh ? '响应时间' : 'Response Time',
+    improvement: '-91.6%',
+    label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
   affordable: {
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
 });
@@ -212,21 +215,7 @@ export default function ValueProps2() {
 
                   {/* Improvement Badge */}
                   <div className={styles.improvement}>
-                    {hoveredKey === 'accurate' && (
-                      <span className={styles.improvementText}>
-                        +{(activeComparison.powermem - activeComparison.fullContext).toFixed(1)}
-                      </span>
-                    )}
-                    {hoveredKey === 'agile' && (
-                      <span className={styles.improvementText}>
-                        {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x faster
-                      </span>
-                    )}
-                    {hoveredKey === 'affordable' && (
-                      <span className={styles.improvementText}>
-                        {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x less
-                      </span>
-                    )}
+                    <span className={styles.improvementText}>{activeComparison.improvement}</span>
                   </div>
                 </div>
               </div>

--- a/docs/website/src/components/ValueProps3/index.tsx
+++ b/docs/website/src/components/ValueProps3/index.tsx
@@ -16,20 +16,23 @@ const valueProps = [
 const getComparisonData = (isZh: boolean) => ({
   accurate: {
     fullContext: 52.9,
-    powermem: 78.7,
-    unit: '',
+    powermem: 87.79,
+    unit: '%',
+    improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
   agile: {
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
-    label: isZh ? '响应时间' : 'Response Time',
+    improvement: '-91.6%',
+    label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
   affordable: {
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
 });
@@ -151,21 +154,7 @@ export default function ValueProps3() {
                         <span className={styles.cardUnit}>{activeComparison.unit}</span>
                       </div>
                       <div className={styles.cardImprovement}>
-                        {hoveredKey === 'accurate' && (
-                          <span className={styles.improvementText}>
-                            +{(activeComparison.powermem - activeComparison.fullContext).toFixed(1)}
-                          </span>
-                        )}
-                        {hoveredKey === 'agile' && (
-                          <span className={styles.improvementText}>
-                            {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x faster
-                          </span>
-                        )}
-                        {hoveredKey === 'affordable' && (
-                          <span className={styles.improvementText}>
-                            {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x less
-                          </span>
-                        )}
+                    <span className={styles.improvementText}>{activeComparison.improvement}</span>
                       </div>
                     </div>
 

--- a/docs/website/src/components/ValueProps3/index.tsx
+++ b/docs/website/src/components/ValueProps3/index.tsx
@@ -18,6 +18,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 52.9,
     powermem: 87.79,
     unit: '%',
+    prefix: '',
     improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
@@ -25,6 +26,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
+    prefix: '',
     improvement: '-91.6%',
     label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
@@ -32,6 +34,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    prefix: '~',
     improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
@@ -150,7 +153,7 @@ export default function ValueProps3() {
                         <div className={styles.cardBadge}>Winner</div>
                       </div>
                       <div className={styles.cardValue}>
-                        {activeComparison.powermem}
+                        {activeComparison.prefix}{activeComparison.powermem}
                         <span className={styles.cardUnit}>{activeComparison.unit}</span>
                       </div>
                       <div className={styles.cardImprovement}>
@@ -169,7 +172,7 @@ export default function ValueProps3() {
                         <div className={styles.cardLabel}>Full-Context</div>
                       </div>
                       <div className={styles.cardValue}>
-                        {activeComparison.fullContext}
+                        {activeComparison.prefix}{activeComparison.fullContext}
                         <span className={styles.cardUnit}>{activeComparison.unit}</span>
                       </div>
                     </div>

--- a/docs/website/src/components/ValueProps4/index.tsx
+++ b/docs/website/src/components/ValueProps4/index.tsx
@@ -16,20 +16,23 @@ const valueProps = [
 const getComparisonData = (isZh: boolean) => ({
   accurate: {
     fullContext: 52.9,
-    powermem: 78.7,
-    unit: '',
+    powermem: 87.79,
+    unit: '%',
+    improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
   agile: {
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
-    label: isZh ? '响应时间' : 'Response Time',
+    improvement: '-91.6%',
+    label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
   affordable: {
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
 });
@@ -148,21 +151,7 @@ export default function ValueProps4() {
                         <span className={styles.dashboardUnit}>{activeComparison.unit}</span>
                       </div>
                       <div className={styles.dashboardImprovement}>
-                        {hoveredKey === 'accurate' && (
-                          <span className={styles.improvementText}>
-                            +{(activeComparison.powermem - activeComparison.fullContext).toFixed(1)}
-                          </span>
-                        )}
-                        {hoveredKey === 'agile' && (
-                          <span className={styles.improvementText}>
-                            {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x faster
-                          </span>
-                        )}
-                        {hoveredKey === 'affordable' && (
-                          <span className={styles.improvementText}>
-                            {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x less
-                          </span>
-                        )}
+                    <span className={styles.improvementText}>{activeComparison.improvement}</span>
                       </div>
                     </div>
 

--- a/docs/website/src/components/ValueProps4/index.tsx
+++ b/docs/website/src/components/ValueProps4/index.tsx
@@ -18,6 +18,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 52.9,
     powermem: 87.79,
     unit: '%',
+    prefix: '',
     improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
@@ -25,6 +26,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
+    prefix: '',
     improvement: '-91.6%',
     label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
@@ -32,6 +34,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    prefix: '~',
     improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
@@ -147,7 +150,7 @@ export default function ValueProps4() {
                     <div className={`${styles.dashboardItem} ${styles.dashboardPowerMem}`}>
                       <div className={styles.dashboardLabel}>PowerMem</div>
                       <div className={styles.dashboardValue}>
-                        {activeComparison.powermem}
+                        {activeComparison.prefix}{activeComparison.powermem}
                         <span className={styles.dashboardUnit}>{activeComparison.unit}</span>
                       </div>
                       <div className={styles.dashboardImprovement}>
@@ -164,7 +167,7 @@ export default function ValueProps4() {
                     <div className={`${styles.dashboardItem} ${styles.dashboardFullContext}`}>
                       <div className={styles.dashboardLabel}>Full-Context</div>
                       <div className={styles.dashboardValue}>
-                        {activeComparison.fullContext}
+                        {activeComparison.prefix}{activeComparison.fullContext}
                         <span className={styles.dashboardUnit}>{activeComparison.unit}</span>
                       </div>
                     </div>

--- a/docs/website/src/components/ValueProps5/index.tsx
+++ b/docs/website/src/components/ValueProps5/index.tsx
@@ -18,6 +18,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 52.9,
     powermem: 87.79,
     unit: '%',
+    prefix: '',
     improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
@@ -25,6 +26,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
+    prefix: '',
     improvement: '-91.6%',
     label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
@@ -32,6 +34,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    prefix: '~',
     improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
@@ -181,7 +184,7 @@ export default function ValueProps5() {
                           />
                         </svg>
                         <div className={styles.circleValue}>
-                          {activeComparison.powermem}
+                          {activeComparison.prefix}{activeComparison.powermem}
                           <span className={styles.circleUnit}>{activeComparison.unit}</span>
                         </div>
                       </div>
@@ -221,7 +224,7 @@ export default function ValueProps5() {
                           />
                         </svg>
                         <div className={styles.circleValue}>
-                          {activeComparison.fullContext}
+                          {activeComparison.prefix}{activeComparison.fullContext}
                           <span className={styles.circleUnit}>{activeComparison.unit}</span>
                         </div>
                       </div>

--- a/docs/website/src/components/ValueProps5/index.tsx
+++ b/docs/website/src/components/ValueProps5/index.tsx
@@ -16,20 +16,23 @@ const valueProps = [
 const getComparisonData = (isZh: boolean) => ({
   accurate: {
     fullContext: 52.9,
-    powermem: 78.7,
-    unit: '',
+    powermem: 87.79,
+    unit: '%',
+    improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
   agile: {
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
-    label: isZh ? '响应时间' : 'Response Time',
+    improvement: '-91.6%',
+    label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
   affordable: {
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
 });
@@ -183,21 +186,7 @@ export default function ValueProps5() {
                         </div>
                       </div>
                       <div className={styles.circleImprovement}>
-                        {hoveredKey === 'accurate' && (
-                          <span className={styles.improvementText}>
-                            +{(activeComparison.powermem - activeComparison.fullContext).toFixed(1)}
-                          </span>
-                        )}
-                        {hoveredKey === 'agile' && (
-                          <span className={styles.improvementText}>
-                            {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x faster
-                          </span>
-                        )}
-                        {hoveredKey === 'affordable' && (
-                          <span className={styles.improvementText}>
-                            {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x less
-                          </span>
-                        )}
+                    <span className={styles.improvementText}>{activeComparison.improvement}</span>
                       </div>
                     </div>
 

--- a/docs/website/src/components/ValueProps6/index.tsx
+++ b/docs/website/src/components/ValueProps6/index.tsx
@@ -16,20 +16,23 @@ const valueProps = [
 const getComparisonData = (isZh: boolean) => ({
   accurate: {
     fullContext: 52.9,
-    powermem: 78.7,
-    unit: '',
+    powermem: 87.79,
+    unit: '%',
+    improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
   agile: {
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
-    label: isZh ? '响应时间' : 'Response Time',
+    improvement: '-91.6%',
+    label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
   affordable: {
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
 });
@@ -161,21 +164,7 @@ export default function ValueProps6() {
                         </div>
                       </div>
                       <div className={styles.barImprovement}>
-                        {hoveredKey === 'accurate' && (
-                          <span className={styles.improvementText}>
-                            +{(activeComparison.powermem - activeComparison.fullContext).toFixed(1)}
-                          </span>
-                        )}
-                        {hoveredKey === 'agile' && (
-                          <span className={styles.improvementText}>
-                            {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x faster
-                          </span>
-                        )}
-                        {hoveredKey === 'affordable' && (
-                          <span className={styles.improvementText}>
-                            {((activeComparison.fullContext / activeComparison.powermem).toFixed(1))}x less
-                          </span>
-                        )}
+                    <span className={styles.improvementText}>{activeComparison.improvement}</span>
                       </div>
                     </div>
 

--- a/docs/website/src/components/ValueProps6/index.tsx
+++ b/docs/website/src/components/ValueProps6/index.tsx
@@ -18,6 +18,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 52.9,
     powermem: 87.79,
     unit: '%',
+    prefix: '',
     improvement: '+65.9%',
     label: isZh ? 'LLM 评分' : 'LLM Score',
   },
@@ -25,6 +26,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 17.12,
     powermem: 1.44,
     unit: 's',
+    prefix: '',
     improvement: '-91.6%',
     label: isZh ? 'Retrieval P95' : 'Retrieval P95',
   },
@@ -32,6 +34,7 @@ const getComparisonData = (isZh: boolean) => ({
     fullContext: 26,
     powermem: 0.9,
     unit: 'k',
+    prefix: '~',
     improvement: '-96.5%',
     label: isZh ? 'Token 使用量' : 'Token Usage',
   },
@@ -157,7 +160,7 @@ export default function ValueProps6() {
                             style={{ height: `${getBarHeight(activeComparison.powermem, maxValue)}%` }}
                           >
                             <div className={styles.barValue}>
-                              {activeComparison.powermem}
+                              {activeComparison.prefix}{activeComparison.powermem}
                               <span className={styles.barUnit}>{activeComparison.unit}</span>
                             </div>
                           </div>
@@ -183,7 +186,7 @@ export default function ValueProps6() {
                             style={{ height: `${getBarHeight(activeComparison.fullContext, maxValue)}%` }}
                           >
                             <div className={styles.barValue}>
-                              {activeComparison.fullContext}
+                              {activeComparison.prefix}{activeComparison.fullContext}
                               <span className={styles.barUnit}>{activeComparison.unit}</span>
                             </div>
                           </div>

--- a/docs/website/src/pages/benchmark.module.css
+++ b/docs/website/src/pages/benchmark.module.css
@@ -187,6 +187,13 @@
   text-shadow: 0 0 20px rgba(134, 239, 172, 0.6);
 }
 
+.metricDetail {
+  color: #9ca3af;
+  font-size: 0.875rem;
+  margin-top: 0.75rem;
+  font-family: 'JetBrains Mono', monospace;
+}
+
 /* Scores Table */
 .tableContainer {
   overflow-x: auto;
@@ -219,15 +226,16 @@
 }
 
 .scoresTable th:first-child {
-  width: 20%;
+  width: 24%;
 }
 
 .scoresTable th:nth-child(2) {
-  width: 60%;
+  width: 48%;
 }
 
+.scoresTable th:nth-child(3),
 .scoresTable th:last-child {
-  width: 20%;
+  width: 14%;
   text-align: center;
 }
 
@@ -299,6 +307,14 @@
 
 .llmCell {
   color: #86efac;
+  font-weight: 600;
+  font-size: 1.125rem;
+  font-family: 'JetBrains Mono', monospace;
+  text-align: center;
+}
+
+.countCell {
+  color: #e5e7eb;
   font-weight: 600;
   font-size: 1.125rem;
   font-family: 'JetBrains Mono', monospace;
@@ -583,4 +599,3 @@
     font-size: 1rem;
   }
 }
-

--- a/docs/website/src/pages/benchmark.module.css
+++ b/docs/website/src/pages/benchmark.module.css
@@ -269,14 +269,6 @@
   gap: 0.75rem;
 }
 
-.overallRow .categoryCell {
-  text-align: center;
-}
-
-.overallRow .categoryName {
-  justify-content: center;
-}
-
 .categoryNumber {
   display: inline-flex;
   align-items: center;
@@ -344,94 +336,6 @@
   box-shadow: 0 8px 12px rgba(37, 99, 235, 0.4);
   text-decoration: none;
   color: white;
-}
-
-/* Overall Scores */
-.overallGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
-  max-width: 900px;
-  margin: 0 auto;
-}
-
-.scoreCard {
-  background: rgba(17, 17, 17, 0.9);
-  border-radius: 16px;
-  padding: 2rem;
-  border: 1px solid rgba(59, 130, 246, 0.2);
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  backdrop-filter: blur(10px);
-  text-align: center;
-  position: relative;
-  overflow: hidden;
-}
-
-.scoreCard::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 4px;
-  background: linear-gradient(90deg, #3b82f6, #9333ea);
-  transform: scaleX(0);
-  transition: transform 0.3s ease;
-}
-
-.scoreCard:hover::before {
-  transform: scaleX(1);
-}
-
-.scoreCard:hover {
-  transform: translateY(-8px);
-  box-shadow: 
-    0 20px 40px rgba(0, 0, 0, 0.6),
-    0 0 40px rgba(59, 130, 246, 0.4);
-  border-color: rgba(59, 130, 246, 0.6);
-}
-
-.scoreCardBlue {
-  border-left: 4px solid #3b82f6;
-}
-
-.scoreCardPurple {
-  border-left: 4px solid #9333ea;
-}
-
-.scoreCardGreen {
-  border-left: 4px solid #22c55e;
-}
-
-.scoreLabel {
-  font-size: 0.875rem;
-  color: #d1d5db;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 1rem;
-  font-weight: 600;
-}
-
-.scoreValue {
-  font-size: 3rem;
-  font-weight: 700;
-  font-family: 'JetBrains Mono', monospace;
-  margin: 0;
-}
-
-.scoreCardBlue .scoreValue {
-  color: #60a5fa;
-  text-shadow: 0 0 30px rgba(96, 165, 250, 0.6);
-}
-
-.scoreCardPurple .scoreValue {
-  color: #a78bfa;
-  text-shadow: 0 0 30px rgba(167, 139, 250, 0.6);
-}
-
-.scoreCardGreen .scoreValue {
-  color: #86efac;
-  text-shadow: 0 0 30px rgba(134, 239, 172, 0.6);
 }
 
 /* Token Usage */
@@ -543,17 +447,12 @@
   }
 
   .performanceGrid,
-  .overallGrid,
   .tokenGrid {
     grid-template-columns: 1fr;
   }
 
   .metricValue {
     font-size: 2rem;
-  }
-
-  .scoreValue {
-    font-size: 2.5rem;
   }
 
   .tokenValue {

--- a/docs/website/src/pages/benchmark.tsx
+++ b/docs/website/src/pages/benchmark.tsx
@@ -25,7 +25,6 @@ const translations: Record<string, Record<string, string>> = {
     'benchmark.metrics.retrievalP95.baseline': 'baseline 17.12s, -91.6%',
     'benchmark.metrics.tokenUsage.baseline': 'baseline ~26k, -96.5%',
     'benchmark.scores.title': 'Mean Scores Per Category',
-    'benchmark.scores.overall': 'Overall Mean Scores',
     'benchmark.scores.bleu': 'BLEU Score',
     'benchmark.scores.f1': 'F1 Score',
     'benchmark.scores.llm': 'LLM Score',
@@ -68,7 +67,6 @@ const translations: Record<string, Record<string, string>> = {
     'benchmark.metrics.retrievalP95.baseline': 'baseline 17.12s, 降低 -91.6%',
     'benchmark.metrics.tokenUsage.baseline': 'baseline ~26k, 降低 -96.5%',
     'benchmark.scores.title': '分类平均评分',
-    'benchmark.scores.overall': '总体平均评分',
     'benchmark.scores.bleu': 'BLEU 评分',
     'benchmark.scores.f1': 'F1 评分',
     'benchmark.scores.llm': 'LLM 评分',
@@ -149,10 +147,6 @@ const categoryScores = [
   },
 ];
 
-const overallScores = {
-  llm_score: 0.8779,
-};
-
 function formatScore(num: number): string {
   return (num * 100).toFixed(2) + '%';
 }
@@ -194,19 +188,6 @@ export default function BenchmarkPage() {
                   <div className={styles.metricDetail}>{t(metric.baselineKey)}</div>
                 </div>
               ))}
-            </div>
-          </section>
-
-          {/* Overall Mean Scores */}
-          <section className={styles.section}>
-            <Heading as="h2" className={styles.sectionTitle}>
-              {t('benchmark.scores.overall')}
-            </Heading>
-            <div className={styles.overallGrid}>
-              <div className={`${styles.scoreCard} ${styles.scoreCardGreen}`}>
-                <div className={styles.scoreLabel}>{t('benchmark.scores.llm')}</div>
-                <div className={styles.scoreValue}>{formatScore(overallScores.llm_score)}</div>
-              </div>
             </div>
           </section>
 

--- a/docs/website/src/pages/benchmark.tsx
+++ b/docs/website/src/pages/benchmark.tsx
@@ -40,7 +40,7 @@ const translations: Record<string, Record<string, string>> = {
     'benchmark.tokens.cached': 'Cached Tokens',
     'category.1.name': 'Single-Hop',
     'category.1.desc': 'Questions asking for specific facts directly mentioned in a single conversation.',
-    'category.2.name': 'Temporal Reasoning',
+    'category.2.name': 'Temporal',
     'category.2.desc': 'Questions can be answered through temporal reasoning and capturing time-related data cues within the conversation.',
     'category.3.name': 'Multi-Hop',
     'category.3.desc': 'Questions that require synthesizing information from multiple sessions.',

--- a/docs/website/src/pages/benchmark.tsx
+++ b/docs/website/src/pages/benchmark.tsx
@@ -9,11 +9,21 @@ const translations: Record<string, Record<string, string>> = {
   en: {
     'benchmark.title': 'Performance Benchmarks',
     'benchmark.subtitle': 'Real-world performance metrics based on LOCOMO dataset',
-    'benchmark.config': 'Configuration: LLM: gpt-4o, OceanBase: 4.3.5.4',
+    'benchmark.config': '10 long multi-turn conversations · 1,540 QA · GPT-5.5',
+    'benchmark.comparison.title': 'PowerMem vs Full-Context',
     'benchmark.performance.title': 'Performance Metrics',
     'benchmark.performance.totalRequests': 'Total Requests',
     'benchmark.performance.avgTime': 'Average Request Time',
     'benchmark.performance.p95Time': 'P95 Request Time',
+    'benchmark.metrics.llmScore': 'LLM Score',
+    'benchmark.metrics.accuracy': 'Accuracy',
+    'benchmark.metrics.retrievalP95': 'Retrieval P95',
+    'benchmark.metrics.latency': 'Latency',
+    'benchmark.metrics.tokenUsage': 'Token Usage',
+    'benchmark.metrics.consumption': 'Consumption',
+    'benchmark.metrics.llmScore.baseline': 'baseline 52.9%, +65.9%',
+    'benchmark.metrics.retrievalP95.baseline': 'baseline 17.12s, -91.6%',
+    'benchmark.metrics.tokenUsage.baseline': 'baseline ~26k, -96.5%',
     'benchmark.scores.title': 'Mean Scores Per Category',
     'benchmark.scores.overall': 'Overall Mean Scores',
     'benchmark.scores.bleu': 'BLEU Score',
@@ -28,25 +38,35 @@ const translations: Record<string, Record<string, string>> = {
     'benchmark.tokens.completion': 'Completion Tokens',
     'benchmark.tokens.total': 'Total Tokens',
     'benchmark.tokens.cached': 'Cached Tokens',
-    'category.1.name': 'Multi-Hop',
-    'category.1.desc': 'Questions that require synthesizing information from multiple sessions.',
+    'category.1.name': 'Single-Hop',
+    'category.1.desc': 'Questions asking for specific facts directly mentioned in a single conversation.',
     'category.2.name': 'Temporal Reasoning',
     'category.2.desc': 'Questions can be answered through temporal reasoning and capturing time-related data cues within the conversation.',
-    'category.3.name': 'Open-Domain',
-    'category.3.desc': 'Questions can be answered by integrating a speaker\'s provided information with external knowledge, such as commonsense or world facts.',
-    'category.4.name': 'Single-Hop',
-    'category.4.desc': 'Questions asking for specific facts directly mentioned in the single session conversation.',
+    'category.3.name': 'Multi-Hop',
+    'category.3.desc': 'Questions that require synthesizing information from multiple sessions.',
+    'category.4.name': 'Open-Domain',
+    'category.4.desc': 'Questions can be answered by integrating a speaker\'s provided information with external knowledge, such as commonsense or world facts.',
     'category.5.name': 'Adversarial',
     'category.5.desc': 'These questions are designed to trick the agent into providing wrong answers, with the expectation that the agent will correctly identify them as unanswerable.',
   },
   zh: {
     'benchmark.title': '性能压测数据',
     'benchmark.subtitle': '基于 LOCOMO 数据集的真实性能指标',
-    'benchmark.config': '配置信息：LLM: gpt-4o, OceanBase: 4.3.5.4',
+    'benchmark.config': '10 段超长多轮对话 · 1540 个 QA · GPT-5.5',
+    'benchmark.comparison.title': 'PowerMem vs Full-Context',
     'benchmark.performance.title': '性能指标',
     'benchmark.performance.totalRequests': '总请求数',
     'benchmark.performance.avgTime': '平均请求时间',
     'benchmark.performance.p95Time': 'P95 请求时间',
+    'benchmark.metrics.llmScore': 'LLM Score',
+    'benchmark.metrics.accuracy': '准确率',
+    'benchmark.metrics.retrievalP95': 'Retrieval P95',
+    'benchmark.metrics.latency': '延迟',
+    'benchmark.metrics.tokenUsage': 'Token 用量',
+    'benchmark.metrics.consumption': '消耗',
+    'benchmark.metrics.llmScore.baseline': 'baseline 52.9%, 提升 +65.9%',
+    'benchmark.metrics.retrievalP95.baseline': 'baseline 17.12s, 降低 -91.6%',
+    'benchmark.metrics.tokenUsage.baseline': 'baseline ~26k, 降低 -96.5%',
     'benchmark.scores.title': '分类平均评分',
     'benchmark.scores.overall': '总体平均评分',
     'benchmark.scores.bleu': 'BLEU 评分',
@@ -61,52 +81,68 @@ const translations: Record<string, Record<string, string>> = {
     'benchmark.tokens.completion': '完成 Token',
     'benchmark.tokens.total': '总 Token',
     'benchmark.tokens.cached': '缓存 Token',
-    'category.1.name': '多跳推理',
-    'category.1.desc': '需要综合多个会话信息的问题。',
-    'category.2.name': '时间推理',
+    'category.1.name': '单轮 (Single-Hop)',
+    'category.1.desc': '询问单段对话中直接提到的特定事实的问题。',
+    'category.2.name': '跨轮 (Temporal)',
     'category.2.desc': '可以通过时间推理和捕获对话中与时间相关的数据线索来回答的问题。',
-    'category.3.name': '开放域',
-    'category.3.desc': '可以通过整合说话者提供的信息与外部知识（如常识或世界事实）来回答的问题。',
-    'category.4.name': '单跳查询',
-    'category.4.desc': '询问在单个会话对话中直接提到的特定事实的问题。',
+    'category.3.name': '多跳 (Multi-Hop)',
+    'category.3.desc': '需要综合多个会话信息的问题。',
+    'category.4.name': '开放 (Open-Domain)',
+    'category.4.desc': '可以通过整合说话者提供的信息与外部知识（如常识或世界事实）来回答的问题。',
     'category.5.name': '对抗性',
     'category.5.desc': '这些问题旨在诱使代理提供错误答案，期望代理能正确识别它们为无法回答的问题。',
   },
 };
 
+const comparisonMetrics = [
+  {
+    labelKey: 'benchmark.metrics.llmScore',
+    detailKey: 'benchmark.metrics.accuracy',
+    value: '87.79%',
+    baselineKey: 'benchmark.metrics.llmScore.baseline',
+    cardClass: 'metricCardBlue',
+  },
+  {
+    labelKey: 'benchmark.metrics.retrievalP95',
+    detailKey: 'benchmark.metrics.latency',
+    value: '1.44s',
+    baselineKey: 'benchmark.metrics.retrievalP95.baseline',
+    cardClass: 'metricCardGreen',
+  },
+  {
+    labelKey: 'benchmark.metrics.tokenUsage',
+    detailKey: 'benchmark.metrics.consumption',
+    value: '~0.9k',
+    baselineKey: 'benchmark.metrics.tokenUsage.baseline',
+    cardClass: 'metricCardPurple',
+  },
+];
+
 const categoryScores = [
   { 
     category: 1, 
-    bleu_score: 0.3507, 
-    f1_score: 0.4553, 
-    llm_score: 0.7163, 
+    llm_score: 0.9078,
     count: 282,
     nameKey: 'category.1.name',
     descKey: 'category.1.desc',
   },
   { 
     category: 2, 
-    bleu_score: 0.4863, 
-    f1_score: 0.6185, 
-    llm_score: 0.7913, 
+    llm_score: 0.8349,
     count: 321,
     nameKey: 'category.2.name',
     descKey: 'category.2.desc',
   },
   { 
     category: 3, 
-    bleu_score: 0.2522, 
-    f1_score: 0.3320, 
-    llm_score: 0.5521, 
+    llm_score: 0.7396,
     count: 96,
     nameKey: 'category.3.name',
     descKey: 'category.3.desc',
   },
   { 
     category: 4, 
-    bleu_score: 0.4731, 
-    f1_score: 0.5774, 
-    llm_score: 0.8359, 
+    llm_score: 0.9001,
     count: 841,
     nameKey: 'category.4.name',
     descKey: 'category.4.desc',
@@ -114,28 +150,11 @@ const categoryScores = [
 ];
 
 const overallScores = {
-  bleu_score: 0.4397,
-  f1_score: 0.5483,
-  llm_score: 0.7870,
+  llm_score: 0.8779,
 };
-
-const tokenUsage = {
-  prompt: 4902481,
-  completion: 591132,
-  total: 5493613,
-  cached: 0,
-};
-
-function formatNumber(num: number): string {
-  return num.toLocaleString('en-US');
-}
-
-function formatPercentage(num: number): string {
-  return (num * 100).toFixed(2) + '%';
-}
 
 function formatScore(num: number): string {
-  return (num * 100).toFixed(2);
+  return (num * 100).toFixed(2) + '%';
 }
 
 export default function BenchmarkPage() {
@@ -158,6 +177,25 @@ export default function BenchmarkPage() {
               {t('benchmark.config')}
             </p>
           </div>
+
+          {/* PowerMem vs Full-Context */}
+          <section className={styles.section}>
+            <Heading as="h2" className={styles.sectionTitle}>
+              {t('benchmark.comparison.title')}
+            </Heading>
+            <div className={styles.performanceGrid}>
+              {comparisonMetrics.map((metric) => (
+                <div
+                  key={metric.labelKey}
+                  className={`${styles.metricCard} ${styles[metric.cardClass]}`}
+                >
+                  <div className={styles.metricLabel}>{t(metric.labelKey)} {t(metric.detailKey)}</div>
+                  <div className={styles.metricValue}>{metric.value}</div>
+                  <div className={styles.metricDetail}>{t(metric.baselineKey)}</div>
+                </div>
+              ))}
+            </div>
+          </section>
 
           {/* Overall Mean Scores */}
           <section className={styles.section}>
@@ -184,6 +222,7 @@ export default function BenchmarkPage() {
                     <th>{t('benchmark.scores.category')}</th>
                     <th>{t('benchmark.scores.description')}</th>
                     <th>{t('benchmark.scores.llm')}</th>
+                    <th>{t('benchmark.scores.count')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -197,6 +236,7 @@ export default function BenchmarkPage() {
                       </td>
                       <td className={styles.descriptionCell}>{t(score.descKey)}</td>
                       <td className={styles.llmCell}>{formatScore(score.llm_score)}</td>
+                      <td className={styles.countCell}>{score.count}</td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
## Summary

- update the benchmark page with the latest LOCOMO PowerMem vs Full-Context results
- sync homepage benchmark comparison cards and static benchmark metric images with the same values
- remove the standalone Overall Mean Scores block so the page focuses on comparison cards and per-category results

## Validation

- `npm run typecheck`
- browser smoke checks for `/benchmark`, `/docs/guides/overview`, and `/docs/benchmark/overview` with the local Docusaurus dev server
- PR preflight check for diff, branch name, commit text, and PR wording

## Notes

- The benchmark page no longer renders `Overall Mean Scores` / `总体平均评分`.
