### PR TITLE
fix(ci): avoid duplicate generated release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,16 +376,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          if body_length="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '(.body // "") | length' 2>/dev/null)"; then
+          release_error="$(mktemp)"
+          trap 'rm -f "$release_error"' EXIT
+
+          if body_length="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '(.body // "") | length' 2>"$release_error")"; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             if [ "${body_length:-0}" -gt 0 ]; then
               echo "has_body=true" >> "$GITHUB_OUTPUT"
             else
               echo "has_body=false" >> "$GITHUB_OUTPUT"
             fi
-          else
+          elif grep -qi "release not found" "$release_error"; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "has_body=false" >> "$GITHUB_OUTPUT"
+          else
+            cat "$release_error" >&2
+            exit 1
           fi
 
       - name: Create Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,6 +370,24 @@ jobs:
           path: binary-artifacts
           merge-multiple: true
 
+      - name: Inspect existing release notes
+        id: release-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if body_length="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '(.body // "") | length' 2>/dev/null)"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            if [ "${body_length:-0}" -gt 0 ]; then
+              echo "has_body=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_body=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "has_body=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
@@ -379,7 +397,7 @@ jobs:
             binary-artifacts/*
           draft: false
           prerelease: false
-          generate_release_notes: true
+          generate_release_notes: ${{ steps.release-notes.outputs.exists != 'true' || steps.release-notes.outputs.has_body != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- avoid regenerating release notes when the tag release already exists and already has a body
- keep release asset upload/update behavior through `softprops/action-gh-release`
- fail closed when the existing-release lookup fails for reasons other than a missing release
- prevent pre-created releases from getting a second generated `What's Changed` block appended

## Root Cause

For v1.1.5 and v1.1.6, the GitHub Release existed before the `build-and-release` job uploaded assets. The release action preserved the existing body and then generated release notes again, which duplicated the RN content.

## Validation

- cleaned the duplicated bodies for v1.1.5 and v1.1.6 manually through the GitHub Release API
- verified v1.1.3 through v1.1.6 each now has exactly one `What's Changed` section and one `Full Changelog` link
- `git diff --check`
- `actionlint .github/workflows/build.yml`
- simulated the inspect step for an existing release with body: `exists=true`, `has_body=true`
- simulated the inspect step for an existing release with empty body: `exists=true`, `has_body=false`
- simulated the inspect step for a missing release: `exists=false`, `has_body=false`
- simulated an unexpected release lookup failure and verified the step exits non-zero instead of enabling generated release notes

Fixes #1122
