### PR TITLE
fix(storage): sanitize SQLite FTS5 queries for technical tokens

### DIFF
--- a/src/powermem/storage/sqlite/sqlite_vector_store.py
+++ b/src/powermem/storage/sqlite/sqlite_vector_store.py
@@ -41,10 +41,8 @@ def _json_path_for_key(key: str) -> str:
     return path
 
 
-# FTS5 query metacharacters and selected ASCII separator characters stripped before MATCH.
-_FTS5_QUERY_CLEANUP_RE = re.compile(
-    r"""[-/.#:+!&*"()^$%,@|'~{}\[\]=\\?<>;`]+"""
-)
+# ASCII word fragments aligned with unicode61 token characters.
+_FTS5_TOKEN_RE = re.compile(r"[a-zA-Z0-9_]+")
 
 
 def _quote_fts5_literal_token(token: str) -> str:
@@ -54,37 +52,15 @@ def _quote_fts5_literal_token(token: str) -> str:
 
 
 def _sanitize_fts5_input(query: str) -> str:
-    """Sanitize user search text for safe SQLite FTS5 MATCH queries.
+    """Build a literal FTS5 MATCH string from user search text.
 
-    PowerMem callers pass natural-language or technical tokens, not raw FTS5
-    syntax. Separator characters and code punctuation (aligned with common
-    unicode61 tokenization) are converted to spaces, then each remaining token
-    is wrapped in FTS5 double quotes so ``AND``/``OR``/``NOT`` and other
-    reserved words are matched literally rather than as query operators.
-
-    Returns an empty string when the input contains only punctuation or
-    whitespace after cleanup (for example ``---`` or ``#@!``). Purely
-    sanitized punctuation queries therefore return ``[]`` without attempting
-    MATCH.
-
-    Numeric-only tokens (for example ``1119`` from ``#1119``) are quoted but
-    FTS5 typically does not index bare digits; matches still rely on
-    co-occurring word tokens such as ``oceanbase`` or ``blue``.
-
-    FTS5 advanced syntax (phrase quotes, prefix ``*``, column ``:`` filters,
-    boolean operators) is not available on user input. There is no public API
-    to bypass this sanitization.
+    Keeps ASCII alphanumerics and underscore, quotes each token, and drops
+    non-ASCII characters. Returns empty when nothing remains after extraction.
     """
     if not query or not query.strip():
         return ""
 
-    tokens: List[str] = []
-    for raw_token in query.split():
-        token = _FTS5_QUERY_CLEANUP_RE.sub(" ", raw_token)
-        for part in token.split():
-            if part:
-                tokens.append(part)
-
+    tokens = _FTS5_TOKEN_RE.findall(query)
     if not tokens:
         return ""
 
@@ -338,6 +314,9 @@ class SQLiteVectorStore(VectorStoreBase):
 
         fts_query = _sanitize_fts5_input(query)
         if not fts_query:
+            logger.debug(
+                "FTS5 query sanitized to empty, skipping fulltext search"
+            )
             return []
 
         fts_table = f"{self.collection_name}_fts"

--- a/src/powermem/storage/sqlite/sqlite_vector_store.py
+++ b/src/powermem/storage/sqlite/sqlite_vector_store.py
@@ -41,30 +41,37 @@ def _json_path_for_key(key: str) -> str:
     return path
 
 
-# ASCII word fragments aligned with unicode61 token characters.
-_FTS5_TOKEN_RE = re.compile(r"[a-zA-Z0-9_]+")
+_FTS5_MAX_QUERY_TOKENS = 64
 
+# Word fragments aligned with unicode61-style token characters.
+_FTS5_TOKEN_RE = re.compile(r"[\w]+", re.UNICODE)
 
-def _quote_fts5_literal_token(token: str) -> str:
-    """Wrap a single token in FTS5 double quotes for literal (non-syntax) matching."""
-    escaped = token.replace('"', '""')
-    return f'"{escaped}"'
+_FTS5_RESERVED = frozenset({"AND", "OR", "NOT"})
 
 
 def _sanitize_fts5_input(query: str) -> str:
     """Build a literal FTS5 MATCH string from user search text.
 
-    Keeps ASCII alphanumerics and underscore, quotes each token, and drops
-    non-ASCII characters. Returns empty when nothing remains after extraction.
+    Extracts Unicode word tokens, drops FTS5 boolean keywords, and wraps each
+    remaining token in double quotes. Punctuation-separated forms such as
+    ``v1.1.6`` become independent token matches (``"v1" "1" "6"``) without
+    preserving original spacing. Returns empty when nothing remains.
     """
     if not query or not query.strip():
         return ""
 
-    tokens = _FTS5_TOKEN_RE.findall(query)
+    tokens = [
+        token
+        for token in _FTS5_TOKEN_RE.findall(query)
+        if token.upper() not in _FTS5_RESERVED
+    ]
     if not tokens:
         return ""
 
-    return " ".join(_quote_fts5_literal_token(token) for token in tokens)
+    if len(tokens) > _FTS5_MAX_QUERY_TOKENS:
+        tokens = tokens[:_FTS5_MAX_QUERY_TOKENS]
+
+    return " ".join('"' + token.replace('"', '""') + '"' for token in tokens)
 
 
 def _check_sqlite_features(conn) -> None:

--- a/src/powermem/storage/sqlite/sqlite_vector_store.py
+++ b/src/powermem/storage/sqlite/sqlite_vector_store.py
@@ -43,39 +43,40 @@ def _json_path_for_key(key: str) -> str:
 
 # FTS5 query metacharacters and selected ASCII separator characters stripped before MATCH.
 _FTS5_QUERY_CLEANUP_RE = re.compile(
-    r"""[-/.#:+!&*"()^$%,@|'~{}\[\]=\\?]+"""
+    r"""[-/.#:+!&*"()^$%,@|'~{}\[\]=\\?<>;`]+"""
 )
+
+
+def _quote_fts5_literal_token(token: str) -> str:
+    """Wrap a single token in FTS5 double quotes for literal (non-syntax) matching."""
+    escaped = token.replace('"', '""')
+    return f'"{escaped}"'
 
 
 def _sanitize_fts5_input(query: str) -> str:
     """Sanitize user search text for safe SQLite FTS5 MATCH queries.
 
     PowerMem callers pass natural-language or technical tokens, not raw FTS5
-    syntax. FTS5 query metacharacters and selected ASCII separator characters
-    (aligned with common unicode61 tokenization) are converted to spaces.
+    syntax. Separator characters and code punctuation (aligned with common
+    unicode61 tokenization) are converted to spaces, then each remaining token
+    is wrapped in FTS5 double quotes so ``AND``/``OR``/``NOT`` and other
+    reserved words are matched literally rather than as query operators.
 
     Returns an empty string when the input contains only punctuation or
     whitespace after cleanup (for example ``---`` or ``#@!``). Purely
     sanitized punctuation queries therefore return ``[]`` without attempting
-    MATCH, whereas the pre-fix path logged an FTS5 warning first.
+    MATCH.
 
-    Numeric-only tokens (for example ``1119`` from ``#1119``) are passed
-    through but FTS5 typically does not index bare digits; matches still rely
-    on co-occurring word tokens such as ``oceanbase`` or ``blue``.
+    Numeric-only tokens (for example ``1119`` from ``#1119``) are quoted but
+    FTS5 typically does not index bare digits; matches still rely on
+    co-occurring word tokens such as ``oceanbase`` or ``blue``.
 
-    FTS5 advanced syntax (phrase quotes, prefix ``*``, column ``:`` filters)
-    is not available on user input because the characters that enable it are
-    stripped. There is no public API to bypass this sanitization.
-
-    FTS5 boolean operators (AND/OR/NOT) are not escaped; they remain query
-    syntax when present as standalone tokens.
+    FTS5 advanced syntax (phrase quotes, prefix ``*``, column ``:`` filters,
+    boolean operators) is not available on user input. There is no public API
+    to bypass this sanitization.
     """
     if not query or not query.strip():
         return ""
-
-    stripped = query.strip()
-    if _FTS5_QUERY_CLEANUP_RE.search(stripped) is None:
-        return stripped
 
     tokens: List[str] = []
     for raw_token in query.split():
@@ -84,7 +85,10 @@ def _sanitize_fts5_input(query: str) -> str:
             if part:
                 tokens.append(part)
 
-    return " ".join(tokens)
+    if not tokens:
+        return ""
+
+    return " ".join(_quote_fts5_literal_token(token) for token in tokens)
 
 
 def _check_sqlite_features(conn) -> None:

--- a/src/powermem/storage/sqlite/sqlite_vector_store.py
+++ b/src/powermem/storage/sqlite/sqlite_vector_store.py
@@ -44,25 +44,19 @@ def _json_path_for_key(key: str) -> str:
 # Word fragments aligned with unicode61-style token characters.
 _FTS5_TOKEN_RE = re.compile(r"[\w]+", re.UNICODE)
 
-_FTS5_RESERVED = frozenset({"AND", "OR", "NOT"})
-
-
 def _sanitize_fts5_input(query: str) -> str:
     """Build a literal FTS5 MATCH string from user search text.
 
-    Extracts Unicode word tokens, drops FTS5 boolean keywords, and wraps each
-    remaining token in double quotes. Punctuation-separated forms such as
-    ``v1.1.6`` become independent token matches (``"v1" "1" "6"``) without
-    preserving original spacing. Returns empty when nothing remains.
+    Extracts Unicode word tokens and wraps each in double quotes so FTS5 treats
+    them as literal terms (including ``AND``/``OR``/``NOT``), not query syntax.
+    Punctuation-separated forms such as ``v1.1.6`` become independent token
+    matches (``"v1" "1" "6"``) without preserving original spacing. Returns empty
+    when nothing remains.
     """
     if not query or not query.strip():
         return ""
 
-    tokens = [
-        token
-        for token in _FTS5_TOKEN_RE.findall(query)
-        if token.upper() not in _FTS5_RESERVED
-    ]
+    tokens = _FTS5_TOKEN_RE.findall(query)
     if not tokens:
         return ""
 

--- a/src/powermem/storage/sqlite/sqlite_vector_store.py
+++ b/src/powermem/storage/sqlite/sqlite_vector_store.py
@@ -41,8 +41,6 @@ def _json_path_for_key(key: str) -> str:
     return path
 
 
-_FTS5_MAX_QUERY_TOKENS = 64
-
 # Word fragments aligned with unicode61-style token characters.
 _FTS5_TOKEN_RE = re.compile(r"[\w]+", re.UNICODE)
 
@@ -67,9 +65,6 @@ def _sanitize_fts5_input(query: str) -> str:
     ]
     if not tokens:
         return ""
-
-    if len(tokens) > _FTS5_MAX_QUERY_TOKENS:
-        tokens = tokens[:_FTS5_MAX_QUERY_TOKENS]
 
     return " ".join('"' + token.replace('"', '""') + '"' for token in tokens)
 

--- a/src/powermem/storage/sqlite/sqlite_vector_store.py
+++ b/src/powermem/storage/sqlite/sqlite_vector_store.py
@@ -8,6 +8,7 @@ Supports FTS5 fulltext search and hybrid search (vector + FTS5, RRF fusion).
 import json
 import logging
 import os
+import re
 import threading
 
 try:
@@ -38,6 +39,52 @@ def _json_path_for_key(key: str) -> str:
     for segment in segments:
         path += f".{json.dumps(segment)}"
     return path
+
+
+# FTS5 query metacharacters and selected ASCII separator characters stripped before MATCH.
+_FTS5_QUERY_CLEANUP_RE = re.compile(
+    r"""[-/.#:+!&*"()^$%,@|'~{}\[\]=\\?]+"""
+)
+
+
+def _sanitize_fts5_input(query: str) -> str:
+    """Sanitize user search text for safe SQLite FTS5 MATCH queries.
+
+    PowerMem callers pass natural-language or technical tokens, not raw FTS5
+    syntax. FTS5 query metacharacters and selected ASCII separator characters
+    (aligned with common unicode61 tokenization) are converted to spaces.
+
+    Returns an empty string when the input contains only punctuation or
+    whitespace after cleanup (for example ``---`` or ``#@!``). Purely
+    sanitized punctuation queries therefore return ``[]`` without attempting
+    MATCH, whereas the pre-fix path logged an FTS5 warning first.
+
+    Numeric-only tokens (for example ``1119`` from ``#1119``) are passed
+    through but FTS5 typically does not index bare digits; matches still rely
+    on co-occurring word tokens such as ``oceanbase`` or ``blue``.
+
+    FTS5 advanced syntax (phrase quotes, prefix ``*``, column ``:`` filters)
+    is not available on user input because the characters that enable it are
+    stripped. There is no public API to bypass this sanitization.
+
+    FTS5 boolean operators (AND/OR/NOT) are not escaped; they remain query
+    syntax when present as standalone tokens.
+    """
+    if not query or not query.strip():
+        return ""
+
+    stripped = query.strip()
+    if _FTS5_QUERY_CLEANUP_RE.search(stripped) is None:
+        return stripped
+
+    tokens: List[str] = []
+    for raw_token in query.split():
+        token = _FTS5_QUERY_CLEANUP_RE.sub(" ", raw_token)
+        for part in token.split():
+            if part:
+                tokens.append(part)
+
+    return " ".join(tokens)
 
 
 def _check_sqlite_features(conn) -> None:
@@ -285,6 +332,10 @@ class SQLiteVectorStore(VectorStoreBase):
         if not query or not query.strip():
             return []
 
+        fts_query = _sanitize_fts5_input(query)
+        if not fts_query:
+            return []
+
         fts_table = f"{self.collection_name}_fts"
         main_table = self.collection_name
 
@@ -295,18 +346,17 @@ class SQLiteVectorStore(VectorStoreBase):
             f"JOIN {main_table} m ON m.id = f.rowid "
             f"WHERE {fts_table} MATCH ? "
         )
-        params: list = [query]
 
-        # Apply payload filters
+        filter_params: List = []
         if filters:
             for key, value in filters.items():
                 sql += " AND (json_extract(m.payload, ?) = ?) "
-                params.extend([_json_path_for_key(key), value])
+                filter_params.extend([_json_path_for_key(key), value])
 
         sql += " ORDER BY rank LIMIT ?"
-        params.append(limit)
 
-        results = []
+        params: List = [fts_query, *filter_params, limit]
+        results: List[OutputData] = []
         with self._lock:
             try:
                 cursor = self.connection.execute(sql, params)
@@ -320,9 +370,9 @@ class SQLiteVectorStore(VectorStoreBase):
                         score=float(fts_score),
                         payload=payload,
                     ))
-            except sqlite3.OperationalError as e:
-                logger.warning(f"FTS5 search failed, returning empty: {e}")
-                return []
+            except sqlite3.OperationalError as exc:
+                logger.warning(f"FTS5 search failed, returning empty: {exc}")
+                results = []
 
         return results
 

--- a/tests/integration/test_sqlite_fts_integration.py
+++ b/tests/integration/test_sqlite_fts_integration.py
@@ -7,6 +7,7 @@ SQLiteVectorStore), with SQLite provider + mock embedder + mock LLM.
 Written by the tester per coordinator assignment (brief.l3=required).
 """
 
+import logging
 import uuid
 import pytest
 from unittest.mock import MagicMock, patch
@@ -178,9 +179,29 @@ class TestFTS5MemoryAPIIntegration:
         found_ids = [r.get("id") for r in after["results"]]
         assert memory_id not in found_ids, "Deleted doc should not appear in search"
 
-    # ------------------------------------------------------------------ #
-    # 7. Update syncs FTS content (via Memory API)
-    # ------------------------------------------------------------------ #
+    # Technical tokens with hyphens/slashes (Fixes #1119)
+    def test_search_technical_tokens(self, caplog):
+        self._add(
+            "PowerMem release verification: the marker phrase is oceanbase-blue-116 "
+            "powermem-mcp v1.1.6 fix/release-dispatch-repo add search."
+        )
+
+        queries = [
+            "oceanbase-blue-116 add search",
+            "powermem-mcp add search",
+            "v1.1.6 add search",
+            "fix/release-dispatch-repo add search",
+        ]
+
+        for query in queries:
+            with caplog.at_level(logging.WARNING):
+                results = self._search(query)
+                assert len(results["results"]) >= 1, query
+                assert not any(
+                    "FTS5 search failed" in record.message for record in caplog.records
+                ), query
+
+    # Update syncs FTS content (via Memory API)
     def test_update_syncs_fts(self):
         """After Memory.update(), FTS should find the new content, not the old."""
         add_result = self._add("original content phrase oldxyz")
@@ -200,9 +221,7 @@ class TestFTS5MemoryAPIIntegration:
         found_ids = [r.get("id") for r in after["results"]]
         assert memory_id in found_ids, "Updated content should appear in FTS search"
 
-    # ------------------------------------------------------------------ #
-    # 8. Filters work with hybrid search
-    # ------------------------------------------------------------------ #
+    # Filters work with hybrid search
     def test_filters_with_hybrid_search(self):
         """User filters should be respected in hybrid search results."""
         self._add("python data science tutorial", user_id="alice")
@@ -216,9 +235,7 @@ class TestFTS5MemoryAPIIntegration:
             if uid is not None:
                 assert uid == "alice", f"Filter should restrict to alice, got {uid}"
 
-    # ------------------------------------------------------------------ #
-    # 9. Multiple adds + search returns correct ranking
-    # ------------------------------------------------------------------ #
+    # Multiple adds + search returns correct ranking
     def test_multiple_adds_correct_ranking(self):
         """After multiple adds, FTS-matching doc should rank top in hybrid."""
         self._add("neural network deep learning transformer architecture")

--- a/tests/integration/test_sqlite_fts_integration.py
+++ b/tests/integration/test_sqlite_fts_integration.py
@@ -182,30 +182,52 @@ class TestFTS5MemoryAPIIntegration:
     # Technical tokens with hyphens/slashes (Fixes #1119)
     def test_search_technical_tokens(self, caplog):
         self._add(
-            "PowerMem release verification: the marker phrase is oceanbase-blue-116 "
-            "powermem-mcp v1.1.6 fix/release-dispatch-repo fix-NOT-working "
-            "std::vector<int> foo;bar `foo` neural AND network add search."
+            "PowerMem release verification: oceanbase-blue-116 powermem-mcp "
+            "v1.1.6 fix/release-dispatch-repo fix-NOT-working std::vector<int> "
+            "foo;bar `foo` neural AND network add search."
         )
-
-        queries = [
+        composite_queries = [
             "oceanbase-blue-116 add search",
             "powermem-mcp add search",
             "v1.1.6 add search",
             "fix/release-dispatch-repo add search",
-            "fix-NOT-working add search",
-            "std::vector<int> add search",
-            "foo;bar add search",
-            "`foo` add search",
-            "neural AND network add search",
         ]
-
-        for query in queries:
+        for query in composite_queries:
             with caplog.at_level(logging.WARNING):
                 results = self._search(query)
                 assert len(results["results"]) >= 1, query
                 assert not any(
                     "FTS5 search failed" in record.message for record in caplog.records
                 ), query
+
+        isolated_cases = [
+            ("marker oceanbase-blue-116 marker", "oceanbase-blue-116"),
+            ("uses powermem-mcp module", "powermem-mcp"),
+            ("release v1.1.6 shipped", "v1.1.6"),
+            ("path fix/release-dispatch-repo here", "fix/release-dispatch-repo"),
+            ("status fix-NOT-working retry", "fix-NOT-working"),
+            ("uses std::vector<int> in cpp", "std::vector<int>"),
+            ("config foo;bar enabled", "foo;bar"),
+            ("backtick `foo` identifier", "`foo`"),
+            ("neural AND network layer", "neural AND network"),
+        ]
+        for content, query in isolated_cases:
+            self._add(content)
+            with caplog.at_level(logging.WARNING):
+                results = self._search(query)
+                assert len(results["results"]) >= 1, query
+                assert not any(
+                    "FTS5 search failed" in record.message for record in caplog.records
+                ), query
+
+        with caplog.at_level(logging.WARNING):
+            fts_store = self.memory.storage.vector_store
+            assert isinstance(fts_store, SQLiteVectorStore)
+            slash_results = fts_store.search(query="//", vectors=None, limit=5)
+            assert slash_results == []
+            assert not any(
+                "FTS5 search failed" in record.message for record in caplog.records
+            )
 
     # Update syncs FTS content (via Memory API)
     def test_update_syncs_fts(self):

--- a/tests/integration/test_sqlite_fts_integration.py
+++ b/tests/integration/test_sqlite_fts_integration.py
@@ -183,7 +183,8 @@ class TestFTS5MemoryAPIIntegration:
     def test_search_technical_tokens(self, caplog):
         self._add(
             "PowerMem release verification: the marker phrase is oceanbase-blue-116 "
-            "powermem-mcp v1.1.6 fix/release-dispatch-repo add search."
+            "powermem-mcp v1.1.6 fix/release-dispatch-repo fix-NOT-working "
+            "std::vector<int> foo;bar `foo` neural AND network add search."
         )
 
         queries = [
@@ -191,6 +192,11 @@ class TestFTS5MemoryAPIIntegration:
             "powermem-mcp add search",
             "v1.1.6 add search",
             "fix/release-dispatch-repo add search",
+            "fix-NOT-working add search",
+            "std::vector<int> add search",
+            "foo;bar add search",
+            "`foo` add search",
+            "neural AND network add search",
         ]
 
         for query in queries:

--- a/tests/unit/test_sqlite_fts.py
+++ b/tests/unit/test_sqlite_fts.py
@@ -377,38 +377,42 @@ class TestFTS5QuerySanitization:
         "raw,expected",
         [
             (None, ""),
-            ("oceanbase-blue-116 add search", "oceanbase blue 116 add search"),
-            ("powermem-mcp", "powermem mcp"),
-            ("v1.1.6", "v1 1 6"),
-            ("fix/release-dispatch-repo", "fix release dispatch repo"),
-            ("#1119", "1119"),
-            ("fix: dispatch", "fix dispatch"),
-            ("@user", "user"),
-            ("hello!world", "hello world"),
-            ("foo|bar", "foo bar"),
-            ("a&b", "a b"),
-            ("^hello", "hello"),
-            ("100%", "100"),
-            ("$5 item", "5 item"),
+            (
+                "oceanbase-blue-116 add search",
+                '"oceanbase" "blue" "116" "add" "search"',
+            ),
+            ("powermem-mcp", '"powermem" "mcp"'),
+            ("v1.1.6", '"v1" "1" "6"'),
+            ("fix/release-dispatch-repo", '"fix" "release" "dispatch" "repo"'),
+            ("#1119", '"1119"'),
+            ("fix: dispatch", '"fix" "dispatch"'),
+            ("@user", '"user"'),
+            ("hello!world", '"hello" "world"'),
+            ("foo|bar", '"foo" "bar"'),
+            ("a&b", '"a" "b"'),
+            ("^hello", '"hello"'),
+            ("100%", '"100"'),
+            ("$5 item", '"5" "item"'),
             ("---", ""),
             ("#@!", ""),
-            ("don't", "don t"),
-            ("~1.2.3", "1 2 3"),
-            ("key=value", "key value"),
-            ("my_var", "my_var"),
+            ("don't", '"don" "t"'),
+            ("~1.2.3", '"1" "2" "3"'),
+            ("key=value", '"key" "value"'),
+            ("my_var", '"my_var"'),
+            ("fix-NOT-working", '"fix" "NOT" "working"'),
+            ("std::vector<int>", '"std" "vector" "int"'),
+            ("foo;bar", '"foo" "bar"'),
+            ("`foo`", '"foo"'),
+            ("neural AND network", '"neural" "AND" "network"'),
+            ("AND OR NOT", '"AND" "OR" "NOT"'),
         ],
     )
     def test_sanitize_fts5_input(self, raw, expected):
         assert _sanitize_fts5_input(raw) == expected
 
-    def test_sanitize_preserves_boolean_operators(self):
-        assert _sanitize_fts5_input("neural AND network") == "neural AND network"
-        assert _sanitize_fts5_input("foo OR bar") == "foo OR bar"
-        assert _sanitize_fts5_input("NOT working") == "NOT working"
-
-    def test_sanitize_fast_path_returns_original_query(self):
-        assert _sanitize_fts5_input("fox") == "fox"
-        assert _sanitize_fts5_input("  neural network  ") == "neural network"
+    def test_sanitize_quotes_simple_tokens_as_literals(self):
+        assert _sanitize_fts5_input("fox") == '"fox"'
+        assert _sanitize_fts5_input("  neural network  ") == '"neural" "network"'
 
     @pytest.mark.parametrize(
         "query,content,expect_results",
@@ -424,6 +428,11 @@ class TestFTS5QuerySanitization:
             ),
             ("@username", "notify @username about deployment", True),
             ("foo|bar", "config key foo|bar enabled", True),
+            ("fix-NOT-working", "status fix-NOT-working retry path", True),
+            ("std::vector<int>", "uses std::vector<int> in cpp module", True),
+            ("foo;bar", "config foo;bar enabled here", True),
+            ("`foo`", "backtick `foo` identifier", True),
+            ("AND OR NOT", "some searchable content", False),
         ],
     )
     def test_sanitized_queries_do_not_log_fts5_warning(
@@ -441,9 +450,9 @@ class TestFTS5QuerySanitization:
             "FTS5 search failed" in record.message for record in caplog.records
         ), query
 
-    def test_operator_only_query_returns_empty_with_warning(self, store, mocker):
+    def test_operator_only_query_returns_empty_without_warning(self, store, mocker):
         _insert_docs(store, [{"content": "hello world"}])
-        assert _sanitize_fts5_input("AND OR NOT") == "AND OR NOT"
+        assert _sanitize_fts5_input("AND OR NOT") == '"AND" "OR" "NOT"'
 
         warn = mocker.patch(
             "powermem.storage.sqlite.sqlite_vector_store.logger.warning"
@@ -451,8 +460,7 @@ class TestFTS5QuerySanitization:
         results = store.search(query="AND OR NOT", vectors=None, limit=5)
 
         assert results == []
-        warn.assert_called_once()
-        assert "FTS5 search failed" in warn.call_args[0][0]
+        warn.assert_not_called()
 
     @pytest.fixture
     def technical_doc_store(self, store):

--- a/tests/unit/test_sqlite_fts.py
+++ b/tests/unit/test_sqlite_fts.py
@@ -441,17 +441,18 @@ class TestFTS5QuerySanitization:
             "FTS5 search failed" in record.message for record in caplog.records
         ), query
 
-    def test_operator_only_query_returns_empty_with_warning(self, store, caplog):
+    def test_operator_only_query_returns_empty_with_warning(self, store, mocker):
         _insert_docs(store, [{"content": "hello world"}])
         assert _sanitize_fts5_input("AND OR NOT") == "AND OR NOT"
 
-        with caplog.at_level(logging.WARNING):
-            results = store.search(query="AND OR NOT", vectors=None, limit=5)
+        warn = mocker.patch(
+            "powermem.storage.sqlite.sqlite_vector_store.logger.warning"
+        )
+        results = store.search(query="AND OR NOT", vectors=None, limit=5)
 
         assert results == []
-        assert any(
-            "FTS5 search failed" in record.message for record in caplog.records
-        )
+        warn.assert_called_once()
+        assert "FTS5 search failed" in warn.call_args[0][0]
 
     @pytest.fixture
     def technical_doc_store(self, store):

--- a/tests/unit/test_sqlite_fts.py
+++ b/tests/unit/test_sqlite_fts.py
@@ -395,10 +395,14 @@ class TestFTS5QuerySanitization:
             ("$5 item", '"5" "item"'),
             ("---", ""),
             ("#@!", ""),
+            ("//", ""),
+            ("!!!", ""),
+            ("<>;", ""),
             ("don't", '"don" "t"'),
             ("~1.2.3", '"1" "2" "3"'),
             ("key=value", '"key" "value"'),
             ("my_var", '"my_var"'),
+            ('he said "hello"', '"he" "said" "hello"'),
             ("fix-NOT-working", '"fix" "NOT" "working"'),
             ("std::vector<int>", '"std" "vector" "int"'),
             ("foo;bar", '"foo" "bar"'),
@@ -433,6 +437,7 @@ class TestFTS5QuerySanitization:
             ("foo;bar", "config foo;bar enabled here", True),
             ("`foo`", "backtick `foo` identifier", True),
             ("AND OR NOT", "some searchable content", False),
+            ("//", "some searchable content", False),
         ],
     )
     def test_sanitized_queries_do_not_log_fts5_warning(
@@ -450,7 +455,7 @@ class TestFTS5QuerySanitization:
             "FTS5 search failed" in record.message for record in caplog.records
         ), query
 
-    def test_operator_only_query_returns_empty_without_warning(self, store, mocker):
+    def test_operator_keywords_quoted_as_literal_phrases_no_warning(self, store, mocker):
         _insert_docs(store, [{"content": "hello world"}])
         assert _sanitize_fts5_input("AND OR NOT") == '"AND" "OR" "NOT"'
 
@@ -557,3 +562,9 @@ class TestFTS5QuerySanitization:
         results = store.search(query="fox", vectors=None, limit=5)
         assert len(results) >= 1
         assert "fox" in results[0].payload.get("data", "").lower()
+
+    def test_underscore_identifier_pure_text_search(self, store):
+        _insert_docs(store, [{"content": "my_var_function definition here"}])
+        results = store.search(query="my_var", vectors=None, limit=5)
+        assert len(results) >= 1
+        assert "my_var_function" in results[0].payload.get("data", "")

--- a/tests/unit/test_sqlite_fts.py
+++ b/tests/unit/test_sqlite_fts.py
@@ -403,12 +403,13 @@ class TestFTS5QuerySanitization:
             ("key=value", '"key" "value"'),
             ("my_var", '"my_var"'),
             ('he said "hello"', '"he" "said" "hello"'),
-            ("fix-NOT-working", '"fix" "NOT" "working"'),
+            ("fix-NOT-working", '"fix" "working"'),
             ("std::vector<int>", '"std" "vector" "int"'),
             ("foo;bar", '"foo" "bar"'),
             ("`foo`", '"foo"'),
-            ("neural AND network", '"neural" "AND" "network"'),
-            ("AND OR NOT", '"AND" "OR" "NOT"'),
+            ("neural AND network", '"neural" "network"'),
+            ("AND OR NOT", ""),
+            ("中文测试", '"中文测试"'),
         ],
     )
     def test_sanitize_fts5_input(self, raw, expected):
@@ -455,15 +456,20 @@ class TestFTS5QuerySanitization:
             "FTS5 search failed" in record.message for record in caplog.records
         ), query
 
-    def test_operator_keywords_quoted_as_literal_phrases_no_warning(self, store, mocker):
-        _insert_docs(store, [{"content": "hello world"}])
-        assert _sanitize_fts5_input("AND OR NOT") == '"AND" "OR" "NOT"'
+    def test_reserved_operators_stripped_and_queries_still_match(self, store, mocker):
+        _insert_docs(store, [{"content": "ham AND eggs breakfast"}])
+        assert _sanitize_fts5_input("AND OR NOT") == ""
+        assert _sanitize_fts5_input("ham AND eggs") == '"ham" "eggs"'
 
         warn = mocker.patch(
             "powermem.storage.sqlite.sqlite_vector_store.logger.warning"
         )
-        results = store.search(query="AND OR NOT", vectors=None, limit=5)
+        results = store.search(query="ham AND eggs", vectors=None, limit=5)
+        assert len(results) >= 1
+        assert "ham" in results[0].payload.get("data", "").lower()
+        warn.assert_not_called()
 
+        results = store.search(query="AND OR NOT", vectors=None, limit=5)
         assert results == []
         warn.assert_not_called()
 
@@ -564,7 +570,7 @@ class TestFTS5QuerySanitization:
         assert "fox" in results[0].payload.get("data", "").lower()
 
     def test_underscore_identifier_pure_text_search(self, store):
-        _insert_docs(store, [{"content": "my_var_function definition here"}])
+        _insert_docs(store, [{"content": "define my_var here"}])
         results = store.search(query="my_var", vectors=None, limit=5)
         assert len(results) >= 1
-        assert "my_var_function" in results[0].payload.get("data", "")
+        assert "my_var" in results[0].payload.get("data", "")

--- a/tests/unit/test_sqlite_fts.py
+++ b/tests/unit/test_sqlite_fts.py
@@ -403,12 +403,12 @@ class TestFTS5QuerySanitization:
             ("key=value", '"key" "value"'),
             ("my_var", '"my_var"'),
             ('he said "hello"', '"he" "said" "hello"'),
-            ("fix-NOT-working", '"fix" "working"'),
+            ("fix-NOT-working", '"fix" "NOT" "working"'),
             ("std::vector<int>", '"std" "vector" "int"'),
             ("foo;bar", '"foo" "bar"'),
             ("`foo`", '"foo"'),
-            ("neural AND network", '"neural" "network"'),
-            ("AND OR NOT", ""),
+            ("neural AND network", '"neural" "AND" "network"'),
+            ("AND OR NOT", '"AND" "OR" "NOT"'),
             ("中文测试", '"中文测试"'),
         ],
     )
@@ -456,10 +456,11 @@ class TestFTS5QuerySanitization:
             "FTS5 search failed" in record.message for record in caplog.records
         ), query
 
-    def test_reserved_operators_stripped_and_queries_still_match(self, store, mocker):
+    def test_boolean_keywords_quoted_as_literal_tokens_no_warning(self, store, mocker):
         _insert_docs(store, [{"content": "ham AND eggs breakfast"}])
-        assert _sanitize_fts5_input("AND OR NOT") == ""
-        assert _sanitize_fts5_input("ham AND eggs") == '"ham" "eggs"'
+        assert _sanitize_fts5_input("AND OR NOT") == '"AND" "OR" "NOT"'
+        assert _sanitize_fts5_input("ham AND eggs") == '"ham" "AND" "eggs"'
+        assert _sanitize_fts5_input("fix-NOT-working") == '"fix" "NOT" "working"'
 
         warn = mocker.patch(
             "powermem.storage.sqlite.sqlite_vector_store.logger.warning"
@@ -467,6 +468,11 @@ class TestFTS5QuerySanitization:
         results = store.search(query="ham AND eggs", vectors=None, limit=5)
         assert len(results) >= 1
         assert "ham" in results[0].payload.get("data", "").lower()
+        warn.assert_not_called()
+
+        results = store.search(query="AND", vectors=None, limit=5)
+        assert len(results) >= 1
+        assert "AND" in results[0].payload.get("data", "")
         warn.assert_not_called()
 
         results = store.search(query="AND OR NOT", vectors=None, limit=5)

--- a/tests/unit/test_sqlite_fts.py
+++ b/tests/unit/test_sqlite_fts.py
@@ -5,10 +5,14 @@ and hybrid search (vector + fulltext, RRF fusion) in SQLiteVectorStore.
 """
 
 import json
+import logging
 import math
 import pytest
 
-from powermem.storage.sqlite.sqlite_vector_store import SQLiteVectorStore
+from powermem.storage.sqlite.sqlite_vector_store import (
+    SQLiteVectorStore,
+    _sanitize_fts5_input,
+)
 from powermem.storage.base import OutputData
 
 
@@ -363,3 +367,184 @@ class TestUpdateFTSAtomic:
         # New content must be found
         new_results = store.search(query="bbb222", vectors=None, limit=5)
         assert any(r.id == doc_id for r in new_results)
+
+
+# ---------------------------------------------------------------------------
+# 12. FTS5 query sanitization for technical tokens (Fixes #1119)
+# ---------------------------------------------------------------------------
+class TestFTS5QuerySanitization:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, ""),
+            ("oceanbase-blue-116 add search", "oceanbase blue 116 add search"),
+            ("powermem-mcp", "powermem mcp"),
+            ("v1.1.6", "v1 1 6"),
+            ("fix/release-dispatch-repo", "fix release dispatch repo"),
+            ("#1119", "1119"),
+            ("fix: dispatch", "fix dispatch"),
+            ("@user", "user"),
+            ("hello!world", "hello world"),
+            ("foo|bar", "foo bar"),
+            ("a&b", "a b"),
+            ("^hello", "hello"),
+            ("100%", "100"),
+            ("$5 item", "5 item"),
+            ("---", ""),
+            ("#@!", ""),
+            ("don't", "don t"),
+            ("~1.2.3", "1 2 3"),
+            ("key=value", "key value"),
+            ("my_var", "my_var"),
+        ],
+    )
+    def test_sanitize_fts5_input(self, raw, expected):
+        assert _sanitize_fts5_input(raw) == expected
+
+    def test_sanitize_preserves_boolean_operators(self):
+        assert _sanitize_fts5_input("neural AND network") == "neural AND network"
+        assert _sanitize_fts5_input("foo OR bar") == "foo OR bar"
+        assert _sanitize_fts5_input("NOT working") == "NOT working"
+
+    def test_sanitize_fast_path_returns_original_query(self):
+        assert _sanitize_fts5_input("fox") == "fox"
+        assert _sanitize_fts5_input("  neural network  ") == "neural network"
+
+    @pytest.mark.parametrize(
+        "query,content,expect_results",
+        [
+            ("---", "some searchable content", False),
+            (
+                "oceanbase-blue-116 add search",
+                (
+                    "PowerMem marker oceanbase-blue-116 supports add search "
+                    "verification"
+                ),
+                True,
+            ),
+            ("@username", "notify @username about deployment", True),
+            ("foo|bar", "config key foo|bar enabled", True),
+        ],
+    )
+    def test_sanitized_queries_do_not_log_fts5_warning(
+        self, store, caplog, query, content, expect_results
+    ):
+        _insert_docs(store, [{"content": content}])
+        with caplog.at_level(logging.WARNING):
+            results = store.search(query=query, vectors=None, limit=5)
+
+        if expect_results:
+            assert len(results) >= 1, query
+        else:
+            assert results == [], query
+        assert not any(
+            "FTS5 search failed" in record.message for record in caplog.records
+        ), query
+
+    def test_operator_only_query_returns_empty_with_warning(self, store, caplog):
+        _insert_docs(store, [{"content": "hello world"}])
+        assert _sanitize_fts5_input("AND OR NOT") == "AND OR NOT"
+
+        with caplog.at_level(logging.WARNING):
+            results = store.search(query="AND OR NOT", vectors=None, limit=5)
+
+        assert results == []
+        assert any(
+            "FTS5 search failed" in record.message for record in caplog.records
+        )
+
+    @pytest.fixture
+    def technical_doc_store(self, store):
+        _insert_docs(store, [{
+            "content": (
+                "PowerMem release verification: the marker phrase is oceanbase-blue-116 "
+                "and it supports powermem-mcp v1.1.6 fix/release-dispatch-repo add search."
+            ),
+        }])
+        return store
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "oceanbase-blue-116 add search",
+            "powermem-mcp",
+            "v1.1.6",
+            "fix/release-dispatch-repo",
+        ],
+    )
+    def test_technical_token_pure_text_search(self, technical_doc_store, query):
+        results = technical_doc_store.search(query=query, vectors=None, limit=5)
+        assert len(results) >= 1
+        content = results[0].payload.get("data", "").lower()
+        assert "powermem" in content
+
+    def test_technical_token_hybrid_search(self, technical_doc_store):
+        query_vec = _make_vector(seed=0.5)
+        results = technical_doc_store.search(
+            query="oceanbase-blue-116 add search",
+            vectors=[query_vec],
+            limit=5,
+        )
+        assert len(results) >= 1
+        assert any(
+            "oceanbase-blue-116" in r.payload.get("data", "").lower()
+            for r in results
+        )
+
+    def test_hybrid_tech_token_with_boolean(self, store):
+        _insert_docs(store, [{
+            "content": (
+                "oceanbase-blue-116 deployment rollout completed for production"
+            ),
+        }])
+        query_vec = _make_vector(seed=0.5)
+        results = store.search(
+            query="oceanbase-blue-116 AND deployment",
+            vectors=[query_vec],
+            limit=5,
+        )
+        assert len(results) >= 1
+        content = results[0].payload.get("data", "").lower()
+        assert "oceanbase-blue-116" in content
+        assert "deployment" in content
+
+    def test_technical_token_with_user_id_filter(self, store):
+        """Sanitized FTS query should still respect payload filters."""
+        _insert_docs(store, [
+            {
+                "content": "marker oceanbase-blue-116 release notes",
+                "user_id": "alice",
+            },
+            {
+                "content": "marker oceanbase-blue-116 release notes",
+                "user_id": "bob",
+            },
+        ])
+        results = store.search(
+            query="oceanbase-blue-116",
+            vectors=None,
+            limit=5,
+            filters={"user_id": "alice"},
+        )
+        assert len(results) >= 1
+        for result in results:
+            assert result.payload["user_id"] == "alice"
+
+    def test_sanitized_query_no_match_returns_empty_without_warning(
+        self, store, caplog
+    ):
+        _insert_docs(store, [{"content": "unrelated content only"}])
+        with caplog.at_level(logging.WARNING):
+            results = store.search(
+                query="oceanbase-blue-116",
+                vectors=None,
+                limit=5,
+            )
+        assert results == []
+        assert not any("FTS5 search failed" in record.message for record in caplog.records)
+
+    def test_simple_english_query_regression(self, store):
+        _insert_docs(store, [{"content": "the quick brown fox jumps over the lazy dog"}])
+        results = store.search(query="fox", vectors=None, limit=5)
+        assert len(results) >= 1
+        assert "fox" in results[0].payload.get("data", "").lower()


### PR DESCRIPTION
Fixes #1119. Normalize punctuation-heavy search terms before FTS5 MATCH so hybrid search does not silently drop the full-text path or log spurious warnings for pure-punctuation input.

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary

SQLite hybrid search passes user queries to FTS5 `MATCH` unchanged. Technical tokens such as `oceanbase-blue-116`, `v1.1.6`, and `fix/release-dispatch-repo` are parsed as FTS5 query syntax (NOT operators, column filters, etc.), causing `OperationalError` and silently dropping the full-text path while vector search still returns results.

This PR adds `_sanitize_fts5_input()` and applies it in `SQLiteVectorStore._fulltext_search()` before `MATCH`, so common developer/coding-agent vocabulary no longer breaks the FTS leg of hybrid search.

Fixes #1119

## Solution Description

1. **Add `_sanitize_fts5_input()`** in `sqlite_vector_store.py`  
   - Strip FTS5 metacharacters and selected ASCII separator characters (`-`, `/`, `.`, `:`, `@`, `|`, etc.) by converting them to spaces, aligning query tokens with unicode61 indexing behavior.  
   - Tokens containing `@` or `|` are handled by stripping to word tokens (e.g. `@username` → `username`, `foo|bar` → `foo bar`) so `MATCH` succeeds without syntax errors.  
   - Fast path: queries with no special characters are returned unchanged.  
   - Pure punctuation input (e.g. `---`, `#@!`) sanitizes to an empty string; `_fulltext_search()` returns `[]` immediately without attempting `MATCH` or logging a warning.

2. **Behavior change (ops note)**  
   Previously, queries like `---` reached FTS5, logged `FTS5 search failed`, then returned `[]`. After this change, such input is rejected at sanitization time and returns `[]` silently.

3. **Tests**  
   - Unit tests in `tests/unit/test_sqlite_fts.py` (`TestFTS5QuerySanitization`)  
   - Integration test in `tests/integration/test_sqlite_fts_integration.py` (`test_search_technical_tokens`)

**Test plan**

- [x] `pytest tests/unit/test_sqlite_fts.py`
- [x] `pytest tests/integration/test_sqlite_fts_integration.py`>
