### PR TITLE
feat(init): AskUserQuestion interactive flow + remote-init mode + dashboard 0.0.0.0

### DIFF
--- a/apps/claude-code-plugin/SETUP.md
+++ b/apps/claude-code-plugin/SETUP.md
@@ -66,7 +66,10 @@ sh "$CLAUDE_PLUGIN_ROOT/scripts/..."
    first, then retry `/memory-powermem:init`.
 2. Run `sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"` and inspect whether config,
    uv, managed PID, Python versions, and health are present.
-3. If `.env` is missing, run init with auto-detection first:
+3. **If the server is healthy and `.env` exists** — tell the user the current
+   storage backend (read `DATABASE_PROVIDER` from `.env`). Do not re-run `init.sh`.
+   If the user wants to reconfigure, stop the server first, then proceed.
+4. If `.env` is missing, run init with auto-detection first:
 
    ```bash
    sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
@@ -83,7 +86,7 @@ sh "$CLAUDE_PLUGIN_ROOT/scripts/..."
    OceanBase/seekdb production use), local HuggingFace embedding (no API key,
    `sentence-transformers` from `powermem[extras]`), server settings, and logging
    settings.
-4. If init reports missing values, ask the user only for those missing values. Do
+5. If init reports missing values, ask the user only for those missing values. Do
    not invent credentials. Re-run init with the matching environment variables:
 
    ```bash
@@ -114,11 +117,11 @@ sh "$CLAUDE_PLUGIN_ROOT/scripts/..."
      `powermem[server,extras] @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>`.
    - `POWERMEM_INIT_PYTHON` to force a specific Python >= 3.11.
    - `POWERMEM_INIT_PORT` to force the managed server port.
-5. Never print API keys, auth tokens, or other credentials. Mask any secret in
+6. Never print API keys, auth tokens, or other credentials. Mask any secret in
    summaries.
-6. After init succeeds, run `sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"` again and
+7. After init succeeds, run `sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"` again and
    report the base URL.
-7. The hook launcher reads `runtime.env`, so once init writes a base URL, prompt
+8. The hook launcher reads `runtime.env`, so once init writes a base URL, prompt
    recall and session-save hooks use that backend automatically.
 
 The default local embedding model (`all-MiniLM-L6-v2`) is downloaded

--- a/apps/claude-code-plugin/hooks/run-hook.sh
+++ b/apps/claude-code-plugin/hooks/run-hook.sh
@@ -12,6 +12,12 @@ load_env_file() {
 }
 load_env_file "$DATA_DIR/runtime.env"
 load_env_file "$PLUGIN_ROOT/config/runtime.env"
+# MCP-only mode: runtime.env sets POWERMEM_HOOK_DISABLED=1 so the native
+# binary never runs (and never falls back to a stale POWERMEM_BASE_URL).
+# Must be checked AFTER loading runtime.env so the marker takes effect.
+if [ "${POWERMEM_HOOK_DISABLED:-0}" = "1" ]; then
+  exit 0
+fi
 case "$(uname -s 2>/dev/null)" in
   Darwin) GOOS=darwin ;;
   Linux) GOOS=linux ;;

--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -314,13 +314,27 @@ write_runtime_base_url() {
 write_runtime_remote() {
   remote_url=$1
   remote_key=${2:-}
+  # Single-quote values so URLs / keys with shell metacharacters ($, ;, spaces,
+  # backticks, etc.) survive being sourced by run-hook.sh and status.sh.
+  # Embedded single quotes are escaped via the standard '\'' trick.
+  sq_url=$(printf '%s' "$remote_url" | sed "s/'/'\\\\''/g")
   tmp="$RUNTIME_FILE.tmp"
   {
-    printf 'POWERMEM_BASE_URL=%s\n' "$remote_url"
+    printf "POWERMEM_BASE_URL='%s'\n" "$sq_url"
     if [ -n "$remote_key" ]; then
-      printf 'POWERMEM_API_KEY=%s\n' "$remote_key"
+      sq_key=$(printf '%s' "$remote_key" | sed "s/'/'\\\\''/g")
+      printf "POWERMEM_API_KEY='%s'\n" "$sq_key"
     fi
   } > "$tmp"
+  mv "$tmp" "$RUNTIME_FILE"
+}
+
+# Write runtime.env for MCP-only mode: no base URL, hooks disabled.
+# Overwrites any stale POWERMEM_BASE_URL so run-hook.sh exits early instead
+# of hitting the previous remote/local URL that no longer applies.
+write_runtime_hook_disabled() {
+  tmp="$RUNTIME_FILE.tmp"
+  printf 'POWERMEM_HOOK_DISABLED=1\n' > "$tmp"
   mv "$tmp" "$RUNTIME_FILE"
 }
 
@@ -576,4 +590,3 @@ remove_user_mcp_config() {
   fi
   claude mcp remove powermem --scope user >/dev/null 2>&1 || true
 }
-

--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -309,6 +309,29 @@ write_runtime_base_url() {
   mv "$tmp" "$RUNTIME_FILE"
 }
 
+# Write runtime.env for remote-server mode (no local .env, no local PID).
+# Args: base_url [api_key]
+write_runtime_remote() {
+  remote_url=$1
+  remote_key=${2:-}
+  tmp="$RUNTIME_FILE.tmp"
+  {
+    printf 'POWERMEM_BASE_URL=%s\n' "$remote_url"
+    if [ -n "$remote_key" ]; then
+      printf 'POWERMEM_API_KEY=%s\n' "$remote_key"
+    fi
+  } > "$tmp"
+  mv "$tmp" "$RUNTIME_FILE"
+}
+
+# Return 0 if the given URL points at a remote host (not localhost/127.0.0.1).
+is_remote_url() {
+  case "$1" in
+    http://localhost:*|http://127.0.0.1:*|https://localhost:*|https://127.0.0.1:*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 export_env_file_vars() {
   env_file=$1
   [ -f "$env_file" ] || return 0

--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -536,3 +536,44 @@ find_free_port() {
   done
   return 1
 }
+
+# --- User-level MCP config ---
+#
+# We write the powermem MCP entry to the user-scope config so it persists
+# across plugin reinstalls (the plugin cache .mcp.json is volatile — wiped
+# on every uninstall+install) and applies to all projects.
+#
+# Implemented via the `claude mcp` CLI so the storage location tracks
+# whatever Claude Code uses for the current version / platform / config
+# dir, rather than hardcoding ~/.claude.json.
+#
+# Usage:
+#   write_user_mcp_config <url> [api_key]
+#   remove_user_mcp_config
+
+write_user_mcp_config() {
+  mcp_url="$1"
+  mcp_api_key="${2:-}"
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "ERROR: 'claude' CLI not found on PATH; cannot configure user-scope MCP." >&2
+    echo "Run 'claude mcp add --scope user --transport http powermem \"$mcp_url\"' manually." >&2
+    return 1
+  fi
+  # Remove any existing entry first so the add is idempotent and stale
+  # headers don't linger when the API key changes.
+  claude mcp remove powermem --scope user >/dev/null 2>&1 || true
+  if [ -n "$mcp_api_key" ]; then
+    claude mcp add --scope user --transport http powermem "$mcp_url" \
+      --header "Authorization: Bearer $mcp_api_key" >/dev/null
+  else
+    claude mcp add --scope user --transport http powermem "$mcp_url" >/dev/null
+  fi
+}
+
+remove_user_mcp_config() {
+  if ! command -v claude >/dev/null 2>&1; then
+    return 0
+  fi
+  claude mcp remove powermem --scope user >/dev/null 2>&1 || true
+}
+

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -14,9 +14,10 @@ echo "Data dir: $DATA_DIR"
 # Skips .env creation, uvx launch, PID management.
 # Connection mode (POWERMEM_INIT_CONNECTION_MODE=hook|mcp|both, default both)
 # decides which files get written:
-#   hook → runtime.env only; remove powermem from user-level mcpServers
-#   mcp  → user-level mcpServers only (no runtime.env, hooks unconfigured)
-#   both → both
+#   hook → runtime.env with URL + key; remove powermem from user-level mcpServers
+#   mcp  → user-level mcpServers only; runtime.env gets POWERMEM_HOOK_DISABLED=1
+#          so the hook launcher exits early instead of falling back to a stale URL
+#   both → both sources populated, hook enabled
 # MCP config is written to the user-scope config (~/.claude.json top-level
 # mcpServers) so it survives plugin reinstalls and applies to all projects.
 remote_init_url="${POWERMEM_INIT_BASE_URL:-${POWERMEM_BASE_URL:-}}"
@@ -59,6 +60,13 @@ if [ -n "$remote_init_url" ] && is_remote_url "$remote_init_url"; then
       # hook-only mode. Other MCP servers are preserved.
       remove_user_mcp_config
       echo "Removed powermem from user-scope config (MCP disabled)"
+      ;;
+    mcp)
+      # Write a marker runtime.env so run-hook.sh exits early instead of
+      # falling back to a stale POWERMEM_BASE_URL. Without this, the hook
+      # binary would run with whatever URL was last configured.
+      write_runtime_hook_disabled
+      echo "Wrote $RUNTIME_FILE (hook disabled; MCP-only mode)"
       ;;
   esac
 

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -13,6 +13,150 @@ base_url=$(runtime_base_url)
 ensure_bootstrap_python || exit 1
 echo "Bootstrap Python: $BOOTSTRAP_PYTHON ($(python_version "$BOOTSTRAP_PYTHON"))"
 
+# Interactive configuration prompts.
+# Bypass: POWERMEM_NON_INTERACTIVE=1, or var already set, or stdin not a TTY.
+ask_user() {
+  var_name="$1"
+  prompt="$2"
+  default="$3"
+  choices="${4:-}"
+
+  if [ "${POWERMEM_NON_INTERACTIVE:-0}" = "1" ]; then
+    eval "${var_name}=\"\${${var_name}:-${default}}\""
+    export "${var_name}"
+    return 0
+  fi
+
+  eval "_existing=\${${var_name}:-}"
+  if [ -n "${_existing}" ]; then
+    return 0
+  fi
+
+  if [ ! -t 0 ] || [ ! -e /dev/tty ]; then
+    eval "${var_name}=\"${default}\""
+    export "${var_name}"
+    return 0
+  fi
+
+  while true; do
+    hint=""
+    [ -n "${choices}" ] && hint=" [${choices}]"
+    [ -n "${default}" ] && hint="${hint} (default: ${default})"
+    printf "%s%s: " "${prompt}" "${hint}"
+    read -r _answer </dev/tty || {
+      eval "${var_name}=\"${default}\""
+      export "${var_name}"
+      return 0
+    }
+    [ -z "${_answer}" ] && _answer="${default}"
+    if [ -z "${choices}" ]; then
+      eval "${var_name}=\"${_answer}\""
+      export "${var_name}"
+      return 0
+    fi
+    _match=0
+    _old_ifs="${IFS:-}"
+    IFS='|'
+    for _opt in ${choices}; do
+      if [ "${_opt}" = "${_answer}" ]; then _match=1; break; fi
+    done
+    IFS="${_old_ifs}"
+    if [ "${_match}" = "1" ]; then
+      eval "${var_name}=\"${_answer}\""
+      export "${var_name}"
+      return 0
+    fi
+    echo "Invalid choice: ${_answer}. Valid: ${choices}" >&2
+  done
+}
+
+prompt_user_config() {
+  echo ""
+  echo "=== Interactive configuration ==="
+  echo "Bypass: POWERMEM_NON_INTERACTIVE=1, or pre-set the POWERMEM_INIT_* env vars."
+  echo ""
+
+  ask_user POWERMEM_INIT_DATABASE_PROVIDER \
+    "Storage backend (sqlite=single-user local, oceanbase=multi-agent/prod)" \
+    "sqlite" \
+    "sqlite|oceanbase"
+  echo "  -> DATABASE_PROVIDER=${POWERMEM_INIT_DATABASE_PROVIDER}"
+
+  _has_llm_cred=0
+  if [ -n "${POWERMEM_INIT_LLM_API_KEY:-}${LLM_API_KEY:-}${ANTHROPIC_API_KEY:-}${POWERMEM_INIT_LLM_AUTH_TOKEN:-}${LLM_AUTH_TOKEN:-${ANTHROPIC_AUTH_TOKEN:-}}" ]; then
+    _has_llm_cred=1
+  fi
+  if [ "$_has_llm_cred" = "0" ] && [ -f "${HOME}/.claude/settings.json" ]; then
+    if "$BOOTSTRAP_PYTHON" -c "
+import json, sys
+try:
+    d = json.load(open('${HOME}/.claude/settings.json')).get('env', {})
+except Exception:
+    sys.exit(1)
+sys.exit(0 if any(d.get(k) for k in ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'LLM_API_KEY']) else 1)
+" 2>/dev/null; then
+      _has_llm_cred=1
+    fi
+  fi
+
+  if [ "$_has_llm_cred" = "0" ]; then
+    echo "No LLM credentials detected in env or ~/.claude/settings.json."
+    ask_user _llm_choice \
+      "Choose LLM provider (noop=skip fact extraction, CRUD still works)" \
+      "noop" \
+      "noop|anthropic|openai|deepseek|qwen|siliconflow"
+    case "${_llm_choice}" in
+      noop)
+        export POWERMEM_INIT_LLM_PROVIDER=noop
+        echo "  -> LLM=noop (fact extraction / profile extraction disabled)"
+        ;;
+      anthropic|openai|deepseek|qwen|siliconflow)
+        export POWERMEM_INIT_LLM_PROVIDER="${_llm_choice}"
+        ask_user POWERMEM_INIT_LLM_API_KEY "  API key for ${_llm_choice}" "" ""
+        ask_user POWERMEM_INIT_LLM_MODEL "  Model name" "" ""
+        _default_base=""
+        case "${_llm_choice}" in
+          openai)      _default_base="https://api.openai.com/v1" ;;
+          deepseek)    _default_base="https://api.deepseek.com/v1" ;;
+          qwen)        _default_base="https://dashscope.aliyuncs.com/compatible-mode/v1" ;;
+          siliconflow) _default_base="https://api.siliconflow.cn/v1" ;;
+        esac
+        if [ -n "${_default_base}" ]; then
+          export POWERMEM_INIT_LLM_BASE_URL="${POWERMEM_INIT_LLM_BASE_URL:-${_default_base}}"
+          echo "  -> LLM=${_llm_choice}, base_url=${POWERMEM_INIT_LLM_BASE_URL}"
+        else
+          echo "  -> LLM=${_llm_choice}"
+        fi
+        ;;
+    esac
+  else
+    echo "LLM credentials detected; skipping LLM provider prompt."
+  fi
+
+  if [ -z "${POWERMEM_INIT_EMBEDDING_PROVIDER:-}${EMBEDDING_PROVIDER:-}" ]; then
+    _embed_default="huggingface"
+    if [ "${POWERMEM_INIT_DATABASE_PROVIDER}" = "oceanbase" ]; then
+      _embed_default="default"
+    fi
+    _cloud_embed=""
+    if [ -n "${OPENAI_API_KEY:-}" ]; then _cloud_embed="openai"
+    elif [ -n "${DASHSCOPE_API_KEY:-}${QWEN_API_KEY:-}" ]; then _cloud_embed="qwen"
+    elif [ -n "${SILICONFLOW_API_KEY:-}" ]; then _cloud_embed="siliconflow"
+    fi
+    if [ -n "${_cloud_embed}" ] && [ "${_cloud_embed}" != "${_embed_default}" ]; then
+      ask_user POWERMEM_INIT_EMBEDDING_PROVIDER \
+        "Detected ${_cloud_embed} API key. Use local or cloud embedding?" \
+        "${_embed_default}" \
+        "${_embed_default}|${_cloud_embed}"
+      echo "  -> EMBEDDING_PROVIDER=${POWERMEM_INIT_EMBEDDING_PROVIDER}"
+    fi
+  else
+    echo "Embedding provider pre-set; skipping prompt."
+  fi
+
+  echo ""
+}
+
 create_env_file() {
   "$BOOTSTRAP_PYTHON" - "$ENV_FILE" "$DATA_DIR" <<'PY'
 import json
@@ -601,6 +745,7 @@ announce_dashboard_url() {
 
 if [ ! -f "$ENV_FILE" ]; then
   echo "Creating plugin .env from environment variables or Claude settings fallback."
+  prompt_user_config
   create_env_file
 else
   echo "Using existing plugin .env: $ENV_FILE"

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -8,155 +8,76 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 echo "PowerMem Claude Code plugin init"
 echo "Data dir: $DATA_DIR"
 
+# --- Remote mode short-circuit ---
+# Triggered when the user provides a remote PowerMem server URL via
+# POWERMEM_INIT_BASE_URL (AskUserQuestion) or POWERMEM_BASE_URL (env, non-localhost).
+# Skips .env creation, uvx launch, PID management.
+# Connection mode (POWERMEM_INIT_CONNECTION_MODE=hook|mcp|both, default both)
+# decides which files get written:
+#   hook → runtime.env only (.mcp.json reset to empty)
+#   mcp  → .mcp.json only (no runtime.env, hooks unconfigured)
+#   both → both files
+remote_init_url="${POWERMEM_INIT_BASE_URL:-${POWERMEM_BASE_URL:-}}"
+if [ -n "$remote_init_url" ] && is_remote_url "$remote_init_url"; then
+  remote_api_key="${POWERMEM_INIT_API_KEY:-${POWERMEM_API_KEY:-}}"
+  remote_mode="${POWERMEM_INIT_CONNECTION_MODE:-both}"
+  case "$remote_mode" in
+    hook|mcp|both) ;;
+    *) echo "ERROR: POWERMEM_INIT_CONNECTION_MODE must be hook, mcp, or both (got: $remote_mode)" >&2; exit 1 ;;
+  esac
+  echo "Remote server mode: $remote_init_url (connection: $remote_mode)"
+  mkdir -p "$DATA_DIR"
+
+  echo "Verifying connectivity..."
+  if ! is_healthy "$remote_init_url"; then
+    echo "ERROR: remote server at $remote_init_url is not healthy." >&2
+    echo "Check the URL and any required API key." >&2
+    exit 1
+  fi
+  echo "Remote server healthy: $remote_init_url"
+
+  case "$remote_mode" in
+    hook|both)
+      write_runtime_remote "$remote_init_url" "$remote_api_key"
+      echo "Wrote $RUNTIME_FILE"
+      ;;
+  esac
+
+  case "$remote_mode" in
+    mcp|both)
+      mcp_url=$(printf '%s' "$remote_init_url" | sed 's:/*$::')"/mcp"
+      mcp_file="$PLUGIN_ROOT/.mcp.json"
+      tmp="$mcp_file.tmp"
+      if [ -n "$remote_api_key" ]; then
+        printf '{"mcpServers":{"powermem":{"type":"http","url":"%s","headers":{"Authorization":"Bearer %s"}}}}' \
+          "$mcp_url" "$remote_api_key" > "$tmp"
+      else
+        printf '{"mcpServers":{"powermem":{"type":"http","url":"%s"}}}' \
+          "$mcp_url" > "$tmp"
+      fi
+      mv "$tmp" "$mcp_file"
+      echo "Wrote $mcp_file (url=$mcp_url)"
+      ;;
+  esac
+
+  case "$remote_mode" in
+    hook)
+      # Reset .mcp.json to empty so MCP is disabled in hook-only mode.
+      mcp_file="$PLUGIN_ROOT/.mcp.json"
+      printf '{"mcpServers":{}}' > "$mcp_file"
+      echo "Reset $mcp_file (MCP disabled)"
+      ;;
+  esac
+
+  exit 0
+fi
+
 base_url=$(runtime_base_url)
 
 ensure_bootstrap_python || exit 1
 echo "Bootstrap Python: $BOOTSTRAP_PYTHON ($(python_version "$BOOTSTRAP_PYTHON"))"
 
 # Interactive configuration prompts.
-# Bypass: POWERMEM_NON_INTERACTIVE=1, or var already set, or stdin not a TTY.
-ask_user() {
-  var_name="$1"
-  prompt="$2"
-  default="$3"
-  choices="${4:-}"
-
-  if [ "${POWERMEM_NON_INTERACTIVE:-0}" = "1" ]; then
-    eval "${var_name}=\"\${${var_name}:-${default}}\""
-    export "${var_name}"
-    return 0
-  fi
-
-  eval "_existing=\${${var_name}:-}"
-  if [ -n "${_existing}" ]; then
-    return 0
-  fi
-
-  if [ ! -t 0 ] || [ ! -e /dev/tty ]; then
-    eval "${var_name}=\"${default}\""
-    export "${var_name}"
-    return 0
-  fi
-
-  while true; do
-    hint=""
-    [ -n "${choices}" ] && hint=" [${choices}]"
-    [ -n "${default}" ] && hint="${hint} (default: ${default})"
-    printf "%s%s: " "${prompt}" "${hint}"
-    read -r _answer </dev/tty || {
-      eval "${var_name}=\"${default}\""
-      export "${var_name}"
-      return 0
-    }
-    [ -z "${_answer}" ] && _answer="${default}"
-    if [ -z "${choices}" ]; then
-      eval "${var_name}=\"${_answer}\""
-      export "${var_name}"
-      return 0
-    fi
-    _match=0
-    _old_ifs="${IFS:-}"
-    IFS='|'
-    for _opt in ${choices}; do
-      if [ "${_opt}" = "${_answer}" ]; then _match=1; break; fi
-    done
-    IFS="${_old_ifs}"
-    if [ "${_match}" = "1" ]; then
-      eval "${var_name}=\"${_answer}\""
-      export "${var_name}"
-      return 0
-    fi
-    echo "Invalid choice: ${_answer}. Valid: ${choices}" >&2
-  done
-}
-
-prompt_user_config() {
-  echo ""
-  echo "=== Interactive configuration ==="
-  echo "Bypass: POWERMEM_NON_INTERACTIVE=1, or pre-set the POWERMEM_INIT_* env vars."
-  echo ""
-
-  ask_user POWERMEM_INIT_DATABASE_PROVIDER \
-    "Storage backend (sqlite=single-user local, oceanbase=multi-agent/prod)" \
-    "sqlite" \
-    "sqlite|oceanbase"
-  echo "  -> DATABASE_PROVIDER=${POWERMEM_INIT_DATABASE_PROVIDER}"
-
-  _has_llm_cred=0
-  if [ -n "${POWERMEM_INIT_LLM_API_KEY:-}${LLM_API_KEY:-}${ANTHROPIC_API_KEY:-}${POWERMEM_INIT_LLM_AUTH_TOKEN:-}${LLM_AUTH_TOKEN:-${ANTHROPIC_AUTH_TOKEN:-}}" ]; then
-    _has_llm_cred=1
-  fi
-  if [ "$_has_llm_cred" = "0" ] && [ -f "${HOME}/.claude/settings.json" ]; then
-    if "$BOOTSTRAP_PYTHON" -c "
-import json, sys
-try:
-    d = json.load(open('${HOME}/.claude/settings.json')).get('env', {})
-except Exception:
-    sys.exit(1)
-sys.exit(0 if any(d.get(k) for k in ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'LLM_API_KEY']) else 1)
-" 2>/dev/null; then
-      _has_llm_cred=1
-    fi
-  fi
-
-  if [ "$_has_llm_cred" = "0" ]; then
-    echo "No LLM credentials detected in env or ~/.claude/settings.json."
-    ask_user _llm_choice \
-      "Choose LLM provider (noop=skip fact extraction, CRUD still works)" \
-      "noop" \
-      "noop|anthropic|openai|deepseek|qwen|siliconflow"
-    case "${_llm_choice}" in
-      noop)
-        export POWERMEM_INIT_LLM_PROVIDER=noop
-        echo "  -> LLM=noop (fact extraction / profile extraction disabled)"
-        ;;
-      anthropic|openai|deepseek|qwen|siliconflow)
-        export POWERMEM_INIT_LLM_PROVIDER="${_llm_choice}"
-        ask_user POWERMEM_INIT_LLM_API_KEY "  API key for ${_llm_choice}" "" ""
-        ask_user POWERMEM_INIT_LLM_MODEL "  Model name" "" ""
-        _default_base=""
-        case "${_llm_choice}" in
-          openai)      _default_base="https://api.openai.com/v1" ;;
-          deepseek)    _default_base="https://api.deepseek.com/v1" ;;
-          qwen)        _default_base="https://dashscope.aliyuncs.com/compatible-mode/v1" ;;
-          siliconflow) _default_base="https://api.siliconflow.cn/v1" ;;
-        esac
-        if [ -n "${_default_base}" ]; then
-          export POWERMEM_INIT_LLM_BASE_URL="${POWERMEM_INIT_LLM_BASE_URL:-${_default_base}}"
-          echo "  -> LLM=${_llm_choice}, base_url=${POWERMEM_INIT_LLM_BASE_URL}"
-        else
-          echo "  -> LLM=${_llm_choice}"
-        fi
-        ;;
-    esac
-  else
-    echo "LLM credentials detected; skipping LLM provider prompt."
-  fi
-
-  if [ -z "${POWERMEM_INIT_EMBEDDING_PROVIDER:-}${EMBEDDING_PROVIDER:-}" ]; then
-    _embed_default="huggingface"
-    if [ "${POWERMEM_INIT_DATABASE_PROVIDER}" = "oceanbase" ]; then
-      _embed_default="default"
-    fi
-    _cloud_embed=""
-    if [ -n "${OPENAI_API_KEY:-}" ]; then _cloud_embed="openai"
-    elif [ -n "${DASHSCOPE_API_KEY:-}${QWEN_API_KEY:-}" ]; then _cloud_embed="qwen"
-    elif [ -n "${SILICONFLOW_API_KEY:-}" ]; then _cloud_embed="siliconflow"
-    fi
-    if [ -n "${_cloud_embed}" ] && [ "${_cloud_embed}" != "${_embed_default}" ]; then
-      ask_user POWERMEM_INIT_EMBEDDING_PROVIDER \
-        "Detected ${_cloud_embed} API key. Use local or cloud embedding?" \
-        "${_embed_default}" \
-        "${_embed_default}|${_cloud_embed}"
-      echo "  -> EMBEDDING_PROVIDER=${POWERMEM_INIT_EMBEDDING_PROVIDER}"
-    fi
-  else
-    echo "Embedding provider pre-set; skipping prompt."
-  fi
-
-  echo ""
-}
-
 create_env_file() {
   "$BOOTSTRAP_PYTHON" - "$ENV_FILE" "$DATA_DIR" <<'PY'
 import json
@@ -408,6 +329,7 @@ embedding_provider = env_first("POWERMEM_INIT_EMBEDDING_PROVIDER", "EMBEDDING_PR
 embedding_provider = embedding_provider.lower()
 
 embedding_model_defaults = {
+    "none": "none",
     "default": "all-MiniLM-L6-v2",
     "huggingface": "all-MiniLM-L6-v2",
     "qwen": "text-embedding-v4",
@@ -417,6 +339,7 @@ embedding_model_defaults = {
     "lmstudio": "text-embedding-nomic-embed-text-v1.5",
 }
 embedding_dim_defaults = {
+    "none": "0",
     "default": "384",
     "huggingface": "384",
     "qwen": "1536",
@@ -442,7 +365,7 @@ if not embedding_api_key:
     elif embedding_provider == "siliconflow":
         embedding_api_key = env_first("SILICONFLOW_API_KEY") or settings_first(settings_env, "SILICONFLOW_API_KEY")
 
-if embedding_provider not in {"default", "huggingface", "ollama", "lmstudio"} and not embedding_api_key:
+if embedding_provider not in {"none", "default", "huggingface", "ollama", "lmstudio"} and not embedding_api_key:
     print(
         "Missing configuration: POWERMEM_INIT_EMBEDDING_API_KEY "
         f"for EMBEDDING_PROVIDER={embedding_provider}",
@@ -451,7 +374,7 @@ if embedding_provider not in {"default", "huggingface", "ollama", "lmstudio"} an
     sys.exit(2)
 
 server_port = env_first("POWERMEM_SERVER_PORT", "POWERMEM_INIT_PORT") or "8848"
-server_host = env_first("POWERMEM_SERVER_HOST") or "127.0.0.1"
+server_host = env_first("POWERMEM_SERVER_HOST") or "0.0.0.0"
 server_workers = env_first("POWERMEM_SERVER_WORKERS") or "1"
 server_log_file = env_first("POWERMEM_SERVER_LOG_FILE") or path_value("powermem-server.log")
 logging_level = env_first("LOGGING_LEVEL") or "INFO"
@@ -745,7 +668,6 @@ announce_dashboard_url() {
 
 if [ ! -f "$ENV_FILE" ]; then
   echo "Creating plugin .env from environment variables or Claude settings fallback."
-  prompt_user_config
   create_env_file
 else
   echo "Using existing plugin .env: $ENV_FILE"
@@ -861,13 +783,13 @@ if [ -n "${POWERMEM_UV_INDEX_URL:-}" ]; then
     --default-index "$POWERMEM_UV_INDEX_URL" \
     --from "$PACKAGE" \
     $UVX_WITH_ARGS \
-    powermem-server --host 127.0.0.1 --port "$port" >> "$LOG_FILE" 2>&1 &
+    powermem-server --host "${POWERMEM_SERVER_HOST:-0.0.0.0}" --port "$port" >> "$LOG_FILE" 2>&1 &
 else
   POWERMEM_ENV_FILE="$ENV_FILE" nohup "$UV_BIN" tool run \
     --python "$BOOTSTRAP_PYTHON" \
     --from "$PACKAGE" \
     $UVX_WITH_ARGS \
-    powermem-server --host 127.0.0.1 --port "$port" >> "$LOG_FILE" 2>&1 &
+    powermem-server --host "${POWERMEM_SERVER_HOST:-0.0.0.0}" --port "$port" >> "$LOG_FILE" 2>&1 &
 fi
 pid=$!
 write_managed_pid "$pid"

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -374,7 +374,7 @@ if embedding_provider not in {"none", "default", "huggingface", "ollama", "lmstu
     sys.exit(2)
 
 server_port = env_first("POWERMEM_SERVER_PORT", "POWERMEM_INIT_PORT") or "8848"
-server_host = env_first("POWERMEM_SERVER_HOST") or "0.0.0.0"
+server_host = env_first("POWERMEM_SERVER_HOST") or "127.0.0.1"
 server_workers = env_first("POWERMEM_SERVER_WORKERS") or "1"
 server_log_file = env_first("POWERMEM_SERVER_LOG_FILE") or path_value("powermem-server.log")
 logging_level = env_first("LOGGING_LEVEL") or "INFO"
@@ -783,13 +783,13 @@ if [ -n "${POWERMEM_UV_INDEX_URL:-}" ]; then
     --default-index "$POWERMEM_UV_INDEX_URL" \
     --from "$PACKAGE" \
     $UVX_WITH_ARGS \
-    powermem-server --host "${POWERMEM_SERVER_HOST:-0.0.0.0}" --port "$port" >> "$LOG_FILE" 2>&1 &
+    powermem-server --host "${POWERMEM_SERVER_HOST:-127.0.0.1}" --port "$port" >> "$LOG_FILE" 2>&1 &
 else
   POWERMEM_ENV_FILE="$ENV_FILE" nohup "$UV_BIN" tool run \
     --python "$BOOTSTRAP_PYTHON" \
     --from "$PACKAGE" \
     $UVX_WITH_ARGS \
-    powermem-server --host "${POWERMEM_SERVER_HOST:-0.0.0.0}" --port "$port" >> "$LOG_FILE" 2>&1 &
+    powermem-server --host "${POWERMEM_SERVER_HOST:-127.0.0.1}" --port "$port" >> "$LOG_FILE" 2>&1 &
 fi
 pid=$!
 write_managed_pid "$pid"

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -14,9 +14,11 @@ echo "Data dir: $DATA_DIR"
 # Skips .env creation, uvx launch, PID management.
 # Connection mode (POWERMEM_INIT_CONNECTION_MODE=hook|mcp|both, default both)
 # decides which files get written:
-#   hook → runtime.env only (.mcp.json reset to empty)
-#   mcp  → .mcp.json only (no runtime.env, hooks unconfigured)
-#   both → both files
+#   hook → runtime.env only; remove powermem from user-level mcpServers
+#   mcp  → user-level mcpServers only (no runtime.env, hooks unconfigured)
+#   both → both
+# MCP config is written to the user-scope config (~/.claude.json top-level
+# mcpServers) so it survives plugin reinstalls and applies to all projects.
 remote_init_url="${POWERMEM_INIT_BASE_URL:-${POWERMEM_BASE_URL:-}}"
 if [ -n "$remote_init_url" ] && is_remote_url "$remote_init_url"; then
   remote_api_key="${POWERMEM_INIT_API_KEY:-${POWERMEM_API_KEY:-}}"
@@ -46,26 +48,17 @@ if [ -n "$remote_init_url" ] && is_remote_url "$remote_init_url"; then
   case "$remote_mode" in
     mcp|both)
       mcp_url=$(printf '%s' "$remote_init_url" | sed 's:/*$::')"/mcp"
-      mcp_file="$PLUGIN_ROOT/.mcp.json"
-      tmp="$mcp_file.tmp"
-      if [ -n "$remote_api_key" ]; then
-        printf '{"mcpServers":{"powermem":{"type":"http","url":"%s","headers":{"Authorization":"Bearer %s"}}}}' \
-          "$mcp_url" "$remote_api_key" > "$tmp"
-      else
-        printf '{"mcpServers":{"powermem":{"type":"http","url":"%s"}}}' \
-          "$mcp_url" > "$tmp"
-      fi
-      mv "$tmp" "$mcp_file"
-      echo "Wrote $mcp_file (url=$mcp_url)"
+      write_user_mcp_config "$mcp_url" "$remote_api_key"
+      echo "Wrote powermem MCP server to user-scope config (url=$mcp_url)"
       ;;
   esac
 
   case "$remote_mode" in
     hook)
-      # Reset .mcp.json to empty so MCP is disabled in hook-only mode.
-      mcp_file="$PLUGIN_ROOT/.mcp.json"
-      printf '{"mcpServers":{}}' > "$mcp_file"
-      echo "Reset $mcp_file (MCP disabled)"
+      # Remove powermem from user-level mcpServers so MCP is disabled in
+      # hook-only mode. Other MCP servers are preserved.
+      remove_user_mcp_config
+      echo "Removed powermem from user-scope config (MCP disabled)"
       ;;
   esac
 

--- a/apps/claude-code-plugin/scripts/status.sh
+++ b/apps/claude-code-plugin/scripts/status.sh
@@ -5,14 +5,59 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/common.sh"
 
-base_url=$(runtime_base_url)
+# --- Discover connection configuration ---
+# Hook mode (REST):   runtime.env holds POWERMEM_BASE_URL (+ optional POWERMEM_API_KEY)
+# MCP mode (http):    $PLUGIN_ROOT/.mcp.json holds mcpServers.powermem.url
+# Both mode:          both files populated
+hook_url=""
+if [ -f "$RUNTIME_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$RUNTIME_FILE"
+  hook_url="${POWERMEM_BASE_URL:-}"
+fi
+
+mcp_url=""
+mcp_file="$PLUGIN_ROOT/.mcp.json"
+if [ -f "$mcp_file" ]; then
+  if BOOTSTRAP_PYTHON=$(choose_python 2>/dev/null); then
+    mcp_url=$("$BOOTSTRAP_PYTHON" - "$mcp_file" <<'PY' 2>/dev/null || true
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+    srv = data.get("mcpServers", {}).get("powermem", {})
+    print(srv.get("url", ""))
+except Exception:
+    pass
+PY
+)
+  fi
+fi
+
+if [ -n "$hook_url" ] && [ -n "$mcp_url" ]; then
+  mode="both"
+elif [ -n "$hook_url" ]; then
+  mode="hook"
+elif [ -n "$mcp_url" ]; then
+  mode="mcp"
+else
+  mode="none"
+fi
+
+# Derive a base URL for health checks. Prefer hook_url; fall back to MCP url
+# with the trailing /mcp stripped.
+health_url="$hook_url"
+if [ -z "$health_url" ] && [ -n "$mcp_url" ]; then
+  health_url=$(printf '%s' "$mcp_url" | sed -E 's#/mcp$##')
+fi
 
 echo "PowerMem Claude Code plugin status"
 echo "Data dir: $DATA_DIR"
 echo "Runtime file: $RUNTIME_FILE"
 echo "Env file: $ENV_FILE"
 echo "PID file: $(managed_pid_file)"
-echo "Base URL: $base_url"
+echo "Connection mode: $mode"
+[ -n "$hook_url" ] && echo "Hook base URL: $hook_url"
+[ -n "$mcp_url" ]  && echo "MCP URL: $mcp_url"
 
 if BOOTSTRAP_PYTHON=$(choose_python 2>/dev/null); then
   echo "Bootstrap Python: $BOOTSTRAP_PYTHON ($(python_version "$BOOTSTRAP_PYTHON"))"
@@ -29,7 +74,12 @@ fi
 if pid_alive; then
   echo "Managed server PID: $(managed_pid)"
 else
-  echo "Managed server PID: not running"
+  case "$mode" in
+    mcp)   echo "Managed server PID: not running (MCP-only mode, no local server expected)" ;;
+    hook)  echo "Managed server PID: not running (hook mode against remote, no local server expected)" ;;
+    both)  echo "Managed server PID: not running (remote mode, no local server expected)" ;;
+    *)     echo "Managed server PID: not running" ;;
+  esac
 fi
 
 if [ -n "${POWERMEM_UV_BIN:-}" ] && command -v "$POWERMEM_UV_BIN" >/dev/null 2>&1; then
@@ -51,19 +101,23 @@ if [ -d "$DATA_DIR/venv" ]; then
   echo "Legacy venv: $DATA_DIR/venv (unused by uvx init)"
 fi
 
-if is_healthy "$base_url"; then
-  echo "Health: healthy"
+if [ -z "$health_url" ]; then
+  echo "Health: no base URL configured (run /memory-powermem:init)"
 else
-  echo "Health: unavailable"
-  case "$base_url" in
-    http://localhost:*|http://127.0.0.1:*)
-      port=$(printf '%s\n' "$base_url" | sed -E 's#^http://(localhost|127\.0\.0\.1):([0-9]+).*#\2#')
-      case "$port" in
-        *[!0-9]*|"") ;;
-        *) describe_port "$port" ;;
-      esac
-      ;;
-  esac
+  if is_healthy "$health_url"; then
+    echo "Health: healthy ($health_url)"
+  else
+    echo "Health: unavailable ($health_url)"
+    case "$health_url" in
+      http://localhost:*|http://127.0.0.1:*)
+        port=$(printf '%s\n' "$health_url" | sed -E 's#^http://(localhost|127\.0\.0\.1):([0-9]+).*#\2#')
+        case "$port" in
+          *[!0-9]*|"") ;;
+          *) describe_port "$port" ;;
+        esac
+        ;;
+    esac
+  fi
 fi
 
 if [ -f "$LOG_FILE" ]; then

--- a/apps/claude-code-plugin/scripts/status.sh
+++ b/apps/claude-code-plugin/scripts/status.sh
@@ -7,8 +7,10 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 
 # --- Discover connection configuration ---
 # Hook mode (REST):   runtime.env holds POWERMEM_BASE_URL (+ optional POWERMEM_API_KEY)
-# MCP mode (http):    $PLUGIN_ROOT/.mcp.json holds mcpServers.powermem.url
-# Both mode:          both files populated
+# MCP mode (http):    user-scope ~/.claude.json holds mcpServers.powermem.url
+#                     (written via `claude mcp add --scope user`, survives plugin
+#                     reinstalls; the plugin cache .mcp.json is volatile and unused)
+# Both mode:          both sources populated
 hook_url=""
 if [ -f "$RUNTIME_FILE" ]; then
   # shellcheck disable=SC1090
@@ -17,7 +19,7 @@ if [ -f "$RUNTIME_FILE" ]; then
 fi
 
 mcp_url=""
-mcp_file="$PLUGIN_ROOT/.mcp.json"
+mcp_file="${HOME:-}/.claude.json"
 if [ -f "$mcp_file" ]; then
   if BOOTSTRAP_PYTHON=$(choose_python 2>/dev/null); then
     mcp_url=$("$BOOTSTRAP_PYTHON" - "$mcp_file" <<'PY' 2>/dev/null || true

--- a/apps/claude-code-plugin/skills/init/SKILL.md
+++ b/apps/claude-code-plugin/skills/init/SKILL.md
@@ -121,13 +121,25 @@ is already set. Skipped entirely in remote mode.
 - **header**: "Server"
 - **question**: "Run a local PowerMem server, or connect to an existing remote one?（运行本地 PowerMem 服务，还是连接已有的远程服务？）"
 - **options**:
-  - "Local (本地)" — Start a local server on 127.0.0.1:8848. Storage,
-    LLM, and Embedding configuration applies to this local instance.
-    （在 127.0.0.1:8848 启动本地服务，Storage/LLM/Embedding 配置作用于该本地实例。）
+  - "Local — loopback (本地 - 仅本地访问)" — Start a local server bound to
+    `127.0.0.1:8848`. Only this machine can reach it. Recommended for
+    single-user / laptop setups.
+    （在 127.0.0.1:8848 启动本地服务，仅本机可访问。适合单用户/笔记本环境。）
+  - "Local — all interfaces (本地 - 允许其他机器访问)" — Start a local server
+    bound to `0.0.0.0:8848`. Other machines / containers on the network can
+    reach it. Use when Claude Code runs in a different container or host than
+    the server. Exposes the dashboard on all network interfaces — only choose
+    this on a trusted network.
+    （在 0.0.0.0:8848 启动本地服务，允许同网络其他机器/容器访问。适用于 Claude Code 与服务分处不同容器/主机的场景。会在所有网络接口暴露 dashboard，仅在可信网络下选择。）
   - "Remote (远程)" — Connect to an existing PowerMem server. You'll provide the URL
     (and an optional API key). Storage/LLM/Embedding are determined by the
     remote server; the remaining questions are skipped.
     （连接已有的 PowerMem 服务，需要提供 URL（可选 API key）。Storage/LLM/Embedding 由远程服务决定，后续问题跳过。）
+
+Map the first two answers → `POWERMEM_SERVER_HOST=127.0.0.1` (loopback) or
+`POWERMEM_SERVER_HOST=0.0.0.0` (all interfaces). Pass this env var to
+`init.sh` so the generated `.env` and launch command use the chosen host.
+Loopback is the script default; all-interface binding is an explicit opt-in.
 
 If the user picks **Remote**, make a **follow-up AskUserQuestion call** with
 3 questions in one round:

--- a/apps/claude-code-plugin/skills/init/SKILL.md
+++ b/apps/claude-code-plugin/skills/init/SKILL.md
@@ -197,10 +197,10 @@ The options depend on the Storage choice from Question 1.
 - **question**: "Which embedding provider should PowerMem use?（PowerMem 使用哪个嵌入提供方？）"
 - **options** (vary by storage choice):
   - **If SQLite**: "None (无)", "Local HuggingFace (本地 HuggingFace)" — `all-MiniLM-L6-v2`, 384-dim, downloads automatically, no API key needed（all-MiniLM-L6-v2，384 维，自动下载，无需 API key）, "Cloud (<provider>) (云端 <provider>)" (only if cloud API key detected).
-  - **If OceanBase**: "None (无)", "Built-in seekdb (内置 seekdb)" — Local embedding through seekdb, no extra dependencies（通过 seekdb 本地嵌入，无额外依赖）, "Cloud (<provider>) (云端 <provider>)" (only if cloud API key detected).
+  - **If OceanBase**: "Built-in seekdb (内置 seekdb)" — Local embedding through seekdb, no extra dependencies（通过 seekdb 本地嵌入，无额外依赖）, "Cloud (<provider>) (云端 <provider>)" (only if cloud API key detected). **Do not offer "None" for OceanBase** — OceanBase requires a vector embedding field to store memories, so embeddings are mandatory.
 
-Map answer → `POWERMEM_INIT_EMBEDDING_PROVIDER=none` (or `huggingface` for SQLite,
-`default` for OceanBase, or the detected cloud provider name).
+Map answer → `POWERMEM_INIT_EMBEDDING_PROVIDER=none` (SQLite only,
+`huggingface` for SQLite, `default` for OceanBase, or the detected cloud provider name).
 
 ## Dev-mode detection (local source override)
 

--- a/apps/claude-code-plugin/skills/init/SKILL.md
+++ b/apps/claude-code-plugin/skills/init/SKILL.md
@@ -28,19 +28,61 @@ passed to `uvx --from` instead of using the default PyPI package.
 
 ## Interactive configuration via AskUserQuestion
 
+**CLAUDE_PLUGIN_ROOT handling (read first):** the harness injects
+`$CLAUDE_PLUGIN_ROOT` when this skill runs. If it is unset, discover it once
+and `export` it on its **own line** — never write
+`CLAUDE_PLUGIN_ROOT=... sh "$CLAUDE_PLUGIN_ROOT/..."` on one line, because the
+shell expands `$CLAUDE_PLUGIN_ROOT` *before* the assignment takes effect,
+producing an empty path (`/scripts/status.sh: No such file or directory`).
+Correct pattern:
+
+```sh
+export CLAUDE_PLUGIN_ROOT=$(find ~/.claude/plugins/cache/powermem/memory-powermem -maxdepth 2 -name scripts -type d 2>/dev/null | head -1 | xargs dirname)
+sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"
+```
+
 Before running `scripts/init.sh`, check what the user already has configured:
 
 1. Run `sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"` to check server health and read
-   `~/.powermem/.env` for existing config.
-2. **Storage preference** — read `DATABASE_PROVIDER` from `~/.powermem/.env`. If set,
+   `~/.powermem/.env` for existing config. **This is the only command you need to
+   run for health checks.** Do not compose your own `curl`/`ss`/`netstat` one-liners
+   — those tools return non-zero exit codes when the server is down (the expected
+   state during init), and the Bash tool reports that as an error even though the
+   output is fine. If you must run such a command, append `|| true` so the pipeline
+   exits 0.
+2. **Server mode detection** — check `POWERMEM_BASE_URL` env var and
+   `~/.powermem/runtime.env` first. The Server (Local/Remote) question is only
+   asked when neither is set.
+   - **`POWERMEM_BASE_URL` is set to a remote URL** (not `localhost` / `127.0.0.1`)
+     → remote mode. **Skip ALL AskUserQuestion rounds** (Server, Storage, LLM,
+     Embedding). Run init.sh directly; it will detect the URL and write
+     `runtime.env`.
+   - **`POWERMEM_BASE_URL` is set to a local URL** (`localhost` / `127.0.0.1`)
+     → local mode with a known port. **Skip the Server question.** Then:
+     - If `status.sh` reports the server healthy → report current backend, no
+       questions (same as "When the server is already healthy" below).
+     - If not healthy → still ask Storage/LLM/Embedding (Questions 1-3) to
+       configure the local server, but skip Question 0.
+   - **`POWERMEM_BASE_URL` unset, but `~/.powermem/runtime.env` exists** →
+     same logic as above, reading the URL from `runtime.env`.
+   - **Both unset** → ask Question 0 (Server mode). If the user picks Remote,
+     ask the follow-up URL + API key questions, then skip Questions 1-3.
+3. **Storage preference** — read `DATABASE_PROVIDER` from `~/.powermem/.env`. If set,
    note the current backend. Also check `POWERMEM_INIT_DATABASE_PROVIDER` env var.
-3. **LLM credentials** — check env vars (`POWERMEM_INIT_LLM_API_KEY`, `LLM_API_KEY`,
+4. **LLM credentials** — check env vars (`POWERMEM_INIT_LLM_API_KEY`, `LLM_API_KEY`,
    `ANTHROPIC_API_KEY`, `POWERMEM_INIT_LLM_AUTH_TOKEN`, `LLM_AUTH_TOKEN`,
    `ANTHROPIC_AUTH_TOKEN`) and `~/.claude/settings.json` (`env.ANTHROPIC_API_KEY`,
    `env.ANTHROPIC_AUTH_TOKEN`, `env.LLM_API_KEY`).
-4. **Embedding preference** — check `POWERMEM_INIT_EMBEDDING_PROVIDER` / `EMBEDDING_PROVIDER`
+5. **Embedding preference** — check `POWERMEM_INIT_EMBEDDING_PROVIDER` / `EMBEDDING_PROVIDER`
    env vars, and whether cloud API keys exist (`OPENAI_API_KEY`, `DASHSCOPE_API_KEY`,
    `QWEN_API_KEY`, `SILICONFLOW_API_KEY`).
+6. **Region detection (for bilingual prompts)** — run
+   `curl -fsSL -m 3 https://ipapi.co/country/ || true` and strip whitespace
+   (this is the same source `common.sh`'s `detect_public_ip_country` uses).
+   If the output is `CN`, set an internal flag `CN=true`. When `CN=true`,
+   append the Chinese translation shown in parentheses (中文) under each
+   question/option below to the corresponding AskUserQuestion `question` and
+   `option.label` strings. When not `CN`, use English only.
 
 ### When the server is already healthy
 
@@ -55,60 +97,163 @@ If `status.sh` reports the server is healthy AND `.env` exists with
 
 ### When config is missing (server not healthy, or `.env` missing, or values unset)
 
-Use the **AskUserQuestion** tool to collect any missing decisions. Ask up to 3
-questions in a single call when possible.
+Use the **AskUserQuestion** tool to collect missing decisions. The flow is
+**three rounds**: Server mode first (its own round), then Storage + LLM
+together, then Embedding (whose options depend on the Storage answer).
 
-### Question 1 — Storage backend (ask only if `DATABASE_PROVIDER` not in `.env` AND `POWERMEM_INIT_DATABASE_PROVIDER` unset)
-- **header**: "Storage"
-- **question**: "Which storage backend should PowerMem use?"
+**Round 1** — ask **only** the Server question (1 question). Skip this round
+entirely if `POWERMEM_BASE_URL` is already set (URL itself tells local vs
+remote).
+- Question 0: Server mode (Local vs Remote)
+
+**Round 2** — after Server mode is known, ask Storage + LLM together (up to
+2 questions in one AskUserQuestion call). Skip entirely if Remote was chosen
+or remote URL detected.
+- Question 1: Storage backend
+- Question 2: LLM provider
+
+**Round 3** — after Storage is known, ask Embedding (1 question, options vary
+by Storage choice). **Always ask Round 3** — never skip it unless
+`EMBEDDING_PROVIDER` is already in `.env` or `POWERMEM_INIT_EMBEDDING_PROVIDER`
+is already set. Skipped entirely in remote mode.
+
+### Question 0 — Server mode (ask only if `POWERMEM_BASE_URL` is unset)
+- **header**: "Server"
+- **question**: "Run a local PowerMem server, or connect to an existing remote one?（运行本地 PowerMem 服务，还是连接已有的远程服务？）"
 - **options**:
-  - "SQLite (Recommended)" — Single-user, local, zero-config. Data in `~/.powermem/powermem.db`.
+  - "Local (本地)" — Start a local server on 127.0.0.1:8848. Storage,
+    LLM, and Embedding configuration applies to this local instance.
+    （在 127.0.0.1:8848 启动本地服务，Storage/LLM/Embedding 配置作用于该本地实例。）
+  - "Remote (远程)" — Connect to an existing PowerMem server. You'll provide the URL
+    (and an optional API key). Storage/LLM/Embedding are determined by the
+    remote server; the remaining questions are skipped.
+    （连接已有的 PowerMem 服务，需要提供 URL（可选 API key）。Storage/LLM/Embedding 由远程服务决定，后续问题跳过。）
+
+If the user picks **Remote**, make a **follow-up AskUserQuestion call** with
+3 questions in one round:
+- **header**: "Server URL" — question: "PowerMem server URL (e.g. http://host:port)（PowerMem 服务地址，例如 http://host:port）"
+- **header**: "API Key" — question: "API key for the remote server (optional, leave blank if none)（远程服务 API key，可选，没有则留空）"
+- **header**: "Connection" — question: "How should Claude Code connect?（Claude Code 应该如何连接？）"
+  - "Hook (REST) (Hook REST)" — Use REST API only. Disable if your server requires an API key you don't have.（仅用 REST API。若服务器需要 API key 而你没有，请改选 MCP。）
+  - "MCP" — Use MCP streamable-http only. Hooks disabled.（仅用 MCP streamable-http，禁用 hook。）
+  - "Both (两路并存)" — Enable both. If REST 401s at runtime, hooks fail silently; MCP keeps working.（同时启用。运行时若 REST 返回 401，hook 静默失败，MCP 继续工作。）
+
+Map answers → `POWERMEM_INIT_BASE_URL`, `POWERMEM_INIT_API_KEY` (may be empty),
+and `POWERMEM_INIT_CONNECTION_MODE=hook|mcp|both`. Skip Questions 1-3 and
+jump to "Running init.sh" with these env vars. Do NOT pass any
+`POWERMEM_INIT_DATABASE_PROVIDER` / `POWERMEM_INIT_LLM_*` /
+`POWERMEM_INIT_EMBEDDING_*` — they are ignored in remote mode.
+
+### Question 1 — Storage backend (ask only if `DATABASE_PROVIDER` not in `.env` AND `POWERMEM_INIT_DATABASE_PROVIDER` unset AND not remote mode)
+- **header**: "Storage"
+- **question**: "Which storage backend should PowerMem use?（PowerMem 使用哪个存储后端？）"
+- **options**:
+  - "SQLite" — Single-user, local, zero-config. Data in `~/.powermem/powermem.db`.
+    （单用户、本地、零配置，数据存于 ~/.powermem/powermem.db。）
   - "OceanBase" — Multi-agent sharing / production. Requires OceanBase instance.
+    （多 agent 共享 / 生产环境，需要 OceanBase 实例。）
 
 Map answer → `POWERMEM_INIT_DATABASE_PROVIDER=sqlite` (or `oceanbase`).
 
-### Question 2 — LLM provider (ask ONLY if no LLM credentials detected)
+### Question 2 — LLM provider (ask if `LLM_PROVIDER` not in `.env` AND `POWERMEM_INIT_LLM_PROVIDER` unset)
 - **header**: "LLM"
-- **question**: "No LLM credentials found. How should PowerMem handle LLM-based features (fact extraction, profile extraction, query rewrite)?"
-- **options**:
-  - "No-LLM mode (Recommended)" — Skip LLM features. Memory CRUD still works. Reconfigurable later via `/init`.
-  - "Anthropic" — Use Anthropic API. Will ask for API key + model next.
-  - "OpenAI" — Use OpenAI API. Will ask for API key + model next.
+- **question**: "Which LLM provider for fact extraction, profile extraction, and query rewrite?（事实抽取、画像抽取、查询改写用哪个 LLM 提供方？）"
+- **options** (vary by credential detection):
+  - If credentials detected: "No-LLM mode (无 LLM 模式)" — Skip LLM features（跳过 LLM 功能）, and "<Detected provider> (已探测到凭据)" — Use detected credentials (no key prompt needed)（使用已探测到的凭据，无需再输入 key）.
+  - If no credentials: "No-LLM mode (无 LLM 模式)", "Anthropic" — will ask for API key + model（将询问 API key + 模型）, "OpenAI" — will ask for API key + model（将询问 API key + 模型）.
 
-If the user picks Anthropic or OpenAI, make a **follow-up AskUserQuestion call**
-with 2 questions (free-text via the "Other" option):
-- **header**: "API Key" — question: "Paste the API key for <provider>"
-- **header**: "Model" — question: "Which model? (e.g. claude-sonnet-4-6, gpt-4o)"
+If the user picks a provider without detected credentials, make a **follow-up AskUserQuestion call**:
+- **header**: "API Key" — question: "Paste the API key for <provider>（粘贴 <provider> 的 API key）"
+- **header**: "Model" — question: "Which model? (e.g. claude-sonnet-4-6, gpt-4o)（使用哪个模型？例如 claude-sonnet-4-6、gpt-4o）"
 
-Map answers → `POWERMEM_INIT_LLM_PROVIDER`, `POWERMEM_INIT_LLM_API_KEY`,
-`POWERMEM_INIT_LLM_MODEL`. For OpenAI/Anthropic, set a sensible `POWERMEM_INIT_LLM_BASE_URL`
-if the user doesn't provide one.
+Map answers → `POWERMEM_INIT_LLM_PROVIDER=noop` (or the chosen provider),
+`POWERMEM_INIT_LLM_API_KEY`, `POWERMEM_INIT_LLM_MODEL`, `POWERMEM_INIT_LLM_BASE_URL`.
 
-### Question 3 — Embedding (ask ONLY if cloud API key detected AND embedding unset)
+### Question 3 — Embedding (**MANDATORY follow-up round**, ask if `EMBEDDING_PROVIDER` not in `.env` AND `POWERMEM_INIT_EMBEDDING_PROVIDER` unset)
+
+After the user answers Question 1, ask this in a **separate AskUserQuestion call**.
+The options depend on the Storage choice from Question 1.
+
 - **header**: "Embedding"
-- **question**: "A cloud API key (<provider>) was detected. Use local or cloud embedding?"
-- **options**:
-  - "Local HuggingFace (Recommended)" — `all-MiniLM-L6-v2`, 384-dim, downloads automatically, no API key needed.
-  - "Cloud (<provider>)" — Use the detected API key for embedding.
+- **question**: "Which embedding provider should PowerMem use?（PowerMem 使用哪个嵌入提供方？）"
+- **options** (vary by storage choice):
+  - **If SQLite**: "None (无)", "Local HuggingFace (本地 HuggingFace)" — `all-MiniLM-L6-v2`, 384-dim, downloads automatically, no API key needed（all-MiniLM-L6-v2，384 维，自动下载，无需 API key）, "Cloud (<provider>) (云端 <provider>)" (only if cloud API key detected).
+  - **If OceanBase**: "None (无)", "Built-in seekdb (内置 seekdb)" — Local embedding through seekdb, no extra dependencies（通过 seekdb 本地嵌入，无额外依赖）, "Cloud (<provider>) (云端 <provider>)" (only if cloud API key detected).
 
-Map answer → `POWERMEM_INIT_EMBEDDING_PROVIDER=huggingface` (or `default` for
-OceanBase path, or the detected cloud provider name).
+Map answer → `POWERMEM_INIT_EMBEDDING_PROVIDER=none` (or `huggingface` for SQLite,
+`default` for OceanBase, or the detected cloud provider name).
+
+## Dev-mode detection (local source override)
+
+Before running `init.sh`, check whether `~/.powermem/dev-mode` exists. This
+file is **user-private** (lives outside the repo, never committed) and opts
+the current machine into running PowerMem from a local source checkout
+instead of the published PyPI package.
+
+- If `~/.powermem/dev-mode` exists → read its **first line** and use it as
+  the value of `POWERMEM_INIT_PACKAGE` when invoking `init.sh`. The file
+  content is a PEP 508 direct reference, e.g.
+  `powermem[server,extras,seekdb] @ file:///home/<user>/github/<owner>/powermem`.
+  Both `extras` and `seekdb` are listed so the same dev-mode file works
+  whether the user picks SQLite or OceanBase as the storage backend.
+  Append this env var to **both** the remote-mode and local-mode commands
+  below.
+- If `~/.powermem/dev-mode` does not exist → use the commands below verbatim
+  (no `POWERMEM_INIT_PACKAGE`).
+
+To toggle dev mode on/off the user runs `echo 'powermem[server,extras,seekdb] @ file://<abs-path>' > ~/.powermem/dev-mode` or `rm ~/.powermem/dev-mode`. Do not
+create or modify this file yourself unless the user explicitly asks.
 
 ## Running init.sh
 
-After collecting answers, run init.sh with `POWERMEM_NON_INTERACTIVE=1` to bypass
-the shell-level interactive prompts (the AskUserQuestion flow replaces them):
+After collecting answers, run init.sh with the `POWERMEM_INIT_*` environment
+variables. Two branches:
+
+### Remote mode (user chose Remote, or `POWERMEM_BASE_URL` / `POWERMEM_INIT_BASE_URL` already points at a non-localhost host)
 
 ```sh
-POWERMEM_NON_INTERACTIVE=1 \
-  POWERMEM_INIT_DATABASE_PROVIDER=<sqlite|oceanbase> \
-  [POWERMEM_INIT_LLM_PROVIDER=<provider>] \
+POWERMEM_INIT_BASE_URL=<http://remote-host:port> \
+  [POWERMEM_INIT_API_KEY=<key-or-blank>] \
+  [POWERMEM_INIT_CONNECTION_MODE=<hook|mcp|both>] \
+  [POWERMEM_INIT_PACKAGE=<value-from-dev-mode-file>] \
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/init.sh"
+```
+
+`POWERMEM_INIT_CONNECTION_MODE` defaults to `both` when unset. init.sh remote
+branch behavior:
+
+- Verifies health at `<url>/api/v1/system/health`.
+- **mode=hook or both** → writes `~/.powermem/runtime.env` with
+  `POWERMEM_BASE_URL=<url>` and optional `POWERMEM_API_KEY=<key>` (only when
+  key is non-empty).
+- **mode=mcp or both** → writes `${CLAUDE_PLUGIN_ROOT}/.mcp.json` with:
+  ```json
+  {"mcpServers":{"powermem":{"type":"http","url":"<url>/mcp"
+   [,"headers":{"Authorization":"Bearer <key>"}]}}}
+  ```
+  (headers block only added when key is non-empty).
+- **mode=mcp** → does NOT write `runtime.env` (hooks unconfigured, won't fire).
+- **mode=hook** → writes `runtime.env` only; leaves `.mcp.json` as
+  `{"mcpServers": {}}` (MCP disabled).
+- No `.env`, no uvx launch, no PID file. Storage/LLM/Embedding env vars are
+  **not** passed and would be ignored.
+
+### Local mode (default)
+
+```sh
+POWERMEM_INIT_DATABASE_PROVIDER=<sqlite|oceanbase> \
+  [POWERMEM_INIT_LLM_PROVIDER=<noop|anthropic|openai|deepseek|qwen|siliconflow>] \
   [POWERMEM_INIT_LLM_API_KEY=<key>] \
   [POWERMEM_INIT_LLM_MODEL=<model>] \
   [POWERMEM_INIT_LLM_BASE_URL=<url>] \
   [POWERMEM_INIT_EMBEDDING_PROVIDER=<provider>] \
+  [POWERMEM_INIT_PACKAGE=<value-from-dev-mode-file>] \
   bash "${CLAUDE_PLUGIN_ROOT}/scripts/init.sh"
 ```
+
+If `~/.powermem/dev-mode` exists, **always** append
+`POWERMEM_INIT_PACKAGE=<first-line-of-dev-mode-file>` to the local-mode
+command. Remote mode ignores this var (it short-circuits before uvx launch).
 
 Never print API keys in your output. Mask secrets as `<hidden>` in summaries.
 

--- a/apps/claude-code-plugin/skills/init/SKILL.md
+++ b/apps/claude-code-plugin/skills/init/SKILL.md
@@ -30,19 +30,35 @@ passed to `uvx --from` instead of using the default PyPI package.
 
 Before running `scripts/init.sh`, check what the user already has configured:
 
-1. **LLM credentials** — check env vars (`POWERMEM_INIT_LLM_API_KEY`, `LLM_API_KEY`,
+1. Run `sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"` to check server health and read
+   `~/.powermem/.env` for existing config.
+2. **Storage preference** — read `DATABASE_PROVIDER` from `~/.powermem/.env`. If set,
+   note the current backend. Also check `POWERMEM_INIT_DATABASE_PROVIDER` env var.
+3. **LLM credentials** — check env vars (`POWERMEM_INIT_LLM_API_KEY`, `LLM_API_KEY`,
    `ANTHROPIC_API_KEY`, `POWERMEM_INIT_LLM_AUTH_TOKEN`, `LLM_AUTH_TOKEN`,
    `ANTHROPIC_AUTH_TOKEN`) and `~/.claude/settings.json` (`env.ANTHROPIC_API_KEY`,
    `env.ANTHROPIC_AUTH_TOKEN`, `env.LLM_API_KEY`).
-2. **Storage preference** — check `POWERMEM_INIT_DATABASE_PROVIDER` env var.
-3. **Embedding preference** — check `POWERMEM_INIT_EMBEDDING_PROVIDER` / `EMBEDDING_PROVIDER`
+4. **Embedding preference** — check `POWERMEM_INIT_EMBEDDING_PROVIDER` / `EMBEDDING_PROVIDER`
    env vars, and whether cloud API keys exist (`OPENAI_API_KEY`, `DASHSCOPE_API_KEY`,
    `QWEN_API_KEY`, `SILICONFLOW_API_KEY`).
 
-Use the **AskUserQuestion** tool to collect any missing decisions. Ask up to 3
-questions in a single call when possible:
+### When the server is already healthy
 
-### Question 1 — Storage backend (ask if `POWERMEM_INIT_DATABASE_PROVIDER` unset)
+If `status.sh` reports the server is healthy AND `.env` exists with
+`DATABASE_PROVIDER` set, **do not ask the Storage question**. Instead:
+
+- Tell the user: "PowerMem is running with **<current_backend>** storage backend."
+- Only re-run `init.sh` if the user explicitly wants to change the storage
+  backend — in that case, ask Question 1 and pass `POWERMEM_INIT_DATABASE_PROVIDER`
+  to `init.sh`.
+- For LLM credentials and embedding: still ask if those values are unset.
+
+### When config is missing (server not healthy, or `.env` missing, or values unset)
+
+Use the **AskUserQuestion** tool to collect any missing decisions. Ask up to 3
+questions in a single call when possible.
+
+### Question 1 — Storage backend (ask only if `DATABASE_PROVIDER` not in `.env` AND `POWERMEM_INIT_DATABASE_PROVIDER` unset)
 - **header**: "Storage"
 - **question**: "Which storage backend should PowerMem use?"
 - **options**:

--- a/apps/claude-code-plugin/skills/init/SKILL.md
+++ b/apps/claude-code-plugin/skills/init/SKILL.md
@@ -238,15 +238,22 @@ branch behavior:
 - **mode=hook or both** → writes `~/.powermem/runtime.env` with
   `POWERMEM_BASE_URL=<url>` and optional `POWERMEM_API_KEY=<key>` (only when
   key is non-empty).
-- **mode=mcp or both** → writes `${CLAUDE_PLUGIN_ROOT}/.mcp.json` with:
+- **mode=mcp or both** → registers the `powermem` MCP server in the
+  user-scope config via `claude mcp add --scope user --transport http`:
   ```json
-  {"mcpServers":{"powermem":{"type":"http","url":"<url>/mcp"
-   [,"headers":{"Authorization":"Bearer <key>"}]}}}
+  {"type":"http","url":"<url>/mcp"
+   [,"headers":{"Authorization":"Bearer <key>"}]}
   ```
-  (headers block only added when key is non-empty).
+  (headers block only added when key is non-empty). User-scope is used so
+  the config survives plugin reinstalls (the plugin cache `.mcp.json` is
+  wiped on every uninstall+install) and applies to all projects. The
+  `claude mcp` CLI decides where to store it (typically `~/.claude.json`
+  top-level `mcpServers`), so the location tracks the current Claude Code
+  version / platform rather than being hardcoded.
 - **mode=mcp** → does NOT write `runtime.env` (hooks unconfigured, won't fire).
-- **mode=hook** → writes `runtime.env` only; leaves `.mcp.json` as
-  `{"mcpServers": {}}` (MCP disabled).
+- **mode=hook** → writes `runtime.env` only; runs
+  `claude mcp remove powermem --scope user` to disable MCP (other MCP
+  servers preserved).
 - No `.env`, no uvx launch, no PID file. Storage/LLM/Embedding env vars are
   **not** passed and would be ignored.
 

--- a/apps/claude-code-plugin/skills/init/SKILL.md
+++ b/apps/claude-code-plugin/skills/init/SKILL.md
@@ -144,9 +144,16 @@ Loopback is the script default; all-interface binding is an explicit opt-in.
 If the user picks **Remote**, make a **follow-up AskUserQuestion call** with
 3 questions in one round:
 - **header**: "Server URL" — question: "PowerMem server URL (e.g. http://host:port)（PowerMem 服务地址，例如 http://host:port）"
+  - The user will type their actual URL via "Other". Provide 2 distinct
+    protocol hints as options — do NOT give two duplicate placeholder URLs:
+    - "http://host:port (HTTP)" — Plain HTTP, internal/trusted network only.（明文 HTTP，仅限内网/可信网络。）
+    - "https://host:port (HTTPS)" — HTTPS, TLS-secured, recommended for cross-network.（HTTPS 加密，跨网络推荐。）
 - **header**: "API Key" — question: "API key for the remote server (optional, leave blank if none)（远程服务 API key，可选，没有则留空）"
+  - The user types the key via "Other" or picks the no-key option:
+    - "No API key (无 key)" — Server has auth disabled, or you'll connect via MCP which doesn't use this key.（服务端未开 auth，或走 MCP 不需要此 key。）
+    - "Enter key (输入 key)" — Type the key via "Other".（通过 Other 输入 key。）
 - **header**: "Connection" — question: "How should Claude Code connect?（Claude Code 应该如何连接？）"
-  - "Hook (REST) (Hook REST)" — Use REST API only. Disable if your server requires an API key you don't have.（仅用 REST API。若服务器需要 API key 而你没有，请改选 MCP。）
+  - "Hook (REST) (Hook REST)" — Use REST API only. Works if the server has auth disabled, or if you provided a valid API key above.（仅用 REST API。服务端未开 auth 或提供了有效 key 时可用。）
   - "MCP" — Use MCP streamable-http only. Hooks disabled.（仅用 MCP streamable-http，禁用 hook。）
   - "Both (两路并存)" — Enable both. If REST 401s at runtime, hooks fail silently; MCP keeps working.（同时启用。运行时若 REST 返回 401，hook 静默失败，MCP 继续工作。）
 

--- a/apps/claude-code-plugin/skills/init/SKILL.md
+++ b/apps/claude-code-plugin/skills/init/SKILL.md
@@ -26,9 +26,75 @@ unpublished backend changes, run the script with
 (SQLite) or the matching `[server,seekdb]` spec (OceanBase) so that value is
 passed to `uvx --from` instead of using the default PyPI package.
 
-If values are missing, ask only for the missing values and pass them through
-`POWERMEM_INIT_*` environment variables. Never print API keys; mask secrets in
-summaries.
+## Interactive configuration via AskUserQuestion
+
+Before running `scripts/init.sh`, check what the user already has configured:
+
+1. **LLM credentials** — check env vars (`POWERMEM_INIT_LLM_API_KEY`, `LLM_API_KEY`,
+   `ANTHROPIC_API_KEY`, `POWERMEM_INIT_LLM_AUTH_TOKEN`, `LLM_AUTH_TOKEN`,
+   `ANTHROPIC_AUTH_TOKEN`) and `~/.claude/settings.json` (`env.ANTHROPIC_API_KEY`,
+   `env.ANTHROPIC_AUTH_TOKEN`, `env.LLM_API_KEY`).
+2. **Storage preference** — check `POWERMEM_INIT_DATABASE_PROVIDER` env var.
+3. **Embedding preference** — check `POWERMEM_INIT_EMBEDDING_PROVIDER` / `EMBEDDING_PROVIDER`
+   env vars, and whether cloud API keys exist (`OPENAI_API_KEY`, `DASHSCOPE_API_KEY`,
+   `QWEN_API_KEY`, `SILICONFLOW_API_KEY`).
+
+Use the **AskUserQuestion** tool to collect any missing decisions. Ask up to 3
+questions in a single call when possible:
+
+### Question 1 — Storage backend (ask if `POWERMEM_INIT_DATABASE_PROVIDER` unset)
+- **header**: "Storage"
+- **question**: "Which storage backend should PowerMem use?"
+- **options**:
+  - "SQLite (Recommended)" — Single-user, local, zero-config. Data in `~/.powermem/powermem.db`.
+  - "OceanBase" — Multi-agent sharing / production. Requires OceanBase instance.
+
+Map answer → `POWERMEM_INIT_DATABASE_PROVIDER=sqlite` (or `oceanbase`).
+
+### Question 2 — LLM provider (ask ONLY if no LLM credentials detected)
+- **header**: "LLM"
+- **question**: "No LLM credentials found. How should PowerMem handle LLM-based features (fact extraction, profile extraction, query rewrite)?"
+- **options**:
+  - "No-LLM mode (Recommended)" — Skip LLM features. Memory CRUD still works. Reconfigurable later via `/init`.
+  - "Anthropic" — Use Anthropic API. Will ask for API key + model next.
+  - "OpenAI" — Use OpenAI API. Will ask for API key + model next.
+
+If the user picks Anthropic or OpenAI, make a **follow-up AskUserQuestion call**
+with 2 questions (free-text via the "Other" option):
+- **header**: "API Key" — question: "Paste the API key for <provider>"
+- **header**: "Model" — question: "Which model? (e.g. claude-sonnet-4-6, gpt-4o)"
+
+Map answers → `POWERMEM_INIT_LLM_PROVIDER`, `POWERMEM_INIT_LLM_API_KEY`,
+`POWERMEM_INIT_LLM_MODEL`. For OpenAI/Anthropic, set a sensible `POWERMEM_INIT_LLM_BASE_URL`
+if the user doesn't provide one.
+
+### Question 3 — Embedding (ask ONLY if cloud API key detected AND embedding unset)
+- **header**: "Embedding"
+- **question**: "A cloud API key (<provider>) was detected. Use local or cloud embedding?"
+- **options**:
+  - "Local HuggingFace (Recommended)" — `all-MiniLM-L6-v2`, 384-dim, downloads automatically, no API key needed.
+  - "Cloud (<provider>)" — Use the detected API key for embedding.
+
+Map answer → `POWERMEM_INIT_EMBEDDING_PROVIDER=huggingface` (or `default` for
+OceanBase path, or the detected cloud provider name).
+
+## Running init.sh
+
+After collecting answers, run init.sh with `POWERMEM_NON_INTERACTIVE=1` to bypass
+the shell-level interactive prompts (the AskUserQuestion flow replaces them):
+
+```sh
+POWERMEM_NON_INTERACTIVE=1 \
+  POWERMEM_INIT_DATABASE_PROVIDER=<sqlite|oceanbase> \
+  [POWERMEM_INIT_LLM_PROVIDER=<provider>] \
+  [POWERMEM_INIT_LLM_API_KEY=<key>] \
+  [POWERMEM_INIT_LLM_MODEL=<model>] \
+  [POWERMEM_INIT_LLM_BASE_URL=<url>] \
+  [POWERMEM_INIT_EMBEDDING_PROVIDER=<provider>] \
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/init.sh"
+```
+
+Never print API keys in your output. Mask secrets as `<hidden>` in summaries.
 
 The default local embedding model (`all-MiniLM-L6-v2`) is downloaded
 automatically by PowerMem at startup — no `init.sh` flag is needed. CN networks

--- a/apps/claude-code-plugin/skills/status/SKILL.md
+++ b/apps/claude-code-plugin/skills/status/SKILL.md
@@ -2,5 +2,25 @@
 description: Check whether PowerMem is configured, running, and reachable from Claude Code.
 ---
 
-Run `sh "${CLAUDE_PLUGIN_ROOT}/scripts/status.sh"` when available. Report the data directory, base URL, managed server PID if any, and health state. Do not print `.env` contents.
+Run `sh "${CLAUDE_PLUGIN_ROOT}/scripts/status.sh"` when available. Report the
+data directory, connection mode (hook / mcp / both / none), hook base URL if
+configured, MCP URL if configured, managed server PID if any, and health
+state. Do not print `.env` contents.
+
+**CLAUDE_PLUGIN_ROOT handling:** same rule as the init skill — if
+`$CLAUDE_PLUGIN_ROOT` is unset, `export` it on its own line via
+`find ~/.claude/plugins/cache/powermem/memory-powermem -maxdepth 2 -name scripts -type d 2>/dev/null | head -1 | xargs dirname`,
+never write `CLAUDE_PLUGIN_ROOT=... sh "$CLAUDE_PLUGIN_ROOT/..."` on one line.
+
+**Interpreting the connection mode line:**
+- `hook` — only `runtime.env` is configured; hooks call the REST API at the
+  Hook base URL.
+- `mcp` — only `${CLAUDE_PLUGIN_ROOT}/.mcp.json` is configured; Claude Code
+  MCP client connects to the MCP URL. No local server expected.
+- `both` — both files configured; hooks and MCP coexist.
+- `none` — neither file is configured; user has not run `/memory-powermem:init`.
+
+The Health line probes whichever base URL applies (hook URL if set, otherwise
+the MCP URL with `/mcp` stripped). For `none` mode, status.sh reports
+"no base URL configured" and skips the health check.
 

--- a/src/powermem/integrations/embeddings/_model_cache.py
+++ b/src/powermem/integrations/embeddings/_model_cache.py
@@ -1,0 +1,276 @@
+"""Shared helpers for local embedding model cache management.
+
+CN-aware download + HuggingFace cache bridge for the default sentence-transformers
+model (``all-MiniLM-L6-v2``). Used by both:
+
+* :class:`powermem.integrations.embeddings.pyseekdb_default.PyseekdbDefaultEmbedding`
+* :class:`powermem.integrations.embeddings.huggingface.HuggingFaceEmbedding`
+
+Extracted so the SQLite/HuggingFace path gets the same CN detection + ModelScope
+fallback that the OceanBase/pyseekdb path already had, avoiding the
+``huggingface_hub`` httpx-client-closed retry bug on networks where
+``huggingface.co`` is unreachable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MODEL_NAME = "all-MiniLM-L6-v2"
+DEFAULT_MODEL_REPO_ID = "sentence-transformers/all-MiniLM-L6-v2"
+DEFAULT_EMBEDDING_DIMS = 384
+
+_MODEL_DOWNLOAD_TIMEOUT_S = 30
+
+_MODELSCOPE_REPO_ID = "AI-ModelScope/all-MiniLM-L6-v2"
+_HF_REVISION_FALLBACK = "fa97f6e7cb1a59073dff9e9d8ba1c7c1591cc08d"
+
+_IP_COUNTRY_URLS = [
+    "https://ipapi.co/country/",
+    "https://ifconfig.co/country-iso",
+    "https://ipinfo.io/country",
+]
+
+
+def is_model_cached(repo_id: str) -> bool:
+    """Return True if the HuggingFace model is already in the local cache."""
+    try:
+        from huggingface_hub import try_to_load_from_cache
+
+        result = try_to_load_from_cache(repo_id, "config.json")
+        return result is not None
+    except Exception:
+        return False
+
+
+def detect_country(timeout: int = 3) -> str:
+    """Detect public IP country code.
+
+    Tries up to three IP geolocation APIs in sequence.  Returns the two-letter
+    ISO country code (upper-case) on success, or an empty string if all APIs
+    fail or time out.
+    """
+    for url in _IP_COUNTRY_URLS:
+        try:
+            resp = urllib.request.urlopen(url, timeout=timeout)
+            code = resp.read().decode().strip().upper()[:2]
+            if len(code) == 2 and code.isalpha():
+                return code
+        except Exception:
+            continue
+    return ""
+
+
+def download_via_modelscope(country: str = "") -> None:
+    """Download the default embedding model via ModelScope using ``uvx``.
+
+    Reads the following environment variables (set by ``common.sh`` / init.sh):
+    - ``POWERMEM_UV_BIN`` — path to the ``uv`` binary
+    - ``POWERMEM_BOOTSTRAP_PYTHON`` — Python version/path for ``uvx --python``
+    - ``POWERMEM_UV_INDEX_URL`` — custom PyPI index (e.g. Tsinghua mirror)
+    - ``POWERMEM_MODELSCOPE_PACKAGE`` — override the modelscope package spec
+    """
+    uv_bin = (
+        os.environ.get("POWERMEM_UV_BIN")
+        or shutil.which("uv")
+        or str(Path.home() / ".local" / "bin" / "uv")
+    )
+    if not shutil.which(uv_bin) and not os.path.isfile(uv_bin):
+        raise RuntimeError(
+            "uv is required to download the embedding model via ModelScope but "
+            "was not found on PATH. "
+            "Install it: https://docs.astral.sh/uv/getting-started/installation/"
+        )
+
+    python = os.environ.get("POWERMEM_BOOTSTRAP_PYTHON", "3.11")
+    package = os.environ.get("POWERMEM_MODELSCOPE_PACKAGE", "modelscope")
+
+    index_url = os.environ.get("POWERMEM_UV_INDEX_URL", "")
+    if not index_url and country == "CN":
+        index_url = "https://pypi.tuna.tsinghua.edu.cn/simple"
+
+    cmd = [uv_bin, "tool", "run", "--python", python]
+    if index_url:
+        cmd += ["--default-index", index_url]
+    cmd += [
+        "--from", package,
+        "python", "-c",
+        f"from modelscope import snapshot_download; "
+        f"snapshot_download({_MODELSCOPE_REPO_ID!r})",
+    ]
+
+    logger.info("Downloading embedding model via ModelScope: %s", _MODELSCOPE_REPO_ID)
+    subprocess.run(cmd, check=True)
+
+
+def bridge_modelscope_to_hf_cache() -> None:
+    """Copy a ModelScope-downloaded model into the HuggingFace hub cache layout.
+
+    Mirrors the bridge logic in ``preload-model.sh``.
+    """
+    org, name = _MODELSCOPE_REPO_ID.split("/", 1)
+    src = Path.home() / ".cache" / "modelscope" / "hub" / "models" / org / name
+    if not src.exists():
+        raise RuntimeError(
+            f"ModelScope cache not found at {src}; the download may have failed."
+        )
+
+    hf_dir_name = "models--" + DEFAULT_MODEL_REPO_ID.replace("/", "--")
+    hub = Path.home() / ".cache" / "huggingface" / "hub" / hf_dir_name
+
+    try:
+        resp = urllib.request.urlopen(
+            f"https://huggingface.co/api/models/{DEFAULT_MODEL_REPO_ID}",
+            timeout=5,
+        )
+        rev = json.load(resp)["sha"]
+    except Exception:
+        rev = _HF_REVISION_FALLBACK
+
+    snap = hub / "snapshots" / rev
+    snap.mkdir(parents=True, exist_ok=True)
+    refs_dir = hub / "refs"
+    refs_dir.mkdir(exist_ok=True)
+    (refs_dir / "main").write_text(rev)
+
+    skip = {"configuration.json", "data_config.json"}
+    for fname in os.listdir(src):
+        if fname in skip:
+            continue
+        source = src / fname
+        target = snap / fname
+        if target.exists():
+            continue
+        if source.is_dir():
+            shutil.copytree(source, target)
+        else:
+            shutil.copy2(source, target)
+
+    logger.info("Bridged ModelScope cache to HuggingFace cache: %s", snap)
+
+
+def load_sentence_transformer_with_fallback(model_name: str, repo_id: str, on_model_loaded=None):
+    """Ensure the embedding model is cached, then load it with SentenceTransformer.
+
+    Flow:
+    1. Cache hit → load with ``local_files_only=True`` (no network).
+    2. Cache miss + CN → download via ModelScope + bridge to HF cache, then load.
+    3. Cache miss + non-CN / detection failed → HF download with timeout.
+
+    ``on_model_loaded(model_name, model)`` is an optional callback invoked after
+    the model is loaded in any path (used by pyseekdb_default to patch pyseekdb's
+    internal cache). ``sentence_transformers`` is optional; if not installed, the
+    download still runs so model files are available, but ``None`` is returned.
+    """
+    if is_model_cached(repo_id):
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            logger.debug(
+                "sentence_transformers not installed; skipping model pre-warm "
+                "(install the 'extras' group to enable the cache-first optimization)"
+            )
+            return None
+        model = SentenceTransformer(model_name, local_files_only=True)
+        if on_model_loaded is not None:
+            on_model_loaded(model_name, model)
+        logger.info("Loaded %s from local cache", model_name)
+        return model
+
+    logger.debug("Model %s not in cache; detecting network region...", model_name)
+    country = detect_country()
+    logger.info(
+        "Network region: %s; downloading %s via %s",
+        country or "unknown",
+        model_name,
+        "ModelScope" if country == "CN" else "HuggingFace",
+    )
+
+    if country == "CN":
+        try:
+            download_via_modelscope(country=country)
+            bridge_modelscope_to_hf_cache()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to download embedding model '{model_name}' via ModelScope: "
+                f"{exc}.\n"
+                "Download it manually:\n"
+                f"  python -c \"from modelscope import snapshot_download; "
+                f"snapshot_download({_MODELSCOPE_REPO_ID!r})\""
+            ) from exc
+
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            logger.debug(
+                "sentence_transformers not installed; skipping model pre-warm "
+                "(install the 'extras' group to enable the cache-first optimization)"
+            )
+            return None
+        model = SentenceTransformer(model_name, local_files_only=True)
+        if on_model_loaded is not None:
+            on_model_loaded(model_name, model)
+        logger.info("Downloaded and loaded %s via ModelScope", model_name)
+        return model
+
+    try:
+        from sentence_transformers import SentenceTransformer
+    except ImportError:
+        logger.debug(
+            "sentence_transformers not installed; skipping model pre-warm "
+            "(install the 'extras' group to enable the cache-first optimization)"
+        )
+        return None
+
+    import threading
+
+    logger.debug(
+        "Attempting HuggingFace download of %s (timeout %ss)...",
+        model_name,
+        _MODEL_DOWNLOAD_TIMEOUT_S,
+    )
+
+    result: list = [None]
+    error: list = [None]
+
+    def _load() -> None:
+        try:
+            result[0] = SentenceTransformer(model_name)
+        except Exception as exc:
+            error[0] = exc
+
+    thread = threading.Thread(target=_load, daemon=True)
+    thread.start()
+    thread.join(timeout=_MODEL_DOWNLOAD_TIMEOUT_S)
+
+    if result[0] is not None:
+        if on_model_loaded is not None:
+            on_model_loaded(model_name, result[0])
+        logger.info("Downloaded and loaded %s", model_name)
+        return result[0]
+
+    if error[0] is not None:
+        raise RuntimeError(
+            f"Failed to download embedding model '{model_name}': {error[0]}.\n"
+            "Download it manually:\n"
+            f"  python -c \"from modelscope import snapshot_download; "
+            f"snapshot_download({_MODELSCOPE_REPO_ID!r})\""
+        ) from error[0]
+
+    raise RuntimeError(
+        f"Downloading embedding model '{model_name}' timed out after "
+        f"{_MODEL_DOWNLOAD_TIMEOUT_S}s. The model is not cached and the "
+        f"network is unreachable.\n"
+        "Download it manually:\n"
+        f"  python -c \"from modelscope import snapshot_download; "
+        f"snapshot_download({_MODELSCOPE_REPO_ID!r})\""
+    )

--- a/src/powermem/integrations/embeddings/huggingface.py
+++ b/src/powermem/integrations/embeddings/huggingface.py
@@ -1,9 +1,14 @@
 import logging
+import threading
 from typing import Literal, Optional
 
 from openai import OpenAI
-from sentence_transformers import SentenceTransformer
 
+from powermem.integrations.embeddings._model_cache import (
+    DEFAULT_MODEL_NAME,
+    DEFAULT_MODEL_REPO_ID,
+    load_sentence_transformer_with_fallback,
+)
 from powermem.integrations.embeddings.base import EmbeddingBase
 from powermem.integrations.embeddings.config.base import BaseEmbedderConfig
 
@@ -16,16 +21,40 @@ class HuggingFaceEmbedding(EmbeddingBase):
     def __init__(self, config: Optional[BaseEmbedderConfig] = None):
         super().__init__(config)
 
+        self._model = None
+        self._model_lock = threading.Lock()
+
         base_url = getattr(self.config, "huggingface_base_url", None)
         if base_url:
             self.client = OpenAI(base_url=base_url)
         else:
             self.config.model = self.config.model or "multi-qa-MiniLM-L6-cos-v1"
 
-            model_kwargs = getattr(self.config, "model_kwargs", {})
-            self.model = SentenceTransformer(self.config.model, **model_kwargs)
+    def _get_model(self):
+        if self._model is not None:
+            return self._model
+        with self._model_lock:
+            if self._model is None:
+                model_name = self.config.model
+                model_kwargs = getattr(self.config, "model_kwargs", {}) or {}
 
-            self.config.embedding_dims = self.config.embedding_dims or self.model.get_sentence_embedding_dimension()
+                # For the default model, use the CN-aware loader (cache-first,
+                # ModelScope fallback for CN) to avoid huggingface_hub's buggy
+                # httpx retry path on networks where huggingface.co is unreachable.
+                if not model_kwargs and model_name in (DEFAULT_MODEL_NAME, DEFAULT_MODEL_REPO_ID):
+                    self._model = load_sentence_transformer_with_fallback(
+                        DEFAULT_MODEL_NAME, DEFAULT_MODEL_REPO_ID
+                    )
+                else:
+                    from sentence_transformers import SentenceTransformer
+                    self._model = SentenceTransformer(model_name, **model_kwargs)
+
+                if self._model is not None:
+                    self.config.embedding_dims = (
+                        self.config.embedding_dims
+                        or self._model.get_sentence_embedding_dimension()
+                    )
+        return self._model
 
     def embed(self, text, memory_action: Optional[Literal["add", "search", "update"]] = None):
         """
@@ -40,4 +69,4 @@ class HuggingFaceEmbedding(EmbeddingBase):
         if getattr(self.config, "huggingface_base_url", None):
             return self.client.embeddings.create(input=text, model="tei").data[0].embedding
         else:
-            return self.model.encode(text, convert_to_numpy=True).tolist()
+            return self._get_model().encode(text, convert_to_numpy=True).tolist()

--- a/src/powermem/integrations/embeddings/pyseekdb_default.py
+++ b/src/powermem/integrations/embeddings/pyseekdb_default.py
@@ -27,16 +27,21 @@ to switch to a production-grade provider (OpenAI, Qwen, SiliconFlow, etc.).
 
 from __future__ import annotations
 
-import json
 import logging
-import os
-import shutil
-import subprocess
-import threading
-import urllib.request
-from pathlib import Path
 from typing import List, Literal, Optional
 
+from powermem.integrations.embeddings._model_cache import (
+    DEFAULT_EMBEDDING_DIMS,
+    DEFAULT_MODEL_NAME,
+    DEFAULT_MODEL_REPO_ID,
+    _HF_REVISION_FALLBACK,
+    _MODELSCOPE_REPO_ID,
+    bridge_modelscope_to_hf_cache as _bridge_modelscope_to_hf_cache,
+    detect_country as _detect_country,
+    download_via_modelscope as _download_via_modelscope,
+    is_model_cached as _is_model_cached,
+    load_sentence_transformer_with_fallback,
+)
 from powermem.integrations.embeddings.base import EmbeddingBase
 from powermem.integrations.embeddings.config.base import BaseEmbedderConfig
 
@@ -44,144 +49,6 @@ logger = logging.getLogger(__name__)
 
 logging.getLogger("onnxruntime").setLevel(logging.WARNING)
 logging.getLogger("huggingface_hub").setLevel(logging.WARNING)
-
-
-# Match pyseekdb's DefaultEmbeddingFunction so the two systems agree on the
-# default model and dimension.
-DEFAULT_MODEL_NAME = "all-MiniLM-L6-v2"
-DEFAULT_MODEL_REPO_ID = "sentence-transformers/all-MiniLM-L6-v2"
-DEFAULT_EMBEDDING_DIMS = 384
-
-# Timeout (seconds) for the HuggingFace download path (non-CN).
-_MODEL_DOWNLOAD_TIMEOUT_S = 30
-
-_MODELSCOPE_REPO_ID = "AI-ModelScope/all-MiniLM-L6-v2"
-# Fallback HF revision SHA used when the HF API is unreachable during bridge.
-_HF_REVISION_FALLBACK = "fa97f6e7cb1a59073dff9e9d8ba1c7c1591cc08d"
-
-_IP_COUNTRY_URLS = [
-    "https://ipapi.co/country/",
-    "https://ifconfig.co/country-iso",
-    "https://ipinfo.io/country",
-]
-
-
-def _is_model_cached(repo_id: str) -> bool:
-    """Return True if the HuggingFace model is already in the local cache."""
-    try:
-        from huggingface_hub import try_to_load_from_cache
-
-        result = try_to_load_from_cache(repo_id, "config.json")
-        return result is not None
-    except Exception:
-        return False
-
-
-def _detect_country(timeout: int = 3) -> str:
-    """Detect public IP country code, mirroring common.sh detect_public_ip_country.
-
-    Tries up to three IP geolocation APIs in sequence.  Returns the two-letter
-    ISO country code (upper-case) on success, or an empty string if all APIs
-    fail or time out.
-    """
-    for url in _IP_COUNTRY_URLS:
-        try:
-            resp = urllib.request.urlopen(url, timeout=timeout)
-            code = resp.read().decode().strip().upper()[:2]
-            if len(code) == 2 and code.isalpha():
-                return code
-        except Exception:
-            continue
-    return ""
-
-
-def _download_via_modelscope(country: str = "") -> None:
-    """Download the default embedding model via ModelScope using ``uvx``.
-
-    Reads the following environment variables (set by ``common.sh`` / init.sh):
-    - ``POWERMEM_UV_BIN`` — path to the ``uv`` binary
-    - ``POWERMEM_BOOTSTRAP_PYTHON`` — Python version/path for ``uvx --python``
-    - ``POWERMEM_UV_INDEX_URL`` — custom PyPI index (e.g. Tsinghua mirror)
-    - ``POWERMEM_MODELSCOPE_PACKAGE`` — override the modelscope package spec
-    """
-    uv_bin = (
-        os.environ.get("POWERMEM_UV_BIN")
-        or shutil.which("uv")
-        or str(Path.home() / ".local" / "bin" / "uv")
-    )
-    if not shutil.which(uv_bin) and not os.path.isfile(uv_bin):
-        raise RuntimeError(
-            "uv is required to download the embedding model via ModelScope but "
-            "was not found on PATH. "
-            "Install it: https://docs.astral.sh/uv/getting-started/installation/"
-        )
-
-    python = os.environ.get("POWERMEM_BOOTSTRAP_PYTHON", "3.11")
-    package = os.environ.get("POWERMEM_MODELSCOPE_PACKAGE", "modelscope")
-
-    index_url = os.environ.get("POWERMEM_UV_INDEX_URL", "")
-    if not index_url and country == "CN":
-        # Mirror common.sh configure_uv_index: default to Tsinghua for CN
-        index_url = "https://pypi.tuna.tsinghua.edu.cn/simple"
-
-    cmd = [uv_bin, "tool", "run", "--python", python]
-    if index_url:
-        cmd += ["--default-index", index_url]
-    cmd += [
-        "--from", package,
-        "python", "-c",
-        f"from modelscope import snapshot_download; "
-        f"snapshot_download({_MODELSCOPE_REPO_ID!r})",
-    ]
-
-    logger.info("Downloading embedding model via ModelScope: %s", _MODELSCOPE_REPO_ID)
-    subprocess.run(cmd, check=True)
-
-
-def _bridge_modelscope_to_hf_cache() -> None:
-    """Copy a ModelScope-downloaded model into the HuggingFace hub cache layout.
-
-    Mirrors the bridge logic in ``preload-model.sh``.
-    """
-    org, name = _MODELSCOPE_REPO_ID.split("/", 1)
-    src = Path.home() / ".cache" / "modelscope" / "hub" / "models" / org / name
-    if not src.exists():
-        raise RuntimeError(
-            f"ModelScope cache not found at {src}; the download may have failed."
-        )
-
-    hf_dir_name = "models--" + DEFAULT_MODEL_REPO_ID.replace("/", "--")
-    hub = Path.home() / ".cache" / "huggingface" / "hub" / hf_dir_name
-
-    try:
-        resp = urllib.request.urlopen(
-            f"https://huggingface.co/api/models/{DEFAULT_MODEL_REPO_ID}",
-            timeout=5,
-        )
-        rev = json.load(resp)["sha"]
-    except Exception:
-        rev = _HF_REVISION_FALLBACK
-
-    snap = hub / "snapshots" / rev
-    snap.mkdir(parents=True, exist_ok=True)
-    refs_dir = hub / "refs"
-    refs_dir.mkdir(exist_ok=True)
-    (refs_dir / "main").write_text(rev)
-
-    skip = {"configuration.json", "data_config.json"}
-    for fname in os.listdir(src):
-        if fname in skip:
-            continue
-        source = src / fname
-        target = snap / fname
-        if target.exists():
-            continue
-        if source.is_dir():
-            shutil.copytree(source, target)
-        else:
-            shutil.copy2(source, target)
-
-    logger.info("Bridged ModelScope cache to HuggingFace cache: %s", snap)
 
 
 def _patch_sentence_transformer_cache(model_name: str, model) -> None:
@@ -206,115 +73,14 @@ def _patch_sentence_transformer_cache(model_name: str, model) -> None:
 def _load_sentence_transformer_with_fallback(model_name: str, repo_id: str):
     """Ensure the embedding model is cached, then load it with SentenceTransformer.
 
-    Flow:
-    1. Cache hit → load with ``local_files_only=True`` and patch pyseekdb cache.
-    2. Cache miss + CN → download via ModelScope + bridge to HF cache, then load.
-    3. Cache miss + non-CN / detection failed → HF download via background thread
-       with :data:`_MODEL_DOWNLOAD_TIMEOUT_S` timeout.
-
-    ``sentence_transformers`` is optional.  If not installed, the download (CN
-    or otherwise) still runs so the model files are available for pyseekdb's own
-    ONNX-based loader; only the pre-warm / cache-patch step is skipped.
+    Thin wrapper around :func:`load_sentence_transformer_with_fallback` that also
+    patches pyseekdb's internal model cache after load. See the shared helper in
+    ``_model_cache.py`` for the full CN-aware download flow.
     """
-    if _is_model_cached(repo_id):
-        try:
-            from sentence_transformers import SentenceTransformer
-        except ImportError:
-            logger.debug(
-                "sentence_transformers not installed; skipping model pre-warm "
-                "(install the 'extras' group to enable the cache-first optimization)"
-            )
-            return None
-        model = SentenceTransformer(model_name, local_files_only=True)
-        _patch_sentence_transformer_cache(model_name, model)
-        logger.info("Loaded %s from local cache", model_name)
-        return model
-
-    # Cache miss: detect network region and download
-    logger.debug("Model %s not in cache; detecting network region...", model_name)
-    country = _detect_country()
-    logger.info(
-        "Network region: %s; downloading %s via %s",
-        country or "unknown",
+    return load_sentence_transformer_with_fallback(
         model_name,
-        "ModelScope" if country == "CN" else "HuggingFace",
-    )
-
-    if country == "CN":
-        try:
-            _download_via_modelscope(country=country)
-            _bridge_modelscope_to_hf_cache()
-        except Exception as exc:
-            raise RuntimeError(
-                f"Failed to download embedding model '{model_name}' via ModelScope: "
-                f"{exc}.\n"
-                "Download it manually:\n"
-                f"  python -c \"from modelscope import snapshot_download; "
-                f"snapshot_download({_MODELSCOPE_REPO_ID!r})\""
-            ) from exc
-
-        try:
-            from sentence_transformers import SentenceTransformer
-        except ImportError:
-            logger.debug(
-                "sentence_transformers not installed; skipping model pre-warm "
-                "(install the 'extras' group to enable the cache-first optimization)"
-            )
-            return None
-        model = SentenceTransformer(model_name, local_files_only=True)
-        _patch_sentence_transformer_cache(model_name, model)
-        logger.info("Downloaded and loaded %s via ModelScope", model_name)
-        return model
-
-    # Non-CN / detection failed: HF download with timeout
-    try:
-        from sentence_transformers import SentenceTransformer
-    except ImportError:
-        logger.debug(
-            "sentence_transformers not installed; skipping model pre-warm "
-            "(install the 'extras' group to enable the cache-first optimization)"
-        )
-        return None
-
-    logger.debug(
-        "Attempting HuggingFace download of %s (timeout %ss)...",
-        model_name,
-        _MODEL_DOWNLOAD_TIMEOUT_S,
-    )
-
-    result: list = [None]
-    error: list = [None]
-
-    def _load() -> None:
-        try:
-            result[0] = SentenceTransformer(model_name)
-        except Exception as exc:
-            error[0] = exc
-
-    thread = threading.Thread(target=_load, daemon=True)
-    thread.start()
-    thread.join(timeout=_MODEL_DOWNLOAD_TIMEOUT_S)
-
-    if result[0] is not None:
-        _patch_sentence_transformer_cache(model_name, result[0])
-        logger.info("Downloaded and loaded %s", model_name)
-        return result[0]
-
-    if error[0] is not None:
-        raise RuntimeError(
-            f"Failed to download embedding model '{model_name}': {error[0]}.\n"
-            "Download it manually:\n"
-            f"  python -c \"from modelscope import snapshot_download; "
-            f"snapshot_download({_MODELSCOPE_REPO_ID!r})\""
-        ) from error[0]
-
-    raise RuntimeError(
-        f"Downloading embedding model '{model_name}' timed out after "
-        f"{_MODEL_DOWNLOAD_TIMEOUT_S}s. The model is not cached and the "
-        f"network is unreachable.\n"
-        "Download it manually:\n"
-        f"  python -c \"from modelscope import snapshot_download; "
-        f"snapshot_download({_MODELSCOPE_REPO_ID!r})\""
+        repo_id,
+        on_model_loaded=_patch_sentence_transformer_cache,
     )
 
 

--- a/tests/unit/test_claude_plugin_uv_install.py
+++ b/tests/unit/test_claude_plugin_uv_install.py
@@ -549,7 +549,7 @@ def test_init_uses_uvx_launcher_instead_of_plugin_venv_install() -> None:
     assert 'export_env_file_vars "$ENV_FILE"' in script
     assert 'tool run \\' in script
     assert "--from \"$PACKAGE\"" in script
-    assert "powermem-server --host 127.0.0.1 --port \"$port\"" in script
+    assert "powermem-server --host \"${POWERMEM_SERVER_HOST:-127.0.0.1}\" --port \"$port\"" in script
     assert "uv_pip_install" not in script
     assert "venv_powermem_server" not in script
 

--- a/tests/unit/test_claude_plugin_uv_install.py
+++ b/tests/unit/test_claude_plugin_uv_install.py
@@ -614,3 +614,122 @@ def test_init_preload_model_is_deprecated_no_op() -> None:
     )
     assert 'sh "$SCRIPT_DIR/preload-model.sh"' not in script
     assert 'POWERMEM_INIT_PRELOAD_MODEL is deprecated' in script
+
+
+def test_write_runtime_remote_quotes_metacharacters(tmp_path: Path) -> None:
+    """runtime.env is sourced by run-hook.sh and status.sh. URLs / API keys
+    may contain shell metacharacters ($, ;, spaces, backticks, single quotes).
+    Values must be single-quoted with embedded ' escaped via the standard
+    '\'' trick so sourcing round-trips the exact bytes. Regression guard for
+    PR #1101 review: previously values were written bare, so a URL like
+    'http://host:8001/path?x=1;y=2' was split on ';' and 'y=2' was lost.
+    """
+    tricky_url = "http://host:8001/path?a=1;b=2 c=3$VAR`echo hi`"
+    tricky_key = "sk-abc'\"def $XYZ"
+
+    env = os.environ.copy()
+    env["TRICKY_URL"] = tricky_url
+    env["TRICKY_KEY"] = tricky_key
+    env["HOME"] = str(tmp_path)
+    env["PATH"] = f"{tmp_path / 'bin'}:/usr/bin:/bin"
+    env["POWERMEM_DATA_DIR"] = str(tmp_path / ".powermem")
+    command = textwrap.dedent(
+        f"""
+        set -eu
+        . "{COMMON_SH}"
+        write_runtime_remote "$TRICKY_URL" "$TRICKY_KEY"
+        cat "$RUNTIME_FILE"
+        echo "---"
+        . "$RUNTIME_FILE"
+        printf 'URL=%s\\n' "$POWERMEM_BASE_URL"
+        printf 'KEY=%s\\n' "$POWERMEM_API_KEY"
+        """
+    )
+    result = subprocess.run(
+        ["sh", "-c", command, str(SCRIPT_ARG0)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "POWERMEM_BASE_URL=" in result.stdout
+    assert f"URL={tricky_url}" in result.stdout
+    assert f"KEY={tricky_key}" in result.stdout
+
+
+def test_write_runtime_hook_disabled_writes_marker(tmp_path: Path) -> None:
+    """MCP-only mode must write POWERMEM_HOOK_DISABLED=1 to runtime.env so
+    run-hook.sh exits early instead of falling back to a stale base URL.
+    Regression guard for PR #1101 review issue: mcp mode previously wrote
+    nothing, leaving stale runtime.env from a prior hook/both init.
+    """
+    result = run_common(
+        """
+        write_runtime_hook_disabled
+        cat "$RUNTIME_FILE"
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "POWERMEM_HOOK_DISABLED=1"
+
+
+def test_run_hook_exits_early_when_hook_disabled(tmp_path: Path) -> None:
+    """When runtime.env sets POWERMEM_HOOK_DISABLED=1, run-hook.sh must exit 0
+    without exec'ing the native binary — so a stale POWERMEM_BASE_URL never
+    gets hit. Regression guard for PR #1101 review.
+    """
+    plugin_root = tmp_path / "plugin"
+    hooks_dir = plugin_root / "hooks"
+    bin_dir = hooks_dir / "bin"
+    hooks_dir.mkdir(parents=True)
+    run_hook = hooks_dir / "run-hook.sh"
+    run_hook.write_text(RUN_HOOK_SH.read_text(encoding="utf-8"), encoding="utf-8")
+    run_hook.chmod(0o755)
+    # Plant a binary that would fail the test if exec'd.
+    write_executable(
+        bin_dir / "powermem-hook-linux-amd64",
+        """
+        #!/usr/bin/env sh
+        echo "BINARY-RAN"
+        exit 99
+        """,
+    )
+    data_dir = tmp_path / ".powermem"
+    data_dir.mkdir()
+    (data_dir / "runtime.env").write_text(
+        "POWERMEM_HOOK_DISABLED=1\nPOWERMEM_BASE_URL=http://stale.example:8848\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["sh", str(run_hook)],
+        cwd=tmp_path,
+        env={**os.environ, "HOME": str(tmp_path), "POWERMEM_DATA_DIR": str(data_dir)},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "BINARY-RAN" not in result.stdout
+
+
+def test_init_mcp_branch_writes_hook_disabled_marker() -> None:
+    """init.sh's mcp connection-mode branch must call write_runtime_hook_disabled
+    so stale runtime.env state doesn't linger. Regression guard for PR #1101
+    review.
+    """
+    script = INIT_SH.read_text(encoding="utf-8")
+
+    assert "write_runtime_hook_disabled" in script
+    # The mcp case must be inside the connection-mode case block, not the
+    # hook|both block.
+    assert "mcp)\n      write_runtime_hook_disabled" in script or \
+           "mcp)\n      # Write a marker" in script

--- a/tests/unit/test_pyseekdb_default_download.py
+++ b/tests/unit/test_pyseekdb_default_download.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from powermem.integrations.embeddings import pyseekdb_default
+from powermem.integrations.embeddings import _model_cache, pyseekdb_default
 
 
 # ---------------------------------------------------------------------------
@@ -43,28 +43,28 @@ class TestDetectCountry:
 
     def test_first_api_returns_cn(self):
         side_effect = self._mock_urlopen([b"CN"])
-        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+        with patch.object(_model_cache.urllib.request, "urlopen", side_effect=side_effect):
             assert pyseekdb_default._detect_country() == "CN"
 
     def test_first_fails_second_returns_us(self):
         side_effect = self._mock_urlopen([OSError("timeout"), b"US"])
-        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+        with patch.object(_model_cache.urllib.request, "urlopen", side_effect=side_effect):
             assert pyseekdb_default._detect_country() == "US"
 
     def test_all_fail_returns_empty(self):
         side_effect = self._mock_urlopen([OSError(), OSError(), OSError()])
-        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+        with patch.object(_model_cache.urllib.request, "urlopen", side_effect=side_effect):
             assert pyseekdb_default._detect_country() == ""
 
     def test_dirty_data_is_skipped(self):
         # First returns non-alpha data (digits), second returns valid
         side_effect = self._mock_urlopen([b"123", b"CN"])
-        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+        with patch.object(_model_cache.urllib.request, "urlopen", side_effect=side_effect):
             assert pyseekdb_default._detect_country() == "CN"
 
     def test_lowercase_normalised_to_upper(self):
         side_effect = self._mock_urlopen([b"cn"])
-        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=side_effect):
+        with patch.object(_model_cache.urllib.request, "urlopen", side_effect=side_effect):
             assert pyseekdb_default._detect_country() == "CN"
 
 
@@ -76,8 +76,8 @@ class TestDetectCountry:
 class TestDownloadViaModelscope:
     def test_raises_when_uv_not_found(self, monkeypatch):
         monkeypatch.delenv("POWERMEM_UV_BIN", raising=False)
-        with patch.object(pyseekdb_default.shutil, "which", return_value=None), \
-             patch.object(pyseekdb_default.os.path, "isfile", return_value=False):
+        with patch.object(_model_cache.shutil, "which", return_value=None), \
+             patch.object(_model_cache.os.path, "isfile", return_value=False):
             with pytest.raises(RuntimeError, match="uv is required"):
                 pyseekdb_default._download_via_modelscope()
 
@@ -92,8 +92,8 @@ class TestDownloadViaModelscope:
         def fake_run(cmd, check):
             captured.append(cmd)
 
-        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
-             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+        with patch.object(_model_cache.subprocess, "run", side_effect=fake_run), \
+             patch.object(_model_cache.os.path, "isfile", return_value=True):
             pyseekdb_default._download_via_modelscope(country="CN")
 
         assert "--default-index" in captured[0]
@@ -110,8 +110,8 @@ class TestDownloadViaModelscope:
         def fake_run(cmd, check):
             captured.append(cmd)
 
-        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
-             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+        with patch.object(_model_cache.subprocess, "run", side_effect=fake_run), \
+             patch.object(_model_cache.os.path, "isfile", return_value=True):
             pyseekdb_default._download_via_modelscope(country="CN")
 
         assert "https://pypi.tuna.tsinghua.edu.cn/simple" in captured[0]
@@ -127,8 +127,8 @@ class TestDownloadViaModelscope:
         def fake_run(cmd, check):
             captured.append(cmd)
 
-        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
-             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+        with patch.object(_model_cache.subprocess, "run", side_effect=fake_run), \
+             patch.object(_model_cache.os.path, "isfile", return_value=True):
             pyseekdb_default._download_via_modelscope(country="US")
 
         assert "--default-index" not in captured[0]
@@ -145,8 +145,8 @@ class TestDownloadViaModelscope:
         def fake_run(cmd, check):
             captured.append(cmd)
 
-        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
-             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+        with patch.object(_model_cache.subprocess, "run", side_effect=fake_run), \
+             patch.object(_model_cache.os.path, "isfile", return_value=True):
             pyseekdb_default._download_via_modelscope()
 
         assert "--python" in captured[0]
@@ -161,9 +161,9 @@ class TestDownloadViaModelscope:
         monkeypatch.setenv("POWERMEM_UV_BIN", fake_uv)
         monkeypatch.delenv("POWERMEM_UV_INDEX_URL", raising=False)
 
-        with patch.object(pyseekdb_default.subprocess, "run",
+        with patch.object(_model_cache.subprocess, "run",
                           side_effect=sp.CalledProcessError(1, "uv")), \
-             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+             patch.object(_model_cache.os.path, "isfile", return_value=True):
             with pytest.raises(sp.CalledProcessError):
                 pyseekdb_default._download_via_modelscope()
 
@@ -179,8 +179,8 @@ class TestDownloadViaModelscope:
         def fake_run(cmd, check):
             captured.append(cmd)
 
-        with patch.object(pyseekdb_default.subprocess, "run", side_effect=fake_run), \
-             patch.object(pyseekdb_default.os.path, "isfile", return_value=True):
+        with patch.object(_model_cache.subprocess, "run", side_effect=fake_run), \
+             patch.object(_model_cache.os.path, "isfile", return_value=True):
             pyseekdb_default._download_via_modelscope()
 
         assert "modelscope==1.99.0" in captured[0]
@@ -217,7 +217,7 @@ class TestBridgeModelscope:
             resp.read.return_value = json.dumps({"sha": fake_sha}).encode()
             return resp
 
-        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=fake_urlopen):
+        with patch.object(_model_cache.urllib.request, "urlopen", side_effect=fake_urlopen):
             pyseekdb_default._bridge_modelscope_to_hf_cache()
 
         hf_dir_name = "models--" + pyseekdb_default.DEFAULT_MODEL_REPO_ID.replace("/", "--")
@@ -248,7 +248,7 @@ class TestBridgeModelscope:
             resp.read.return_value = json.dumps({"sha": fake_sha}).encode()
             return resp
 
-        with patch.object(pyseekdb_default.urllib.request, "urlopen", side_effect=fake_urlopen):
+        with patch.object(_model_cache.urllib.request, "urlopen", side_effect=fake_urlopen):
             pyseekdb_default._bridge_modelscope_to_hf_cache()
 
         assert existing.read_text() == "original"
@@ -257,7 +257,7 @@ class TestBridgeModelscope:
         monkeypatch.setenv("HOME", str(tmp_path))
         self._setup_modelscope_src(tmp_path)
 
-        with patch.object(pyseekdb_default.urllib.request, "urlopen",
+        with patch.object(_model_cache.urllib.request, "urlopen",
                           side_effect=OSError("no network")):
             pyseekdb_default._bridge_modelscope_to_hf_cache()
 
@@ -282,8 +282,8 @@ class TestLoadSentenceTransformerWithFallback:
 
     def test_cache_hit_loads_locally_no_download(self):
         mock_st_cls = MagicMock(return_value=MagicMock())
-        with patch.object(pyseekdb_default, "_is_model_cached", return_value=True), \
-             patch.object(pyseekdb_default, "_detect_country") as mock_detect, \
+        with patch.object(_model_cache, "is_model_cached", return_value=True), \
+             patch.object(_model_cache, "detect_country") as mock_detect, \
              patch.object(pyseekdb_default, "_patch_sentence_transformer_cache"), \
              patch.dict("sys.modules", {"sentence_transformers": MagicMock(
                  SentenceTransformer=mock_st_cls)}):
@@ -292,10 +292,10 @@ class TestLoadSentenceTransformerWithFallback:
         mock_detect.assert_not_called()
 
     def test_cache_miss_cn_triggers_modelscope(self):
-        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
-             patch.object(pyseekdb_default, "_detect_country", return_value="CN"), \
-             patch.object(pyseekdb_default, "_download_via_modelscope") as mock_dl, \
-             patch.object(pyseekdb_default, "_bridge_modelscope_to_hf_cache") as mock_bridge, \
+        with patch.object(_model_cache, "is_model_cached", return_value=False), \
+             patch.object(_model_cache, "detect_country", return_value="CN"), \
+             patch.object(_model_cache, "download_via_modelscope") as mock_dl, \
+             patch.object(_model_cache, "bridge_modelscope_to_hf_cache") as mock_bridge, \
              patch.dict("sys.modules", {"sentence_transformers": None}):
             pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
 
@@ -306,9 +306,9 @@ class TestLoadSentenceTransformerWithFallback:
         mock_st_instance = MagicMock()
         mock_st_cls = MagicMock(return_value=mock_st_instance)
 
-        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
-             patch.object(pyseekdb_default, "_detect_country", return_value="US"), \
-             patch.object(pyseekdb_default, "_download_via_modelscope") as mock_dl, \
+        with patch.object(_model_cache, "is_model_cached", return_value=False), \
+             patch.object(_model_cache, "detect_country", return_value="US"), \
+             patch.object(_model_cache, "download_via_modelscope") as mock_dl, \
              patch.dict("sys.modules", {"sentence_transformers": MagicMock(
                  SentenceTransformer=mock_st_cls)}):
             pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
@@ -319,9 +319,9 @@ class TestLoadSentenceTransformerWithFallback:
         mock_st_instance = MagicMock()
         mock_st_cls = MagicMock(return_value=mock_st_instance)
 
-        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
-             patch.object(pyseekdb_default, "_detect_country", return_value=""), \
-             patch.object(pyseekdb_default, "_download_via_modelscope") as mock_dl, \
+        with patch.object(_model_cache, "is_model_cached", return_value=False), \
+             patch.object(_model_cache, "detect_country", return_value=""), \
+             patch.object(_model_cache, "download_via_modelscope") as mock_dl, \
              patch.dict("sys.modules", {"sentence_transformers": MagicMock(
                  SentenceTransformer=mock_st_cls)}):
             pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
@@ -329,9 +329,9 @@ class TestLoadSentenceTransformerWithFallback:
         mock_dl.assert_not_called()
 
     def test_cn_modelscope_failure_raises_runtime_error(self):
-        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
-             patch.object(pyseekdb_default, "_detect_country", return_value="CN"), \
-             patch.object(pyseekdb_default, "_download_via_modelscope",
+        with patch.object(_model_cache, "is_model_cached", return_value=False), \
+             patch.object(_model_cache, "detect_country", return_value="CN"), \
+             patch.object(_model_cache, "download_via_modelscope",
                           side_effect=RuntimeError("uvx failed")):
             with pytest.raises(RuntimeError, match="uvx failed"):
                 pyseekdb_default._load_sentence_transformer_with_fallback(self.MODEL, self.REPO)
@@ -347,8 +347,8 @@ class TestLoadSentenceTransformerWithFallback:
                 return  # return immediately, result[0] stays None
             return original_join(self_thread, timeout)
 
-        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
-             patch.object(pyseekdb_default, "_detect_country", return_value="US"), \
+        with patch.object(_model_cache, "is_model_cached", return_value=False), \
+             patch.object(_model_cache, "detect_country", return_value="US"), \
              patch.dict("sys.modules", {"sentence_transformers": MagicMock(
                  SentenceTransformer=MagicMock(side_effect=lambda _: None))}), \
              patch.object(_threading.Thread, "join", slow_join):
@@ -357,10 +357,10 @@ class TestLoadSentenceTransformerWithFallback:
 
     def test_sentence_transformers_absent_cn_still_downloads(self):
         """CN download must run even when sentence_transformers is not installed."""
-        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
-             patch.object(pyseekdb_default, "_detect_country", return_value="CN"), \
-             patch.object(pyseekdb_default, "_download_via_modelscope") as mock_dl, \
-             patch.object(pyseekdb_default, "_bridge_modelscope_to_hf_cache"), \
+        with patch.object(_model_cache, "is_model_cached", return_value=False), \
+             patch.object(_model_cache, "detect_country", return_value="CN"), \
+             patch.object(_model_cache, "download_via_modelscope") as mock_dl, \
+             patch.object(_model_cache, "bridge_modelscope_to_hf_cache"), \
              patch.dict("sys.modules", {"sentence_transformers": None}):
             result = pyseekdb_default._load_sentence_transformer_with_fallback(
                 self.MODEL, self.REPO
@@ -370,8 +370,8 @@ class TestLoadSentenceTransformerWithFallback:
         assert result is None  # no ST, but download happened
 
     def test_sentence_transformers_absent_non_cn_returns_none(self):
-        with patch.object(pyseekdb_default, "_is_model_cached", return_value=False), \
-             patch.object(pyseekdb_default, "_detect_country", return_value="US"), \
+        with patch.object(_model_cache, "is_model_cached", return_value=False), \
+             patch.object(_model_cache, "detect_country", return_value="US"), \
              patch.dict("sys.modules", {"sentence_transformers": None}):
             result = pyseekdb_default._load_sentence_transformer_with_fallback(
                 self.MODEL, self.REPO


### PR DESCRIPTION
## Summary

- Replace shell-level interactive prompts in `init.sh` with a 3-round **AskUserQuestion** flow (Server → Storage+LLM → Embedding) driven from the init SKILL, so decisions are made in the Claude Code UI instead of the terminal.
- Split the Server question (Round 1) into three options: **Local — loopback** (`127.0.0.1`), **Local — all interfaces** (`0.0.0.0`), and **Remote**. Loopback remains the script default; all-interface binding is an explicit user choice, mapped to `POWERMEM_SERVER_HOST`.
- Add a **remote-init short-circuit**: when the user supplies a remote PowerMem server URL, `init.sh` skips `.env` / `uvx` / PID management and writes only `runtime.env` and/or `.mcp.json` per `POWERMEM_INIT_CONNECTION_MODE` (`hook` | `mcp` | `both`).
- Make `status.sh` / `status` SKILL **mode-aware** (`hook` | `mcp` | `both` | `none`) by reading both `runtime.env` (hook URL) and `${PLUGIN_ROOT}/.mcp.json` (MCP URL).
- Extract shared model-cache / CN-mirror download helpers (`is_model_cached`, `detect_country`, `download_via_modelscope`, `bridge_modelscope_to_hf_cache`) from `pyseekdb_default.py` into a new `_model_cache.py` module so both `pyseekdb_default` and `huggingface` share the same logic.

## Changes

### Plugin scripts (`apps/claude-code-plugin/scripts/`)
- `common.sh` — shared helpers: `is_remote_url`, `is_healthy`, `write_runtime_remote`.
- `init.sh` — remote-init short-circuit; dashboard host `${POWERMEM_SERVER_HOST:-127.0.0.1}` (loopback default, `0.0.0.0` opt-in via env or Question 0); connection-mode switch.
- `status.sh` — mode-aware reporting from `runtime.env` + `.mcp.json`.

### SKILL files (`apps/claude-code-plugin/skills/`)
- `init/SKILL.md` — 3-round AskUserQuestion flow; Round 1 splits Local into loopback / all-interfaces options; skip Storage question when server healthy; `CLAUDE_PLUGIN_ROOT` resolved per-invocation.
- `status/SKILL.md` — documents the new `hook|mcp|both|none` mode reporting.

### Embedding refactor (`src/powermem/integrations/embeddings/`)
- `_model_cache.py` (new) — shared cache/mirror helpers extracted from `pyseekdb_default.py`.
- `pyseekdb_default.py` — imports from `_model_cache`.
- `huggingface.py` — adopts the shared cache/mirror helpers.
- `tests/unit/test_pyseekdb_default_download.py` — patches `_model_cache` instead of `pyseekdb_default` internals.

### Tests
- `tests/unit/test_claude_plugin_uv_install.py` — updated uvx-launcher assertion to the parameterized form `--host "${POWERMEM_SERVER_HOST:-127.0.0.1}"` to match the new default + override contract.

## Test plan

- [x] `pytest tests/unit/test_claude_plugin_uv_install.py` — uvx-launcher assertion matches the new parameterized host form.
- [x] `pytest tests/unit/test_pyseekdb_default_download.py` — download / CN-mirror tests pass against the extracted module.
- [x] CI `test (3.11)`, `test (3.12)`, `claude-hook-regression` all green on `049627a`.
- [x] Manual: install plugin from this branch, run `/init`, confirm Server → Storage+LLM → Embedding questions appear in the Claude Code UI (not the terminal).
- [ ] Manual: with `POWERMEM_INIT_BASE_URL=https://remote:8848`, confirm `init.sh` writes `runtime.env` and/or `.mcp.json` without starting a local server.
- [x] Manual: confirm dashboard binds `127.0.0.1:8848` by default; choosing "Local — all interfaces" in Round 1 (or setting `POWERMEM_SERVER_HOST=0.0.0.0`) binds `0.0.0.0` and is reachable from another host.
- [ ] Manual: `/status` reports `mode=hook`, `mode=mcp`, `mode=both`, or `mode=none` correctly.
