### PR TITLE
fix(ci): dispatch publish workflow without git checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -399,4 +399,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
-        run: gh workflow run publish.yml --ref "$RELEASE_TAG" -f release_tag="$RELEASE_TAG"
+        run: gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" --ref "$RELEASE_TAG" -f release_tag="$RELEASE_TAG"


### PR DESCRIPTION
## Summary
- pass the repository explicitly when dispatching publish.yml from the tag build workflow
- avoids gh failing with `fatal: not a git repository` in jobs that do not checkout the repo

## Validation
- git diff --check

Context: v1.1.6 tag Build Package uploaded release assets successfully, but the final dispatch-pypi-publish job failed because `gh workflow run` could not infer a repository from a checkout-less job workspace.
