### PR TITLE
Split regression workflow into parallel shards

### DIFF
--- a/.github/scripts/select_regression_shard.py
+++ b/.github/scripts/select_regression_shard.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Select a balanced file-level shard for regression tests."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+from pathlib import Path
+
+
+def test_weight(path: Path) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    count = sum(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+        for node in ast.walk(tree)
+    )
+    return max(count, 1)
+
+
+def select_files(mode: str) -> list[Path]:
+    files = sorted(Path("tests/regression").glob("test_*.py"))
+    if mode == "scenarios":
+        return [path for path in files if path.name.startswith("test_scenario")]
+    if mode == "non-scenarios":
+        return [path for path in files if not path.name.startswith("test_scenario")]
+    raise ValueError(f"unknown shard mode: {mode}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("scenarios", "non-scenarios"), required=True)
+    parser.add_argument("--shard-index", type=int, required=True)
+    parser.add_argument("--shard-total", type=int, required=True)
+    parser.add_argument("--output", default="selected-tests.txt")
+    args = parser.parse_args()
+    if args.shard_total <= 0:
+        parser.error("--shard-total must be greater than zero")
+    if args.shard_index < 0 or args.shard_index >= args.shard_total:
+        parser.error("--shard-index must be between zero and shard-total - 1")
+
+    shards = [{"weight": 0, "files": []} for _ in range(args.shard_total)]
+    weighted_files = sorted(
+        ((path, test_weight(path)) for path in select_files(args.mode)),
+        key=lambda item: (-item[1], item[0].as_posix()),
+    )
+
+    for path, weight in weighted_files:
+        shard = min(shards, key=lambda item: (item["weight"], len(item["files"])))
+        shard["files"].append(path)
+        shard["weight"] += weight
+
+    selected = [path.as_posix() for path in shards[args.shard_index]["files"]]
+    Path(args.output).write_text(
+        "\n".join(selected) + ("\n" if selected else ""),
+        encoding="utf-8",
+    )
+
+    print(
+        f"{args.mode} shard {args.shard_index + 1}/{args.shard_total}: "
+        f"{len(selected)} files, estimated weight {shards[args.shard_index]['weight']}"
+    )
+    for path in selected:
+        print(f"  {path}")
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as output:
+            output.write(f"has_tests={'true' if selected else 'false'}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -8,6 +8,8 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
       - 'Makefile'
+      - '.github/workflows/regression.yml'
+      - '.github/scripts/**'
   pull_request_target:
     branches: [main]
     paths:
@@ -15,6 +17,8 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
       - 'Makefile'
+      - '.github/workflows/regression.yml'
+      - '.github/scripts/**'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -30,6 +34,7 @@ on:
 
 jobs:
   test1:
+    name: scenarios / ${{ matrix.group }}
     runs-on: ubuntu-latest
     # Skip on forks: schedule/push only run in the upstream repo (secrets are unavailable in forks).
     # External PRs (from forks) require manual trigger via workflow_dispatch.
@@ -39,9 +44,26 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'oceanbase/powermem') ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
-      matrix:
-        python-version: ["3.11"]
       fail-fast: false
+      max-parallel: 2
+      matrix:
+        include:
+          - python-version: "3.11"
+            group: scenario-shard-1
+            shard-index: 0
+            shard-total: 4
+          - python-version: "3.11"
+            group: scenario-shard-2
+            shard-index: 1
+            shard-total: 4
+          - python-version: "3.11"
+            group: scenario-shard-3
+            shard-index: 2
+            shard-total: 4
+          - python-version: "3.11"
+            group: scenario-shard-4
+            shard-index: 3
+            shard-total: 4
 
     steps:
       - name: Get PR SHA (if PR number provided)
@@ -145,6 +167,14 @@ jobs:
           set_env_var POWERMEM_SERVER_API_KEYS key1,key2,key3
           set_env_var POWERMEM_SERVER_WORKERS 1
 
+      - name: Select regression shard
+        id: select_tests
+        run: |
+          uv run --no-project --python "${{ matrix.python-version }}" python .github/scripts/select_regression_shard.py \
+            --mode scenarios \
+            --shard-index "${{ matrix.shard-index }}" \
+            --shard-total "${{ matrix.shard-total }}"
+
       - name: Run regression tests
         id: run_tests
         env:
@@ -153,12 +183,16 @@ jobs:
           SILICONFLOW_COM_API_KEY: "${{ secrets.SILICONFLOW_COM_API_KEY }}"
         run: |
           mkdir -p report
-          uv run --no-project --python "${{ matrix.python-version }}" --with-editable ".[dev,test,server,seekdb]" pytest tests/regression/test_scenario*.py -vs --junitxml=report/test1.xml
+          if [ "${{ steps.select_tests.outputs.has_tests }}" != "true" ]; then
+            echo "No regression tests selected for ${{ matrix.group }}."
+            exit 0
+          fi
+          uv run --no-project --python "${{ matrix.python-version }}" --with-editable ".[dev,test,server,seekdb]" pytest $(cat selected-tests.txt) -vs --junitxml=report/${{ matrix.group }}.xml
       - name: Upload JUnit report
         if: always() && (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure')
         uses: actions/upload-artifact@v7
         with:
-          name: junit-test1
+          name: junit-${{ matrix.group }}
           path: report/
       - name: Cleanup Docker
         if: always()
@@ -167,7 +201,9 @@ jobs:
           sudo docker rm -f seekdb 2>/dev/null || true
           sudo docker ps
           echo "✓ 清理完成"
+
   test2:
+    name: non-scenarios / ${{ matrix.group }}
     runs-on: ubuntu-latest
     # Skip on forks: schedule/push only run in the upstream repo (secrets are unavailable in forks).
     # External PRs (from forks) require manual trigger via workflow_dispatch.
@@ -177,9 +213,34 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'oceanbase/powermem') ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
-      matrix:
-        python-version: ["3.11"]
       fail-fast: false
+      max-parallel: 2
+      matrix:
+        include:
+          - python-version: "3.11"
+            group: non-scenario-shard-1
+            shard-index: 0
+            shard-total: 6
+          - python-version: "3.11"
+            group: non-scenario-shard-2
+            shard-index: 1
+            shard-total: 6
+          - python-version: "3.11"
+            group: non-scenario-shard-3
+            shard-index: 2
+            shard-total: 6
+          - python-version: "3.11"
+            group: non-scenario-shard-4
+            shard-index: 3
+            shard-total: 6
+          - python-version: "3.11"
+            group: non-scenario-shard-5
+            shard-index: 4
+            shard-total: 6
+          - python-version: "3.11"
+            group: non-scenario-shard-6
+            shard-index: 5
+            shard-total: 6
 
     steps:
       - name: Get PR SHA (if PR number provided)
@@ -283,6 +344,14 @@ jobs:
           set_env_var POWERMEM_SERVER_API_KEYS key1,key2,key3
           set_env_var POWERMEM_SERVER_WORKERS 1
 
+      - name: Select regression shard
+        id: select_tests
+        run: |
+          uv run --no-project --python "${{ matrix.python-version }}" python .github/scripts/select_regression_shard.py \
+            --mode non-scenarios \
+            --shard-index "${{ matrix.shard-index }}" \
+            --shard-total "${{ matrix.shard-total }}"
+
       - name: Run regression tests
         id: run_tests
         env:
@@ -291,12 +360,16 @@ jobs:
           SILICONFLOW_COM_API_KEY: "${{ secrets.SILICONFLOW_COM_API_KEY }}"
         run: |
           mkdir -p report
-          uv run --no-project --python "${{ matrix.python-version }}" --with-editable ".[dev,test,server,seekdb]" pytest tests/regression/ --ignore-glob='*test_scenario*.py' -vs --junitxml=report/test2.xml
+          if [ "${{ steps.select_tests.outputs.has_tests }}" != "true" ]; then
+            echo "No regression tests selected for ${{ matrix.group }}."
+            exit 0
+          fi
+          uv run --no-project --python "${{ matrix.python-version }}" --with-editable ".[dev,test,server,seekdb]" pytest $(cat selected-tests.txt) -vs --junitxml=report/${{ matrix.group }}.xml
       - name: Upload JUnit report
         if: always() && (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure')
         uses: actions/upload-artifact@v7
         with:
-          name: junit-test2
+          name: junit-${{ matrix.group }}
           path: report/
       - name: Cleanup Docker
         if: always()


### PR DESCRIPTION
## Summary
- Split scenario regression tests into four file-level shards and non-scenario regression tests into six file-level shards.
- Add a small shard-selection helper that balances files by test function count and keeps new `test_*.py` files covered automatically.
- Preserve the existing JUnit artifact aggregation while limiting each regression job to two concurrent shards.
- Include the regression workflow and helper script paths in the workflow trigger filters so workflow-only changes can be tested.

## Validation
- `actionlint .github/workflows/regression.yml`
- YAML parse of `.github/workflows/regression.yml`
- Shard planner dry-run covered 21 regression files with no missing or duplicate files.
- `uv run --no-project --python "3.11" --with-editable ".[dev,test,server,seekdb]" pytest --collect-only -q tests/regression/test_claude_hook_privacy_e2e.py`
