### PR TITLE
Publish individual release binary assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,7 +228,8 @@ jobs:
               uv run --no-project --python /opt/miniconda3/envs/powermem/bin/python python scripts/smoke_binary_package.py \
                 --dist /powermem/dist-binaries \
                 --target-os linux \
-                --target-arch amd64
+                --target-arch amd64 \
+                --require-individual-assets
             '
 
       - name: Copy Linux binaries out of image
@@ -239,14 +240,17 @@ jobs:
             -v "${GITHUB_WORKSPACE}/dist-binaries:/out" \
             --entrypoint /bin/bash \
             powermem-binaries-centos7 \
-            -c 'cp -av /powermem/dist-binaries/*.tar.gz /powermem/dist-binaries/*.sha256 /out/'
+            -c 'find /powermem/dist-binaries -maxdepth 1 -type f -print -exec cp -av {} /out/ \;'
 
       - name: Verify copied Linux binary artifacts
         run: |
           set -eux
           cd dist-binaries
-          sha256sum -c powermem-*-linux-amd64-binaries.tar.gz.sha256
-          ls -lh powermem-*-linux-amd64-binaries.tar.gz powermem-*-linux-amd64-binaries.tar.gz.sha256
+          sha256sum -c powermem-*-linux-amd64-*.sha256
+          ls -lh \
+            powermem-*-linux-amd64-binaries.tar.gz \
+            powermem-*-linux-amd64-binaries.tar.gz.sha256 \
+            powermem-*-linux-amd64-powermem*
 
       - name: Upload Linux amd64 binaries
         uses: actions/upload-artifact@v7
@@ -255,6 +259,7 @@ jobs:
           path: |
             dist-binaries/powermem-*-linux-amd64-binaries.tar.gz
             dist-binaries/powermem-*-linux-amd64-binaries.tar.gz.sha256
+            dist-binaries/powermem-*-linux-amd64-powermem*
           if-no-files-found: error
           retention-days: 30
 
@@ -320,7 +325,8 @@ jobs:
           uv run --no-project --python "3.11" python scripts/smoke_binary_package.py \
             --dist dist-binaries \
             --target-os "${{ matrix.binary-os }}" \
-            --target-arch "${{ matrix.binary-arch }}"
+            --target-arch "${{ matrix.binary-arch }}" \
+            --require-individual-assets
 
       - name: Upload native binaries
         uses: actions/upload-artifact@v7
@@ -328,6 +334,7 @@ jobs:
           name: powermem-${{ matrix.binary-os }}-${{ matrix.binary-arch }}-binaries
           path: |
             dist-binaries/powermem-*-${{ matrix.binary-os }}-${{ matrix.binary-arch }}-binaries.*
+            dist-binaries/powermem-*-${{ matrix.binary-os }}-${{ matrix.binary-arch }}-powermem*
           if-no-files-found: error
           retention-days: 30
 

--- a/scripts/build_binary_package.sh
+++ b/scripts/build_binary_package.sh
@@ -188,7 +188,9 @@ PY
     ;;
 esac
 
-"${PYTHON_CMD[@]}" - "${ARCHIVE_FILE}" > "${ARCHIVE_FILE}.sha256" <<'PY'
+write_sha256() {
+  local path="$1"
+  "${PYTHON_CMD[@]}" - "${path}" > "${path}.sha256" <<'PY'
 import hashlib
 import pathlib
 import sys
@@ -196,6 +198,26 @@ import sys
 path = pathlib.Path(sys.argv[1])
 print(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}")
 PY
+}
+
+write_sha256 "${ARCHIVE_FILE}"
+
+SINGLE_BINARY_FILES=()
+
+publish_binary_asset() {
+  local binary_name="$1"
+  local source="${BIN_DIR}/${binary_name}${EXE_SUFFIX}"
+  local asset="${DIST}/${PACKAGE_BASENAME}-${binary_name}${EXE_SUFFIX}"
+
+  cp -av "${source}" "${asset}"
+  chmod +x "${asset}" 2>/dev/null || true
+  write_sha256 "${asset}"
+  SINGLE_BINARY_FILES+=("${asset}" "${asset}.sha256")
+}
+
+publish_binary_asset powermem
+publish_binary_asset powermem-server
+publish_binary_asset powermem-mcp
 
 echo "Built ${TARGET_OS}-${TARGET_ARCH} binaries:"
-ls -lh "${BIN_DIR}" "${ARCHIVE_FILE}" "${ARCHIVE_FILE}.sha256"
+ls -lh "${BIN_DIR}" "${ARCHIVE_FILE}" "${ARCHIVE_FILE}.sha256" "${SINGLE_BINARY_FILES[@]}"

--- a/scripts/smoke_binary_package.py
+++ b/scripts/smoke_binary_package.py
@@ -48,15 +48,21 @@ def _strip_suffix(value: str, suffix: str) -> str:
     return value
 
 
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
 def _verify_checksum(archive: Path) -> None:
     checksum_path = archive.with_name(f"{archive.name}.sha256")
     if not checksum_path.is_file():
         _fail(f"missing checksum file: {checksum_path.name}")
 
     expected = checksum_path.read_text(encoding="utf-8").split()[0]
-    actual = hashlib.sha256(archive.read_bytes()).hexdigest()
+    actual = _sha256(archive)
     if actual != expected:
-        _fail(f"checksum mismatch for {archive.name}: expected {expected}, got {actual}")
+        _fail(
+            f"checksum mismatch for {archive.name}: expected {expected}, got {actual}"
+        )
 
 
 def _extract(archive: Path, target: Path) -> None:
@@ -116,8 +122,7 @@ def _run_checked(
 
     if result.returncode != 0:
         _fail(
-            f"{description} exited with status {result.returncode}\n"
-            f"{result.stdout}"
+            f"{description} exited with status {result.returncode}\n" f"{result.stdout}"
         )
     return result
 
@@ -178,7 +183,9 @@ def _smoke_server(server_binary: Path, port: int) -> None:
             }
         )
 
-        with server_output_path.open("w", encoding="utf-8", errors="replace") as server_output:
+        with server_output_path.open(
+            "w", encoding="utf-8", errors="replace"
+        ) as server_output:
             process = subprocess.Popen(
                 [
                     str(server_binary),
@@ -210,7 +217,9 @@ def _smoke_server(server_binary: Path, port: int) -> None:
                         )
                         break
                     try:
-                        health_body = _fetch(f"http://localhost:{port}/api/v1/system/health")
+                        health_body = _fetch(
+                            f"http://localhost:{port}/api/v1/system/health"
+                        )
                         dashboard_body = _fetch(f"http://localhost:{port}/dashboard/")
                         break
                     except urllib.error.HTTPError as exc:
@@ -232,9 +241,13 @@ def _smoke_server(server_binary: Path, port: int) -> None:
                     assert dashboard_body is not None
                     health = json.loads(health_body.decode("utf-8"))
                     if health.get("success") is not True:
-                        failure = f"health response did not report success=true: {health}"
+                        failure = (
+                            f"health response did not report success=true: {health}"
+                        )
                     elif health.get("data", {}).get("status") != "healthy":
-                        failure = f"health response did not report status=healthy: {health}"
+                        failure = (
+                            f"health response did not report status=healthy: {health}"
+                        )
                     elif not dashboard_body.strip():
                         failure = "dashboard response body is empty"
             finally:
@@ -264,12 +277,34 @@ def _smoke_mcp(mcp_binary: Path) -> None:
         )
 
 
+def _verify_individual_binary_assets(
+    dist: Path,
+    package_name: str,
+    packaged_binaries: dict[str, Path],
+) -> None:
+    for binary_file_name, packaged_binary in packaged_binaries.items():
+        asset = dist / f"{package_name}-{binary_file_name}"
+        if not asset.is_file():
+            _fail(f"missing individual binary asset: {asset.name}")
+        _verify_checksum(asset)
+        if _sha256(asset) != _sha256(packaged_binary):
+            _fail(
+                "individual binary asset does not match archive contents: "
+                f"{asset.name}"
+            )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dist", default="dist-binaries", type=Path)
     parser.add_argument("--target-os", required=True)
     parser.add_argument("--target-arch", required=True)
     parser.add_argument("--port", default=18848, type=int)
+    parser.add_argument(
+        "--require-individual-assets",
+        action="store_true",
+        help="Also require per-command binary assets next to the archive.",
+    )
     args = parser.parse_args()
 
     dist = args.dist.resolve()
@@ -281,11 +316,12 @@ def main() -> None:
         ],
     )
     _verify_checksum(archive)
+    package_name = _package_name(archive)
 
     with _temporary_directory(prefix="powermem-binary-smoke-") as tmp:
         extract_root = Path(tmp)
         _extract(archive, extract_root)
-        package_root = extract_root / _package_name(archive)
+        package_root = extract_root / package_name
         bin_dir = package_root / "bin"
         if not bin_dir.is_dir():
             _fail(f"missing bin directory: {bin_dir}")
@@ -298,20 +334,25 @@ def main() -> None:
         }
         actual = {path.name for path in bin_dir.iterdir() if path.is_file()}
         if actual != expected:
-            _fail(f"unexpected bin contents: expected {sorted(expected)}, got {sorted(actual)}")
+            _fail(
+                f"unexpected bin contents: expected {sorted(expected)}, got {sorted(actual)}"
+            )
 
         binaries = {
-            name: bin_dir / f"{name}{exe_suffix}"
+            f"{name}{exe_suffix}": bin_dir / f"{name}{exe_suffix}"
             for name in ("powermem", "powermem-server", "powermem-mcp")
         }
         for binary in binaries.values():
             if args.target_os != "windows" and not os.access(binary, os.X_OK):
                 _fail(f"binary is not executable: {binary}")
 
-        _run_help(binaries["powermem"])
-        _run_help(binaries["powermem-server"])
-        _smoke_server(binaries["powermem-server"], args.port)
-        _smoke_mcp(binaries["powermem-mcp"])
+        if args.require_individual_assets:
+            _verify_individual_binary_assets(dist, package_name, binaries)
+
+        _run_help(binaries[f"powermem{exe_suffix}"])
+        _run_help(binaries[f"powermem-server{exe_suffix}"])
+        _smoke_server(binaries[f"powermem-server{exe_suffix}"], args.port)
+        _smoke_mcp(binaries[f"powermem-mcp{exe_suffix}"])
 
     print(f"Smoke test passed for {archive.name}")
 

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -1,7 +1,11 @@
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 
 from scripts.smoke_binary_package import _package_name
-
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -10,14 +14,18 @@ def test_binary_builder_verifies_miniconda_installer_checksum() -> None:
     dockerfile = (ROOT / "docker" / "Dockerfile.binaries-centos7").read_text()
 
     assert "ARG MINICONDA_SHA256=" in dockerfile
-    assert "634d76df5e489c44ade4085552b97bebc786d49245ed1a830022b0b406de5817" in dockerfile
-    assert 'echo "${MINICONDA_SHA256}  /tmp/miniconda.sh" | sha256sum -c -' in dockerfile
+    assert (
+        "634d76df5e489c44ade4085552b97bebc786d49245ed1a830022b0b406de5817" in dockerfile
+    )
+    assert (
+        'echo "${MINICONDA_SHA256}  /tmp/miniconda.sh" | sha256sum -c -' in dockerfile
+    )
 
 
 def test_release_binary_help_smokes_are_bounded() -> None:
     smoke_script = (ROOT / "scripts" / "smoke_binary_package.py").read_text()
 
-    assert "[str(binary), \"--help\"]" in smoke_script
+    assert '[str(binary), "--help"]' in smoke_script
     assert "timeout=60" in smoke_script
     assert "_run_checked(" in smoke_script
 
@@ -38,7 +46,7 @@ def test_release_binary_server_smoke_checks_health_json_and_dashboard() -> None:
     assert "/dashboard/" in smoke_script
     assert 'ready_timeout = 180 if os.name == "nt" else 60' in smoke_script
     assert '"taskkill", "/F", "/T", "/PID"' in smoke_script
-    assert "ignore_cleanup_errors=os.name == \"nt\"" in smoke_script
+    assert 'ignore_cleanup_errors=os.name == "nt"' in smoke_script
     assert "powermem-server-smoke-output.txt" in smoke_script
     assert "stdout=server_output" in smoke_script
     assert "log_path" not in smoke_script
@@ -48,14 +56,108 @@ def test_release_binary_server_smoke_checks_health_json_and_dashboard() -> None:
     assert 'health.get("data", {}).get("status") != "healthy"' in smoke_script
 
 
+def test_release_binary_smoke_checks_individual_binary_assets() -> None:
+    smoke_script = (ROOT / "scripts" / "smoke_binary_package.py").read_text()
+
+    assert "--require-individual-assets" in smoke_script
+    assert "def _verify_individual_binary_assets(" in smoke_script
+    assert 'asset = dist / f"{package_name}-{binary_file_name}"' in smoke_script
+    assert "_verify_checksum(asset)" in smoke_script
+    assert "_sha256(asset) != _sha256(packaged_binary)" in smoke_script
+    assert "if args.require_individual_assets:" in smoke_script
+
+
 def test_release_binary_builder_accepts_platform_and_arch_targets() -> None:
     builder = (ROOT / "scripts" / "build_binary_package.sh").read_text()
 
     assert "POWERMEM_BINARY_OS" in builder
     assert "POWERMEM_BINARY_ARCH" in builder
-    assert "PACKAGE_BASENAME=\"powermem-${VERSION}-${TARGET_OS}-${TARGET_ARCH}\"" in builder
+    assert (
+        'PACKAGE_BASENAME="powermem-${VERSION}-${TARGET_OS}-${TARGET_ARCH}"' in builder
+    )
     assert "POWERMEM_BINARY_FORMAT" in builder
     assert ".sha256" in builder
+
+
+def test_release_binary_builder_exports_individual_binary_assets() -> None:
+    builder = (ROOT / "scripts" / "build_binary_package.sh").read_text()
+
+    assert (
+        'local asset="${DIST}/${PACKAGE_BASENAME}-${binary_name}${EXE_SUFFIX}"'
+        in builder
+    )
+    assert "SINGLE_BINARY_FILES" in builder
+    assert "publish_binary_asset powermem\n" in builder
+    assert "publish_binary_asset powermem-server" in builder
+    assert "publish_binary_asset powermem-mcp" in builder
+    assert 'write_sha256 "${asset}"' in builder
+
+
+def test_release_binary_builder_writes_individual_assets(tmp_path: Path) -> None:
+    work = tmp_path / "work"
+    scripts_dir = work / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy2(ROOT / "scripts" / "build_binary_package.sh", scripts_dir)
+    shutil.copy2(ROOT / "pyproject.toml", work / "pyproject.toml")
+
+    fake_python = tmp_path / "fake-python"
+    fake_python.write_text(
+        textwrap.dedent(f"""\
+            #!{sys.executable}
+            import os
+            import pathlib
+            import sys
+
+            if len(sys.argv) >= 3 and sys.argv[1:3] == ["-m", "PyInstaller"]:
+                args = sys.argv[3:]
+                name = args[args.index("--name") + 1]
+                distpath = pathlib.Path(args[args.index("--distpath") + 1])
+                distpath.mkdir(parents=True, exist_ok=True)
+                output = distpath / name
+                output.write_text(f"fake binary {{name}}\\n", encoding="utf-8")
+                output.chmod(0o755)
+                raise SystemExit(0)
+
+            os.execv({sys.executable!r}, [{sys.executable!r}, *sys.argv[1:]])
+            """),
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PYTHON": str(fake_python),
+            "POWERMEM_BINARY_OS": "macos",
+            "POWERMEM_BINARY_ARCH": "aarch64",
+            "POWERMEM_BINARY_FORMAT": "tar.gz",
+        }
+    )
+    result = subprocess.run(
+        ["bash", "scripts/build_binary_package.sh"],
+        cwd=work,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout
+
+    dist = work / "dist-binaries"
+    archive = next(dist.glob("powermem-*-macos-aarch64-binaries.tar.gz"))
+    package_name = _package_name(archive)
+    expected_assets = [
+        dist / f"{package_name}-powermem",
+        dist / f"{package_name}-powermem-server",
+        dist / f"{package_name}-powermem-mcp",
+    ]
+
+    assert archive.is_file()
+    assert archive.with_name(f"{archive.name}.sha256").is_file()
+    for asset in expected_assets:
+        assert asset.is_file()
+        assert asset.with_name(f"{asset.name}.sha256").is_file()
 
 
 def test_release_binary_zip_packaging_keeps_uv_in_project_root() -> None:
@@ -92,6 +194,7 @@ def test_release_binary_matrix_includes_supported_macos_and_windows_arches() -> 
         'uv run --no-project --python "3.11" python scripts/smoke_binary_package.py'
         in workflow
     )
+    assert workflow.count("--require-individual-assets") == 2
 
 
 def test_linux_binary_dockerfile_pins_pyinstaller_setuptools_runtime_api() -> None:
@@ -116,9 +219,19 @@ def test_release_uploads_arch_named_binary_assets() -> None:
     workflow = (ROOT / ".github" / "workflows" / "build.yml").read_text()
 
     assert "name: powermem-linux-amd64-binaries" in workflow
-    assert "name: powermem-${{ matrix.binary-os }}-${{ matrix.binary-arch }}-binaries" in workflow
+    assert (
+        "name: powermem-${{ matrix.binary-os }}-${{ matrix.binary-arch }}-binaries"
+        in workflow
+    )
     assert "pattern: powermem-*-binaries" in workflow
     assert "binary-artifacts/*" in workflow
+    assert "find /powermem/dist-binaries -maxdepth 1 -type f" in workflow
+    assert "sha256sum -c powermem-*-linux-amd64-*.sha256" in workflow
+    assert "dist-binaries/powermem-*-linux-amd64-powermem*" in workflow
+    assert (
+        "dist-binaries/powermem-*-${{ matrix.binary-os }}-${{ matrix.binary-arch }}-powermem*"
+        in workflow
+    )
 
 
 def test_smoke_script_maps_archive_names_to_package_dirs() -> None:


### PR DESCRIPTION
## Summary

- publish each packaged command binary as an individual release asset alongside the existing per-platform archive
- add per-file checksums for the individual binary assets
- make release smoke checks verify individual assets in CI while keeping archive-only smoke behavior available by default

## Validation

- `bash -n scripts/build_binary_package.sh scripts/build_linux_binaries.sh`
- `python -m pytest tests/unit/test_release_binary_ci.py -q`
- `python -m black --check scripts/smoke_binary_package.py tests/unit/test_release_binary_ci.py`
- `git diff --check`
- built a local Linux binary package and verified the generated individual assets match the archive contents and checksums

## Notes

The GitHub Actions release matrix passed for Linux amd64, macOS amd64, macOS aarch64, and Windows amd64 binary jobs on this PR.

Closes #1110.
