### PR TITLE
feat(plugin): enable transcript inference by default; remove recall/remember skills

### DIFF
--- a/apps/claude-code-plugin/scripts/common.sh
+++ b/apps/claude-code-plugin/scripts/common.sh
@@ -305,6 +305,7 @@ write_runtime_base_url() {
   {
     printf 'POWERMEM_BASE_URL=%s\n' "$base_url"
     printf 'POWERMEM_ENV_FILE=%s\n' "$ENV_FILE"
+    printf 'POWERMEM_INFER_TRANSCRIPT=true\n'
   } > "$tmp"
   mv "$tmp" "$RUNTIME_FILE"
 }

--- a/apps/claude-code-plugin/skills/recall/SKILL.md
+++ b/apps/claude-code-plugin/skills/recall/SKILL.md
@@ -1,8 +1,0 @@
----
-description: Search PowerMem for relevant memories. Use before answering questions about the user, project, or past decisions.
----
-
-Before answering questions about the user, project history, or past decisions:
-1. Use the PowerMem `search_memories` tool with a short query.
-2. Optionally filter by user_id or agent_id if the user has multiple contexts.
-3. Use the retrieved memories to tailor the response.

--- a/apps/claude-code-plugin/skills/remember/SKILL.md
+++ b/apps/claude-code-plugin/skills/remember/SKILL.md
@@ -1,8 +1,0 @@
----
-description: Add or update a memory in PowerMem. Use when the user or conversation reveals a fact, preference, or decision that should be remembered across sessions.
----
-
-When the user asks to remember something, or when the conversation contains a clear fact/preference/decision worth persisting:
-1. Use the PowerMem `add_memory` tool with appropriate content and optional user_id/agent_id.
-2. Prefer concise, factual memory content.
-3. Confirm what was stored in one sentence.


### PR DESCRIPTION
## Summary

- **Remove `recall` and `remember` skills** — these slash commands duplicated what the hook layer already does automatically (UserPromptSubmit injects search results; SessionEnd/PostCompact persist memories). Removing them reduces user-facing surface area and avoids confusion.

- **Enable `POWERMEM_INFER_TRANSCRIPT=true` on init** — `write_runtime_base_url()` in `common.sh` now writes this flag into `runtime.env` so LLM fact extraction runs on every session transcript automatically, without requiring manual env configuration after install.

## Changes

| File | Change |
|---|---|
| `skills/recall/SKILL.md` | Deleted |
| `skills/remember/SKILL.md` | Deleted |
| `scripts/common.sh` | +1 line in `write_runtime_base_url()` |

## Notes

- `POWERMEM_INFER_TRANSCRIPT` was previously `false` by default (only `POWERMEM_INFER_COMPACT` defaulted to `true`). This change makes transcript inference opt-out rather than opt-in.
- Users who want to disable it can set `POWERMEM_INFER_TRANSCRIPT=false` in their environment before re-running `init.sh`.
