### PR TITLE
Allow Claude Code plugin to use a remote PowerMem server

### DIFF
--- a/apps/claude-code-plugin/README.md
+++ b/apps/claude-code-plugin/README.md
@@ -45,6 +45,11 @@ while CN networks use the USTC mirror at
 `https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/`.
 CN package resolution uses `--default-index https://pypi.tuna.tsinghua.edu.cn/simple`.
 
+If you already run PowerMem on another host, initialize the plugin with
+`POWERMEM_INIT_REMOTE_BASE_URL=https://powermem.example.com` and
+`POWERMEM_INIT_CONNECTION_MODE=hook|mcp|both`; remote init writes the Claude
+connection files without starting a local server.
+
 The PyPI package used by init must include the backend features and dependencies
 required by the plugin, including the default local embedding path
 (`sentence-transformers` / `all-MiniLM-L6-v2`). If you are testing plugin changes

--- a/apps/claude-code-plugin/SETUP.md
+++ b/apps/claude-code-plugin/SETUP.md
@@ -66,7 +66,22 @@ sh "$CLAUDE_PLUGIN_ROOT/scripts/..."
    first, then retry `/memory-powermem:init`.
 2. Run `sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"` and inspect whether config,
    uv, managed PID, Python versions, and health are present.
-3. If `.env` is missing, run init with auto-detection first:
+3. If the user already has a remote PowerMem server, configure that endpoint
+   instead of creating a local backend. Choose `hook`, `mcp`, or `both`:
+
+   ```bash
+   POWERMEM_INIT_REMOTE_BASE_URL=https://powermem.example.com \
+   POWERMEM_INIT_CONNECTION_MODE=hook \
+   sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
+   ```
+
+   Use `POWERMEM_INIT_CONNECTION_MODE=mcp` to configure only the HTTP MCP
+   endpoint, or `both` to enable both hooks and MCP tools. If the server requires
+   API-key auth, add `POWERMEM_INIT_REMOTE_API_KEY=...`; never print the value.
+   Remote init writes `runtime.env` and/or `.mcp.json`, then exits without
+   creating the plugin `.env`, launching `uvx`, or managing a local PID.
+4. If `.env` is missing and the user wants a local backend, run init with
+   auto-detection first:
 
    ```bash
    sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
@@ -83,7 +98,7 @@ sh "$CLAUDE_PLUGIN_ROOT/scripts/..."
    OceanBase/seekdb production use), local HuggingFace embedding (no API key,
    `sentence-transformers` from `powermem[extras]`), server settings, and logging
    settings.
-4. If init reports missing values, ask the user only for those missing values. Do
+5. If init reports missing values, ask the user only for those missing values. Do
    not invent credentials. Re-run init with the matching environment variables:
 
    ```bash
@@ -114,11 +129,11 @@ sh "$CLAUDE_PLUGIN_ROOT/scripts/..."
      `powermem[server,extras] @ git+https://github.com/oceanbase/powermem.git@<branch-or-sha>`.
    - `POWERMEM_INIT_PYTHON` to force a specific Python >= 3.11.
    - `POWERMEM_INIT_PORT` to force the managed server port.
-5. Never print API keys, auth tokens, or other credentials. Mask any secret in
+6. Never print API keys, auth tokens, or other credentials. Mask any secret in
    summaries.
-6. After init succeeds, run `sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"` again and
+7. After init succeeds, run `sh "$CLAUDE_PLUGIN_ROOT/scripts/status.sh"` again and
    report the base URL.
-7. The hook launcher reads `runtime.env`, so once init writes a base URL, prompt
+8. The hook launcher reads `runtime.env`, so once init writes a base URL, prompt
    recall and session-save hooks use that backend automatically.
 
 The default local embedding model (`all-MiniLM-L6-v2`) is downloaded

--- a/apps/claude-code-plugin/config/README.md
+++ b/apps/claude-code-plugin/config/README.md
@@ -21,4 +21,7 @@ bash scripts/apply-connection-mode.sh http   # default
 bash scripts/apply-connection-mode.sh mcp
 ```
 
+For a remote PowerMem server, `scripts/init.sh` can write the URL directly:
+`POWERMEM_INIT_REMOTE_BASE_URL=https://powermem.example.com POWERMEM_INIT_CONNECTION_MODE=hook|mcp|both sh scripts/init.sh`.
+
 Restart Claude Code after changing `.mcp.json`.

--- a/apps/claude-code-plugin/hooks/run-hook.ps1
+++ b/apps/claude-code-plugin/hooks/run-hook.ps1
@@ -28,6 +28,9 @@ function Import-PowerMemEnvFile {
 $dataDir = if ($env:POWERMEM_DATA_DIR) { $env:POWERMEM_DATA_DIR } else { Join-Path $HOME ".powermem" }
 Import-PowerMemEnvFile (Join-Path $dataDir "runtime.env")
 Import-PowerMemEnvFile (Join-Path $PluginRoot "config\runtime.env")
+if ($env:POWERMEM_CONNECTION_MODE -eq "mcp") {
+    exit 0
+}
 
 $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'amd64' }
 $exe = Join-Path $Root "bin\powermem-hook-windows-$arch.exe"

--- a/apps/claude-code-plugin/hooks/run-hook.sh
+++ b/apps/claude-code-plugin/hooks/run-hook.sh
@@ -12,6 +12,9 @@ load_env_file() {
 }
 load_env_file "$DATA_DIR/runtime.env"
 load_env_file "$PLUGIN_ROOT/config/runtime.env"
+case "${POWERMEM_CONNECTION_MODE:-}" in
+  mcp) exit 0 ;;
+esac
 case "$(uname -s 2>/dev/null)" in
   Darwin) GOOS=darwin ;;
   Linux) GOOS=linux ;;

--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -299,6 +299,122 @@ runtime_base_url() {
   printf '%s\n' "http://localhost:8848"
 }
 
+normalize_base_url() {
+  printf '%s\n' "$1" \
+    | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's#/*$##'
+}
+
+is_loopback_base_url() {
+  case "$(normalize_base_url "$1")" in
+    http://localhost:*|http://127[.]0[.]0[.]1:*|http://[[]::1[]]:*|http://localhost|http://127[.]0[.]0[.]1|http://[[]::1[]]|https://localhost:*|https://127[.]0[.]0[.]1:*|https://[[]::1[]]:*|https://localhost|https://127[.]0[.]0[.]1|https://[[]::1[]])
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+configured_remote_base_url() {
+  if [ -n "${POWERMEM_INIT_REMOTE_BASE_URL:-}" ]; then
+    normalize_base_url "$POWERMEM_INIT_REMOTE_BASE_URL"
+    return
+  fi
+  if [ -n "${POWERMEM_REMOTE_BASE_URL:-}" ]; then
+    normalize_base_url "$POWERMEM_REMOTE_BASE_URL"
+    return
+  fi
+  if [ -n "${POWERMEM_BASE_URL:-}" ] && ! is_loopback_base_url "$POWERMEM_BASE_URL"; then
+    normalize_base_url "$POWERMEM_BASE_URL"
+    return
+  fi
+  if runtime_remote_mode; then
+    normalize_base_url "$(runtime_base_url)"
+    return
+  fi
+  printf '%s\n' ""
+}
+
+configured_connection_mode() {
+  mode=${POWERMEM_INIT_CONNECTION_MODE:-${POWERMEM_CONNECTION_MODE:-}}
+  if [ -z "$mode" ]; then
+    mode=$(runtime_connection_mode)
+  fi
+  mode=${mode:-hook}
+  printf '%s\n' "$mode" | tr '[:upper:]' '[:lower:]'
+}
+
+validate_connection_mode() {
+  case "$1" in
+    hook|mcp|both) return 0 ;;
+  esac
+  echo "Invalid POWERMEM_INIT_CONNECTION_MODE='$1'. Use hook, mcp, or both." >&2
+  return 1
+}
+
+runtime_connection_mode() {
+  if [ -n "${POWERMEM_CONNECTION_MODE:-}" ]; then
+    printf '%s\n' "$POWERMEM_CONNECTION_MODE" | tr '[:upper:]' '[:lower:]'
+    return
+  fi
+  if [ -f "$RUNTIME_FILE" ]; then
+    # shellcheck disable=SC1090
+    . "$RUNTIME_FILE"
+    if [ -n "${POWERMEM_CONNECTION_MODE:-}" ]; then
+      printf '%s\n' "$POWERMEM_CONNECTION_MODE" | tr '[:upper:]' '[:lower:]'
+      return
+    fi
+  fi
+  printf '%s\n' ""
+}
+
+runtime_remote_mode() {
+  if [ "${POWERMEM_REMOTE_MODE:-}" = "1" ]; then
+    return 0
+  fi
+  if [ -f "$RUNTIME_FILE" ]; then
+    # shellcheck disable=SC1090
+    . "$RUNTIME_FILE"
+    if [ "${POWERMEM_REMOTE_MODE:-}" = "1" ]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+configured_remote_api_key() {
+  if [ -n "${POWERMEM_INIT_REMOTE_API_KEY:-}" ]; then
+    printf '%s\n' "$POWERMEM_INIT_REMOTE_API_KEY"
+    return
+  fi
+  if [ -n "${POWERMEM_REMOTE_API_KEY:-}" ]; then
+    printf '%s\n' "$POWERMEM_REMOTE_API_KEY"
+    return
+  fi
+  if [ -n "${POWERMEM_API_KEY:-}" ]; then
+    printf '%s\n' "$POWERMEM_API_KEY"
+    return
+  fi
+  if runtime_remote_mode && [ -f "$RUNTIME_FILE" ]; then
+    # shellcheck disable=SC1090
+    . "$RUNTIME_FILE"
+    if [ -n "${POWERMEM_API_KEY:-}" ]; then
+      printf '%s\n' "$POWERMEM_API_KEY"
+      return
+    fi
+  fi
+  printf '%s\n' ""
+}
+
+quote_runtime_value() {
+  value=$1
+  if contains_newline "$value"; then
+    echo "Remote PowerMem runtime values must be single-line values." >&2
+    return 1
+  fi
+  printf "'"
+  printf '%s' "$value" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
 write_runtime_base_url() {
   base_url=$1
   tmp="$RUNTIME_FILE.tmp"
@@ -307,6 +423,101 @@ write_runtime_base_url() {
     printf 'POWERMEM_ENV_FILE=%s\n' "$ENV_FILE"
   } > "$tmp"
   mv "$tmp" "$RUNTIME_FILE"
+}
+
+write_remote_runtime_config_file() {
+  target=$1
+  base_url=$2
+  mode=$3
+  remote_auth=${4:-}
+
+  quoted_base_url=$(quote_runtime_value "$base_url") || return 1
+  quoted_mode=$(quote_runtime_value "$mode") || return 1
+  {
+    printf 'POWERMEM_BASE_URL=%s\n' "$quoted_base_url"
+    printf 'POWERMEM_CONNECTION_MODE=%s\n' "$quoted_mode"
+    printf 'POWERMEM_REMOTE_MODE=1\n'
+    if [ -n "$remote_auth" ]; then
+      quoted_remote_auth=$(quote_runtime_value "$remote_auth") || return 1
+      printf 'POWERMEM_API_KEY=%s\n' "$quoted_remote_auth"
+    fi
+  } > "$target"
+}
+
+write_remote_runtime_config() {
+  base_url=$1
+  mode=$2
+  remote_auth=${3:-}
+  tmp="$RUNTIME_FILE.tmp"
+  write_remote_runtime_config_file "$tmp" "$base_url" "$mode" "$remote_auth" || return 1
+  mv "$tmp" "$RUNTIME_FILE"
+}
+
+mcp_endpoint_url() {
+  base_url=$(normalize_base_url "$1")
+  case "$base_url" in
+    */mcp) printf '%s\n' "$base_url" ;;
+    *) printf '%s/mcp\n' "$base_url" ;;
+  esac
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+contains_newline() {
+  case "$1" in
+    *'
+'*) return 0 ;;
+  esac
+  return 1
+}
+
+write_http_only_mcp_config() {
+  tmp="$PLUGIN_ROOT/.mcp.json.tmp"
+  printf '{\n  "mcpServers": {}\n}\n' > "$tmp"
+  mv "$tmp" "$PLUGIN_ROOT/.mcp.json"
+}
+
+write_remote_mcp_config() {
+  base_url=$1
+  remote_auth=${2:-}
+  mcp_url=$(mcp_endpoint_url "$base_url")
+  if contains_newline "$mcp_url" || contains_newline "$remote_auth"; then
+    echo "Remote PowerMem URL and API key must be single-line values." >&2
+    return 1
+  fi
+
+  escaped_url=$(json_escape "$mcp_url")
+  tmp="$PLUGIN_ROOT/.mcp.json.tmp"
+  if [ -n "$remote_auth" ]; then
+    escaped_key=$(json_escape "$remote_auth")
+    {
+      printf '{\n'
+      printf '  "mcpServers": {\n'
+      printf '    "powermem": {\n'
+      printf '      "transport": "http",\n'
+      printf '      "url": "%s",\n' "$escaped_url"
+      printf '      "headers": {\n'
+      printf '        "X-API-Key": "%s"\n' "$escaped_key"
+      printf '      }\n'
+      printf '    }\n'
+      printf '  }\n'
+      printf '}\n'
+    } > "$tmp"
+  else
+    {
+      printf '{\n'
+      printf '  "mcpServers": {\n'
+      printf '    "powermem": {\n'
+      printf '      "transport": "http",\n'
+      printf '      "url": "%s"\n' "$escaped_url"
+      printf '    }\n'
+      printf '  }\n'
+      printf '}\n'
+    } > "$tmp"
+  fi
+  mv "$tmp" "$PLUGIN_ROOT/.mcp.json"
 }
 
 export_env_file_vars() {
@@ -339,6 +550,14 @@ health_url() {
 is_healthy() {
   url=$(health_url "$1")
   curl -fsS -m 5 "$url" 2>/dev/null | grep -q '"healthy"'
+}
+
+announce_dashboard_url() {
+  case "$1" in
+    */) dashboard_url="${1}dashboard/" ;;
+    *) dashboard_url="${1}/dashboard/" ;;
+  esac
+  echo "Memory dashboard: $dashboard_url"
 }
 
 pid_alive() {

--- a/apps/claude-code-plugin/scripts/init.sh
+++ b/apps/claude-code-plugin/scripts/init.sh
@@ -9,6 +9,59 @@ echo "PowerMem Claude Code plugin init"
 echo "Data dir: $DATA_DIR"
 
 base_url=$(runtime_base_url)
+remote_base_url=$(configured_remote_base_url)
+
+if [ -n "$remote_base_url" ]; then
+  case "$remote_base_url" in
+    http://*|https://*) ;;
+    *)
+      echo "POWERMEM_INIT_REMOTE_BASE_URL must start with http:// or https://." >&2
+      exit 2
+      ;;
+  esac
+
+  connection_mode=$(configured_connection_mode)
+  validate_connection_mode "$connection_mode" || exit 2
+  remote_auth=$(configured_remote_api_key)
+
+  echo "Configuring remote PowerMem backend: $remote_base_url"
+  echo "Connection mode: $connection_mode"
+  runtime_tmp="$RUNTIME_FILE.tmp"
+  write_remote_runtime_config_file "$runtime_tmp" "$remote_base_url" "$connection_mode" "$remote_auth"
+  case "$connection_mode" in
+    hook)
+      write_http_only_mcp_config
+      mv "$runtime_tmp" "$RUNTIME_FILE"
+      echo "Configured hooks through $RUNTIME_FILE."
+      echo "PowerMem MCP tools are disabled in $PLUGIN_ROOT/.mcp.json."
+      ;;
+    mcp)
+      write_remote_mcp_config "$remote_base_url" "$remote_auth"
+      mv "$runtime_tmp" "$RUNTIME_FILE"
+      echo "Configured MCP tools in $PLUGIN_ROOT/.mcp.json."
+      echo "Hooks are disabled by POWERMEM_CONNECTION_MODE=mcp in $RUNTIME_FILE."
+      ;;
+    both)
+      write_remote_mcp_config "$remote_base_url" "$remote_auth"
+      mv "$runtime_tmp" "$RUNTIME_FILE"
+      echo "Configured hooks through $RUNTIME_FILE."
+      echo "Configured MCP tools in $PLUGIN_ROOT/.mcp.json."
+      ;;
+  esac
+
+  if [ -n "$remote_auth" ]; then
+    echo "Remote API key configured (value hidden)."
+  fi
+
+  if is_healthy "$remote_base_url"; then
+    echo "Remote PowerMem backend is healthy: $remote_base_url"
+    announce_dashboard_url "$remote_base_url"
+  else
+    echo "Warning: remote PowerMem health check is unavailable now; configuration was still written." >&2
+  fi
+  echo "Remote mode does not create plugin .env, start uvx, or manage a local PID."
+  exit 0
+fi
 
 ensure_bootstrap_python || exit 1
 echo "Bootstrap Python: $BOOTSTRAP_PYTHON ($(python_version "$BOOTSTRAP_PYTHON"))"
@@ -589,14 +642,6 @@ stop_unhealthy_managed_server() {
     fi
   fi
   remove_managed_pid_files
-}
-
-announce_dashboard_url() {
-  case "$1" in
-    */) dashboard_url="${1}dashboard/" ;;
-    *) dashboard_url="${1}/dashboard/" ;;
-  esac
-  echo "Memory dashboard: $dashboard_url"
 }
 
 if [ ! -f "$ENV_FILE" ]; then

--- a/apps/claude-code-plugin/scripts/status.sh
+++ b/apps/claude-code-plugin/scripts/status.sh
@@ -6,6 +6,52 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 . "$SCRIPT_DIR/common.sh"
 
 base_url=$(runtime_base_url)
+connection_mode=$(runtime_connection_mode)
+mcp_config="$PLUGIN_ROOT/.mcp.json"
+mcp_enabled=0
+if [ -f "$mcp_config" ] && grep -q '"powermem"' "$mcp_config"; then
+  mcp_enabled=1
+fi
+
+remote_backend=0
+if runtime_remote_mode || ! is_loopback_base_url "$base_url"; then
+  remote_backend=1
+fi
+
+case "$connection_mode" in
+  hook)
+    if [ "$remote_backend" = "1" ]; then
+      connection_summary="remote hook"
+    else
+      connection_summary="local hook"
+    fi
+    ;;
+  mcp)
+    if [ "$remote_backend" = "1" ]; then
+      connection_summary="remote MCP"
+    else
+      connection_summary="local MCP"
+    fi
+    ;;
+  both)
+    if [ "$remote_backend" = "1" ]; then
+      connection_summary="remote hook+MCP"
+    else
+      connection_summary="local hook+MCP"
+    fi
+    ;;
+  *)
+    if [ "$remote_backend" = "1" ] && [ "$mcp_enabled" = "1" ]; then
+      connection_summary="remote hook+MCP"
+    elif [ "$remote_backend" = "1" ]; then
+      connection_summary="remote hook"
+    elif [ "$mcp_enabled" = "1" ]; then
+      connection_summary="local hook+MCP"
+    else
+      connection_summary="local hook"
+    fi
+    ;;
+esac
 
 echo "PowerMem Claude Code plugin status"
 echo "Data dir: $DATA_DIR"
@@ -13,20 +59,32 @@ echo "Runtime file: $RUNTIME_FILE"
 echo "Env file: $ENV_FILE"
 echo "PID file: $(managed_pid_file)"
 echo "Base URL: $base_url"
+echo "Connection mode: $connection_summary"
+if [ "$mcp_enabled" = "1" ]; then
+  echo "MCP config: enabled ($mcp_config)"
+else
+  echo "MCP config: disabled ($mcp_config)"
+fi
 
-if BOOTSTRAP_PYTHON=$(choose_python 2>/dev/null); then
+if [ "$remote_backend" = "1" ]; then
+  echo "Bootstrap Python: not required for remote mode"
+elif BOOTSTRAP_PYTHON=$(choose_python 2>/dev/null); then
   echo "Bootstrap Python: $BOOTSTRAP_PYTHON ($(python_version "$BOOTSTRAP_PYTHON"))"
 else
   echo "Bootstrap Python: missing Python >= 3.11"
 fi
 
-if [ -f "$ENV_FILE" ]; then
+if [ "$remote_backend" = "1" ]; then
+  echo "Config: not required for remote mode"
+elif [ -f "$ENV_FILE" ]; then
   echo "Config: present"
 else
   echo "Config: missing"
 fi
 
-if pid_alive; then
+if [ "$remote_backend" = "1" ]; then
+  echo "Managed server PID: not expected in remote mode"
+elif pid_alive; then
   echo "Managed server PID: $(managed_pid)"
 else
   echo "Managed server PID: not running"
@@ -40,7 +98,9 @@ else
   uv_bin=""
 fi
 
-if [ -n "$uv_bin" ]; then
+if [ "$remote_backend" = "1" ]; then
+  echo "uv: not required for remote mode"
+elif [ -n "$uv_bin" ]; then
   echo "uv: $uv_bin ($("$uv_bin" --version 2>/dev/null || echo unknown))"
   echo "Backend launcher: uvx --from '${POWERMEM_INIT_PACKAGE:-powermem[server,seekdb]}' powermem-server"
 else

--- a/apps/claude-code-plugin/skills/init/SKILL.md
+++ b/apps/claude-code-plugin/skills/init/SKILL.md
@@ -16,6 +16,19 @@ Use the plugin scripts as directed by that section:
 - `scripts/status.sh`
 - `scripts/init.sh`
 
+If the user already has a reachable PowerMem server, configure remote mode
+instead of starting a local backend:
+
+```bash
+POWERMEM_INIT_REMOTE_BASE_URL=https://powermem.example.com \
+POWERMEM_INIT_CONNECTION_MODE=hook \
+sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
+```
+
+Use `POWERMEM_INIT_CONNECTION_MODE=mcp` for in-chat MCP tools only, or `both`
+for both hooks and MCP tools. If the server requires PowerMem API auth, pass
+`POWERMEM_INIT_REMOTE_API_KEY`; never print the value.
+
 Remember that `scripts/init.sh` ensures uv and starts the backend with the
 uvx-style launcher. Package depends on the storage backend: SQLite (default)
 uses `uvx --from 'powermem[server,extras]' powermem-server` (pulls

--- a/apps/claude-code-plugin/skills/status/SKILL.md
+++ b/apps/claude-code-plugin/skills/status/SKILL.md
@@ -2,5 +2,4 @@
 description: Check whether PowerMem is configured, running, and reachable from Claude Code.
 ---
 
-Run `sh "${CLAUDE_PLUGIN_ROOT}/scripts/status.sh"` when available. Report the data directory, base URL, managed server PID if any, and health state. Do not print `.env` contents.
-
+Run `sh "${CLAUDE_PLUGIN_ROOT}/scripts/status.sh"` when available. Report the data directory, base URL, connection mode, MCP config state, managed server PID if any, and health state. In remote mode, a missing managed PID is expected. Do not print `.env` or API key contents.

--- a/docs/integrations/claude_code.md
+++ b/docs/integrations/claude_code.md
@@ -240,7 +240,7 @@ After updating, restart the Claude Code session (or the whole app) so MCP config
 
 ### Two PowerMem modes (HTTP default, MCP optional)
 
-Same **MCP / HTTP** split as elsewhere in PowerMem. **Standard shipping = HTTP mode**: root `.mcp.json` has **`mcpServers: {}`**. **Hooks always use REST** in both modes.
+Same **MCP / HTTP** split as elsewhere in PowerMem. **Standard shipping = HTTP mode**: root `.mcp.json` has **`mcpServers: {}`**. Hooks use REST when enabled; remote init with `POWERMEM_INIT_CONNECTION_MODE=mcp` configures MCP tools only and disables the hook launcher.
 
 | Mode | Plugin root `.mcp.json` | Claude in-chat | Silent capture (hooks → REST) |
 |------|-------------------------|----------------|--------------------------------|
@@ -257,6 +257,36 @@ bash scripts/apply-connection-mode.sh mcp   # enable in-chat PowerMem tools
 Restart Claude Code after changing `.mcp.json`. See [`config/README.md`](https://github.com/oceanbase/powermem/blob/main/apps/claude-code-plugin/config/README.md).
 
 **Naming note:** In **MCP mode**, `transport: "http"` means “connect to the **MCP** endpoint over HTTP” (`https://host/mcp`), not “replace MCP with REST.” **HTTP mode** means “no MCP entry for PowerMem”; REST is still used by hooks.
+
+### Remote server init
+
+If PowerMem already runs on another machine, initialize the Claude Code plugin
+against that server instead of starting a local `powermem-server`. Remote init
+writes `~/.powermem/runtime.env` and/or the plugin root `.mcp.json`, then exits
+without creating the plugin `.env`, launching `uvx`, or managing a local PID.
+The default local path still uses `http://localhost:8848`.
+
+```bash
+# Hooks only: transcript capture and prompt search through REST
+POWERMEM_INIT_REMOTE_BASE_URL=https://powermem.example.com \
+POWERMEM_INIT_CONNECTION_MODE=hook \
+sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
+
+# MCP tools only: configure Claude's PowerMem MCP endpoint
+POWERMEM_INIT_REMOTE_BASE_URL=https://powermem.example.com \
+POWERMEM_INIT_CONNECTION_MODE=mcp \
+sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
+
+# Both hooks and MCP tools
+POWERMEM_INIT_REMOTE_BASE_URL=https://powermem.example.com \
+POWERMEM_INIT_CONNECTION_MODE=both \
+sh "$CLAUDE_PLUGIN_ROOT/scripts/init.sh"
+```
+
+If the server requires API-key auth, add
+`POWERMEM_INIT_REMOTE_API_KEY=<key>`. Hooks receive it as `POWERMEM_API_KEY`
+and send `X-API-Key`; MCP HTTP config writes the same header under
+`mcpServers.powermem.headers`.
 
 ### MCP mode: team or local URL
 

--- a/tests/unit/test_claude_plugin_uv_install.py
+++ b/tests/unit/test_claude_plugin_uv_install.py
@@ -1,4 +1,6 @@
+import json
 import os
+import shutil
 import subprocess
 import textwrap
 from pathlib import Path
@@ -60,6 +62,29 @@ def run_stop_script(tmp_path: Path, *, bin_dir: Path) -> subprocess.CompletedPro
     return subprocess.run(
         ["sh", "-c", command, str(STOP_SH)],
         cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def run_init_script(
+    plugin_root: Path,
+    tmp_path: Path,
+    *,
+    bin_dir: Path,
+    extra_env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["PATH"] = f"{bin_dir}:/usr/bin:/bin"
+    env["POWERMEM_DATA_DIR"] = str(tmp_path / ".powermem")
+    env.update(extra_env)
+    return subprocess.run(
+        ["sh", str(plugin_root / "scripts" / "init.sh")],
+        cwd=tmp_path,
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -352,6 +377,263 @@ def test_hook_launcher_exports_runtime_env_to_native_binary(tmp_path: Path) -> N
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "BASE=http://localhost:18848"
+
+
+def test_hook_launcher_skips_native_binary_in_mcp_only_mode(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    hooks_dir = plugin_root / "hooks"
+    bin_dir = hooks_dir / "bin"
+    hooks_dir.mkdir(parents=True)
+    run_hook = hooks_dir / "run-hook.sh"
+    run_hook.write_text(RUN_HOOK_SH.read_text(encoding="utf-8"), encoding="utf-8")
+    run_hook.chmod(0o755)
+    write_executable(
+        bin_dir / "powermem-hook-linux-amd64",
+        """
+        #!/usr/bin/env sh
+        printf 'unexpected\n'
+        exit 42
+        """,
+    )
+    data_dir = tmp_path / ".powermem"
+    data_dir.mkdir()
+    (data_dir / "runtime.env").write_text(
+        "POWERMEM_BASE_URL=https://powermem.example.com\n"
+        "POWERMEM_CONNECTION_MODE=mcp\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["sh", str(run_hook)],
+        cwd=tmp_path,
+        env={**os.environ, "HOME": str(tmp_path), "POWERMEM_DATA_DIR": str(data_dir)},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+
+
+def test_write_remote_runtime_config_includes_mode_and_api_key(tmp_path: Path) -> None:
+    result = run_common(
+        """
+        write_remote_runtime_config "https://powermem.example.com" "both" "test-key"
+        cat "$RUNTIME_FILE"
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "POWERMEM_BASE_URL='https://powermem.example.com'" in result.stdout
+    assert "POWERMEM_CONNECTION_MODE='both'" in result.stdout
+    assert "POWERMEM_REMOTE_MODE=1" in result.stdout
+    assert "POWERMEM_API_KEY='test-key'" in result.stdout
+    assert "POWERMEM_ENV_FILE=" not in result.stdout
+
+
+def test_write_remote_runtime_config_shell_quotes_values(tmp_path: Path) -> None:
+    result = run_common(
+        r"""
+        base_url='https://powermem.example.com/path?x=1&y=$(touch "$HOME/url-pwned")'
+        api_key='key with spaces & $(touch "$HOME/key-pwned") and '\'' quote'
+        write_remote_runtime_config "$base_url" "both" "$api_key"
+        . "$RUNTIME_FILE"
+        printf 'BASE=%s\n' "$POWERMEM_BASE_URL"
+        printf 'MODE=%s\n' "$POWERMEM_CONNECTION_MODE"
+        printf 'KEY=%s\n' "$POWERMEM_API_KEY"
+        [ ! -e "$HOME/url-pwned" ]
+        [ ! -e "$HOME/key-pwned" ]
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "BASE=https://powermem.example.com/path?x=1&y=$(touch" in result.stdout
+    assert "MODE=both" in result.stdout
+    assert "KEY=key with spaces & $(touch" in result.stdout
+    assert "and ' quote" in result.stdout
+    assert not (tmp_path / "url-pwned").exists()
+    assert not (tmp_path / "key-pwned").exists()
+
+
+def test_write_remote_mcp_config_sets_endpoint_and_header(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+
+    result = run_common(
+        f"""
+        PLUGIN_ROOT="{plugin_root}"
+        write_remote_mcp_config "https://powermem.example.com/" "test-key"
+        cat "$PLUGIN_ROOT/.mcp.json"
+        """,
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    config = json.loads(result.stdout)
+    server = config["mcpServers"]["powermem"]
+    assert server["transport"] == "http"
+    assert server["url"] == "https://powermem.example.com/mcp"
+    assert server["headers"] == {"X-API-Key": "test-key"}
+
+
+def test_remote_init_configures_both_mode_without_local_server_lifecycle(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    shutil.copytree(ROOT / "apps" / "claude-code-plugin", plugin_root)
+    bin_dir = tmp_path / "bin"
+    write_executable(
+        bin_dir / "curl",
+        """
+        #!/usr/bin/env sh
+        printf '%s\n' "$*" > "$HOME/curl_args"
+        printf '{"success":true,"data":{"status":"healthy"}}\n'
+        """,
+    )
+    write_executable(
+        bin_dir / "uv",
+        """
+        #!/usr/bin/env sh
+        printf 'uv should not run\n' >&2
+        exit 99
+        """,
+    )
+
+    result = run_init_script(
+        plugin_root,
+        tmp_path,
+        bin_dir=bin_dir,
+        extra_env={
+            "POWERMEM_INIT_REMOTE_BASE_URL": "https://powermem.example.com/",
+            "POWERMEM_INIT_CONNECTION_MODE": "both",
+            "POWERMEM_INIT_REMOTE_API_KEY": "test-key",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "test-key" not in result.stdout
+    assert "test-key" not in result.stderr
+    data_dir = tmp_path / ".powermem"
+    runtime = (data_dir / "runtime.env").read_text(encoding="utf-8")
+    assert "POWERMEM_BASE_URL='https://powermem.example.com'" in runtime
+    assert "POWERMEM_CONNECTION_MODE='both'" in runtime
+    assert "POWERMEM_API_KEY='test-key'" in runtime
+    assert not (data_dir / ".env").exists()
+    assert not (data_dir / "powermem.pid").exists()
+
+    config = json.loads((plugin_root / ".mcp.json").read_text(encoding="utf-8"))
+    server = config["mcpServers"]["powermem"]
+    assert server["url"] == "https://powermem.example.com/mcp"
+    assert server["headers"] == {"X-API-Key": "test-key"}
+    assert "tool run" not in result.stdout
+    assert "uv should not run" not in result.stderr
+    assert "Remote mode does not create plugin .env, start uvx, or manage a local PID." in result.stdout
+
+
+def test_remote_init_is_idempotent_from_existing_runtime(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    shutil.copytree(ROOT / "apps" / "claude-code-plugin", plugin_root)
+    bin_dir = tmp_path / "bin"
+    write_executable(
+        bin_dir / "curl",
+        """
+        #!/usr/bin/env sh
+        printf '{"success":true,"data":{"status":"healthy"}}\n'
+        """,
+    )
+    write_executable(
+        bin_dir / "uv",
+        """
+        #!/usr/bin/env sh
+        printf 'uv should not run\n' >&2
+        exit 99
+        """,
+    )
+
+    first = run_init_script(
+        plugin_root,
+        tmp_path,
+        bin_dir=bin_dir,
+        extra_env={
+            "POWERMEM_INIT_REMOTE_BASE_URL": "https://powermem.example.com",
+            "POWERMEM_INIT_CONNECTION_MODE": "both",
+            "POWERMEM_INIT_REMOTE_API_KEY": "test-key",
+        },
+    )
+    assert first.returncode == 0, first.stderr
+
+    second = run_init_script(
+        plugin_root,
+        tmp_path,
+        bin_dir=bin_dir,
+        extra_env={},
+    )
+
+    assert second.returncode == 0, second.stderr
+    assert "Configuring remote PowerMem backend: https://powermem.example.com" in second.stdout
+    assert "Connection mode: both" in second.stdout
+    assert "uv should not run" not in second.stderr
+    data_dir = tmp_path / ".powermem"
+    runtime = (data_dir / "runtime.env").read_text(encoding="utf-8")
+    assert "POWERMEM_CONNECTION_MODE='both'" in runtime
+    assert "POWERMEM_API_KEY='test-key'" in runtime
+    assert not (data_dir / ".env").exists()
+    assert not (data_dir / "powermem.pid").exists()
+
+
+def test_status_remote_mode_does_not_require_python(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    shutil.copytree(ROOT / "apps" / "claude-code-plugin", plugin_root)
+    data_dir = tmp_path / ".powermem"
+    data_dir.mkdir()
+    (data_dir / "runtime.env").write_text(
+        "POWERMEM_BASE_URL='https://powermem.example.com'\n"
+        "POWERMEM_CONNECTION_MODE='hook'\n"
+        "POWERMEM_REMOTE_MODE=1\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["PATH"] = "/usr/bin:/bin"
+    env["POWERMEM_DATA_DIR"] = str(data_dir)
+    env["POWERMEM_INIT_PYTHON"] = "missing-python"
+
+    result = subprocess.run(
+        ["sh", str(plugin_root / "scripts" / "status.sh")],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Connection mode: remote hook" in result.stdout
+    assert "Bootstrap Python: not required for remote mode" in result.stdout
+    assert "missing Python" not in result.stdout
+
+
+def test_remote_init_rejects_invalid_connection_mode(tmp_path: Path) -> None:
+    plugin_root = tmp_path / "plugin"
+    shutil.copytree(ROOT / "apps" / "claude-code-plugin", plugin_root)
+    bin_dir = tmp_path / "bin"
+
+    result = run_init_script(
+        plugin_root,
+        tmp_path,
+        bin_dir=bin_dir,
+        extra_env={
+            "POWERMEM_INIT_REMOTE_BASE_URL": "https://powermem.example.com",
+            "POWERMEM_INIT_CONNECTION_MODE": "invalid",
+        },
+    )
+
+    assert result.returncode == 2
+    assert "Use hook, mcp, or both" in result.stderr
+    assert not (tmp_path / ".powermem" / "runtime.env").exists()
 
 
 def test_bootstrap_python_uses_uv_managed_python_by_default(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add remote initialization for the Claude Code plugin via `POWERMEM_INIT_REMOTE_BASE_URL`.
- Support `hook`, `mcp`, and `both` connection modes with optional `POWERMEM_INIT_REMOTE_API_KEY`.
- Keep local initialization unchanged by default while documenting the remote setup path.

## Details
- Remote mode writes `runtime.env` and/or `.mcp.json` without generating a local backend `.env`, starting `uvx`, or managing a local PID.
- `runtime.env` values are shell-quoted so API keys and URLs with shell-sensitive characters can be sourced safely.
- Re-running init from an existing remote runtime remains in remote mode and preserves the configured mode/API key.
- Status output now distinguishes local and remote connection modes and marks Python/uv as not required for remote mode.

Closes #1103

## Validation
- `sh -n apps/claude-code-plugin/scripts/common.sh && sh -n apps/claude-code-plugin/scripts/init.sh && sh -n apps/claude-code-plugin/scripts/status.sh && sh -n apps/claude-code-plugin/hooks/run-hook.sh`
- `python -m pytest tests/unit/test_claude_plugin_uv_install.py tests/regression/test_claude_hook_privacy_e2e.py::test_windows_launcher_imports_runtime_env_files_with_quoted_values`
- Temp-dir script E2E with a live local health endpoint covering remote `both` init, `.mcp.json`, shell-safe `runtime.env`, status, hook invocation, mcp-only hook skip, and no local `uvx` startup.
