### PR TITLE
fix(scripts): preserve doc dirs in sync-website-docs (Fixes #1096)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/scripts/sync-website-docs.sh
+++ b/scripts/sync-website-docs.sh
@@ -8,13 +8,19 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SOURCE_DOCS_DIR="$PROJECT_ROOT/docs"
 WEBSITE_DOCS_DIR="$PROJECT_ROOT/docs/website/docs"
 
+if [ ! -d "$SOURCE_DOCS_DIR" ]; then
+    echo "Error: source docs directory not found: $SOURCE_DOCS_DIR" >&2
+    exit 1
+fi
+
 echo "  Cleaning docs/website/docs directory..."
 mkdir -p "$WEBSITE_DOCS_DIR"
 find "$WEBSITE_DOCS_DIR" -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} + 2>/dev/null || true
 
 echo "  Copying documentation files from docs/ to docs/website/docs/..."
+synced_count=0
+shopt -s nullglob
 for dirname in "$SOURCE_DOCS_DIR"/*/; do
-    [ -d "$dirname" ] || continue
     name="$(basename "$dirname")"
 
     case "$name" in
@@ -24,8 +30,32 @@ for dirname in "$SOURCE_DOCS_DIR"/*/; do
     esac
 
     echo "    Copying directory: $name"
-    cp -R "$dirname" "$WEBSITE_DOCS_DIR/"
+    cp -R "${dirname%/}" "$WEBSITE_DOCS_DIR/"
+    synced_count=$((synced_count + 1))
 done
+
+echo "  Verifying required documentation directories..."
+for dirname in "$SOURCE_DOCS_DIR"/*/; do
+    name="$(basename "$dirname")"
+
+    case "$name" in
+        website|images)
+            continue
+            ;;
+    esac
+
+    if [ ! -d "$WEBSITE_DOCS_DIR/$name" ]; then
+        echo "Error: expected directory missing after sync: $WEBSITE_DOCS_DIR/$name" >&2
+        exit 1
+    fi
+done
+shopt -u nullglob
+
+if [ "$synced_count" -eq 0 ]; then
+    echo "Error: no documentation directories were synced from $SOURCE_DOCS_DIR" >&2
+    exit 1
+fi
 
 echo "  Copied documentation directories:"
 find "$WEBSITE_DOCS_DIR" -maxdepth 1 -mindepth 1 -type d -print | sort
+echo "  ✓ synced $synced_count documentation directories"


### PR DESCRIPTION
Fixes #1096. Strip trailing slash when copying so guides/, api/, and other category folders are preserved for Docusaurus sidebars. Add post-sync verification, synced_count guard, and *.sh text eol=lf in .gitattributes for Linux CI.

<!--
Thank you for contributing to OceanBase!
Please feel free to ping the maintainers for the review!
-->

## Summary

<!--
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Fixes #1096. When syncing docs into the Docusaurus site, `cp -R` with a trailing-slash source path flattened category directories (`guides/`, `api/`, etc.) into `docs/website/docs/`, breaking sidebar autogeneration and causing the build to fail.

## Solution Description

<!--
Please clearly and concisely describe your solution.
-->

1. **Copy path**: Use `cp -R "${dirname%/}"` instead of `cp -R "$dirname"` to strip the trailing slash and preserve subdirectory structure.
2. **Post-sync checks**: Dynamically verify each synced directory (excluding `website` and `images`); exit 1 if any are missing. Guard with `synced_count` so `nullglob` zero-match runs cannot pass silently.
3. **bash compatibility**: Keep cleanup via `find -exec` (compatible with macOS bash 3.2); wrap copy/verify loops with `shopt -s/u nullglob`.
4. **CI line endings**: Add `.gitattributes` with `*.sh text eol=lf` to avoid CRLF failures on Linux CI.

**Local verification:**
- `./scripts/sync-website-docs.sh` — 8 directories synced, smoke check passed
- `shellcheck scripts/sync-website-docs.sh` — zero warnings
- `npm run build` in `docs/website` — en + zh build succeeded