### PR TITLE
chore: bump version to 1.1.6

### DIFF
--- a/packages/powermem-mcp/README.md
+++ b/packages/powermem-mcp/README.md
@@ -4,7 +4,7 @@ Thin wrapper package for launching the PowerMem MCP server with `uvx`.
 
 This package intentionally uses the same version as the main
 [`powermem`](https://pypi.org/project/powermem/) package. For example,
-`powermem-mcp==1.1.5` depends on `powermem[server,seekdb]==1.1.5`.
+`powermem-mcp==1.1.6` depends on `powermem[server,seekdb]==1.1.6`.
 
 Use this package when an MCP client needs a zero-install command such as:
 

--- a/packages/powermem-mcp/pyproject.toml
+++ b/packages/powermem-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powermem-mcp"
-version = "1.1.5"
+version = "1.1.6"
 description = "PowerMem MCP server - thin wrapper that installs powermem[server,seekdb] and exposes the powermem-mcp command."
 readme = "README.md"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "powermem[server,seekdb]==1.1.5",
+    "powermem[server,seekdb]==1.1.6",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powermem"
-version = "1.1.5"
+version = "1.1.6"
 description = "Intelligent Memory System - Persistent memory layer for LLM applications"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/powermem/core/audit.py
+++ b/src/powermem/core/audit.py
@@ -106,7 +106,7 @@ class AuditLogger:
                 "user_id": user_id,
                 "agent_id": agent_id,
                 "details": details,
-                "version": "1.1.5",
+                "version": "1.1.6",
             }
             
             # Log to file

--- a/src/powermem/core/telemetry.py
+++ b/src/powermem/core/telemetry.py
@@ -82,7 +82,7 @@ class TelemetryManager:
                 "user_id": user_id,
                 "agent_id": agent_id,
                 "timestamp": get_current_datetime().isoformat(),
-                "version": "1.1.5",
+                "version": "1.1.6",
             }
             
             self.events.append(event)
@@ -182,7 +182,7 @@ class TelemetryManager:
                 "properties": properties,
                 "user_id": user_id,
                 "timestamp": get_current_datetime().isoformat(),
-                "version": "1.1.5",
+                "version": "1.1.6",
             }
             
             self.events.append(event)

--- a/src/powermem/version.py
+++ b/src/powermem/version.py
@@ -2,11 +2,12 @@
 Version information management
 """
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 __version_info__ = tuple(map(int, __version__.split(".")))
 
 # Version history
 VERSION_HISTORY = {
+    "1.1.6": "2026-06-30 - Version 1.1.6 release",
     "1.1.5": "2026-06-23 - Version 1.1.5 release",
     "1.1.4": "2026-06-14 - Version 1.1.4 release",
     "1.1.3": "2026-06-08 - Version 1.1.3 release",


### PR DESCRIPTION
## Summary
- bump powermem and powermem-mcp versions to 1.1.6
- update VERSION_HISTORY and powermem-mcp README dependency example

## Validation
- make check-package-versions
- git diff --check
- python3.11 -m build --wheel --outdir /tmp/powermem-root-dist-1.1.6 .
- python3.11 -m build --wheel --outdir /tmp/powermem-mcp-dist-1.1.6 packages/powermem-mcp
- inspected wheel metadata for powermem==1.1.6 and powermem-mcp dependency powermem[seekdb,server]==1.1.6
