### PR TITLE
Fix powermem-mcp help to exit without starting the server

### DIFF
--- a/packages/powermem-mcp/pyproject.toml
+++ b/packages/powermem-mcp/pyproject.toml
@@ -21,7 +21,7 @@ Homepage = "https://github.com/oceanbase/powermem"
 Repository = "https://github.com/oceanbase/powermem.git"
 
 [project.scripts]
-powermem-mcp = "powermem.mcp.server:main"
+powermem-mcp = "powermem.mcp.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ server = ["dashboard/**"]
 powermem-server = "server.cli.server:server"
 pmem            = "powermem.cli.main:cli"
 powermem-cli    = "powermem.cli.main:cli"
-powermem-mcp    = "powermem.mcp.server:main"
+powermem-mcp    = "powermem.mcp.cli:main"
 
 [tool.black]
 line-length = 88

--- a/scripts/build_binary_package.sh
+++ b/scripts/build_binary_package.sh
@@ -86,7 +86,7 @@ if __name__ == "__main__":
 PY
 
 cat > "${ENTRYPOINTS}/powermem_mcp_entry.py" <<'PY'
-from powermem.mcp.server import main
+from powermem.mcp.cli import main
 
 if __name__ == "__main__":
     main()

--- a/scripts/smoke_binary_package.py
+++ b/scripts/smoke_binary_package.py
@@ -351,6 +351,7 @@ def main() -> None:
 
         _run_help(binaries[f"powermem{exe_suffix}"])
         _run_help(binaries[f"powermem-server{exe_suffix}"])
+        _run_help(binaries[f"powermem-mcp{exe_suffix}"])
         _smoke_server(binaries[f"powermem-server{exe_suffix}"], args.port)
         _smoke_mcp(binaries[f"powermem-mcp{exe_suffix}"])
 

--- a/src/powermem/mcp/__main__.py
+++ b/src/powermem/mcp/__main__.py
@@ -1,4 +1,4 @@
 """Allow ``python -m powermem.mcp`` as an alias for ``powermem-mcp``."""
-from powermem.mcp.server import main
+from powermem.mcp.cli import main
 
 main()

--- a/src/powermem/mcp/args.py
+++ b/src/powermem/mcp/args.py
@@ -1,0 +1,25 @@
+"""Argument parsing helpers for PowerMem MCP command-line entry points."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="powermem-mcp",
+        description="Start the PowerMem MCP server.",
+    )
+    parser.add_argument(
+        "transport",
+        nargs="?",
+        default="streamable-http",
+        help="MCP transport to use: streamable-http, sse, or stdio.",
+    )
+    parser.add_argument(
+        "port",
+        nargs="?",
+        default="8848",
+        help="Port for streamable-http or sse transports (default: 8848).",
+    )
+    return parser

--- a/src/powermem/mcp/cli.py
+++ b/src/powermem/mcp/cli.py
@@ -1,0 +1,13 @@
+"""Lightweight command-line entry point for ``powermem-mcp``."""
+
+from typing import List, Optional
+
+from powermem.mcp.args import build_arg_parser
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    build_arg_parser().parse_args(argv)
+
+    from powermem.mcp.server import main as server_main
+
+    server_main(argv)

--- a/src/powermem/mcp/server.py
+++ b/src/powermem/mcp/server.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 from fastmcp import FastMCP
 
 from powermem import auto_config, create_memory
+from powermem.mcp.args import build_arg_parser
 from powermem.user_memory import UserMemory
 
 # ============================================================================
@@ -600,7 +601,7 @@ def delete_memory_with_profile(
 # Entry point
 # ============================================================================
 
-def main() -> None:
+def main(argv: Optional[List[str]] = None) -> None:
     """
     Start the PowerMem MCP server.
 
@@ -615,13 +616,14 @@ def main() -> None:
         powermem-mcp stdio                    # stdio / JSON-RPC
         powermem-mcp streamable-http 9000
     """
-    transport = sys.argv[1] if len(sys.argv) > 1 else "streamable-http"
+    args = build_arg_parser().parse_args(argv)
+    transport = args.transport
     port = 8848
-    if len(sys.argv) > 2:
+    if args.port:
         try:
-            port = int(sys.argv[2])
+            port = int(args.port)
         except ValueError:
-            print(f"Invalid port '{sys.argv[2]}', using 8848", file=sys.stderr)
+            print(f"Invalid port '{args.port}', using 8848", file=sys.stderr)
 
     path = "/mcp"
 

--- a/tests/unit/test_mcp_cli.py
+++ b/tests/unit/test_mcp_cli.py
@@ -1,0 +1,90 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def _restore_module(module_name, saved_module):
+    if saved_module is None:
+        sys.modules.pop(module_name, None)
+    else:
+        sys.modules[module_name] = saved_module
+
+
+def test_powermem_mcp_cli_help_does_not_import_server(monkeypatch, capsys):
+    cli_module = "powermem.mcp.cli"
+    server_module = "powermem.mcp.server"
+    saved_cli = sys.modules.pop(cli_module, None)
+    saved_server = sys.modules.pop(server_module, None)
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == server_module or name.startswith(server_module + "."):
+            raise AssertionError("help should not import the MCP server module")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    try:
+        cli = importlib.import_module(cli_module)
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(["--help"])
+    finally:
+        _restore_module(cli_module, saved_cli)
+        _restore_module(server_module, saved_server)
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out
+    assert "streamable-http" in captured.out
+
+
+def test_powermem_mcp_help_exits_without_starting_server(monkeypatch, capsys):
+    pytest.importorskip("fastmcp", exc_type=ImportError)
+
+    from powermem.mcp import server
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("help should not start the MCP server")
+
+    monkeypatch.setattr(server.mcp, "run", fail_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        server.main(["--help"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out
+    assert "streamable-http" in captured.out
+    assert "Starting PowerMem MCP Server" not in captured.err
+
+
+def test_powermem_mcp_invalid_port_falls_back_to_default(monkeypatch, capsys):
+    pytest.importorskip("fastmcp", exc_type=ImportError)
+
+    from powermem.mcp import server
+
+    calls = []
+
+    def record_run(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(server.mcp, "run", record_run)
+
+    server.main(["sse", "not-a-port"])
+
+    captured = capsys.readouterr()
+    assert "Invalid port 'not-a-port', using 8848" in captured.err
+    assert calls == [
+        (
+            (),
+            {
+                "transport": "sse",
+                "host": "0.0.0.0",
+                "port": 8848,
+                "path": "/mcp",
+            },
+        )
+    ]

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -28,6 +28,14 @@ def test_release_binary_help_smokes_are_bounded() -> None:
     assert '[str(binary), "--help"]' in smoke_script
     assert "timeout=60" in smoke_script
     assert "_run_checked(" in smoke_script
+    assert '_run_help(binaries[f"powermem-mcp{exe_suffix}"])' in smoke_script
+
+
+def test_release_binary_mcp_entrypoint_uses_lightweight_cli() -> None:
+    builder = (ROOT / "scripts" / "build_binary_package.sh").read_text()
+
+    assert "from powermem.mcp.cli import main" in builder
+    assert "from powermem.mcp.server import main" not in builder
 
 
 def test_release_binary_tarball_bin_contents_are_exact() -> None:


### PR DESCRIPTION
## Summary

Fixes #1120.

- Route `powermem-mcp` and `python -m powermem.mcp` through a lightweight CLI parser so `--help` exits before importing the MCP server.
- Keep normal MCP server startup behavior delegated to the existing server implementation, including the default transport, `sse`/`stdio`, custom ports, and invalid-port fallback.
- Update release binary entrypoint generation and smoke checks so packaged `powermem-mcp --help` uses the same lightweight path.

## Validation

- `python -m pytest tests/unit/test_mcp_cli.py tests/unit/test_release_binary_ci.py -q`
- `python -m pytest tests/unit/test_optional_dependency_imports.py tests/unit/server/test_main_mcp_optional.py -q`
- `python -m py_compile src/powermem/mcp/args.py src/powermem/mcp/cli.py src/powermem/mcp/server.py src/powermem/mcp/__main__.py tests/unit/test_mcp_cli.py scripts/smoke_binary_package.py tests/unit/test_release_binary_ci.py`
- `bash -n scripts/build_binary_package.sh`
- `powermem-mcp --help`
- `python -m powermem.mcp --help`
- `git diff --check`
- `python scripts/check_package_versions.py`

The direct CLI E2E check returned 0, printed usage text, emitted no server-start log, and did not leave the default MCP port open.

Two independent code reviews found no blocking issues.
