### PR TITLE
chore: bump version to 1.1.7

### DIFF
--- a/packages/powermem-mcp/pyproject.toml
+++ b/packages/powermem-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powermem-mcp"
-version = "1.1.6"
+version = "1.1.7"
 description = "PowerMem MCP server - thin wrapper that installs powermem[server,seekdb] and exposes the powermem-mcp command."
 readme = "README.md"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "powermem[server,seekdb]==1.1.6",
+    "powermem[server,seekdb]==1.1.7",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "powermem"
-version = "1.1.6"
+version = "1.1.7"
 description = "Intelligent Memory System - Persistent memory layer for LLM applications"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/powermem/core/audit.py
+++ b/src/powermem/core/audit.py
@@ -106,7 +106,7 @@ class AuditLogger:
                 "user_id": user_id,
                 "agent_id": agent_id,
                 "details": details,
-                "version": "1.1.6",
+                "version": "1.1.7",
             }
             
             # Log to file

--- a/src/powermem/core/telemetry.py
+++ b/src/powermem/core/telemetry.py
@@ -82,7 +82,7 @@ class TelemetryManager:
                 "user_id": user_id,
                 "agent_id": agent_id,
                 "timestamp": get_current_datetime().isoformat(),
-                "version": "1.1.6",
+                "version": "1.1.7",
             }
             
             self.events.append(event)
@@ -182,7 +182,7 @@ class TelemetryManager:
                 "properties": properties,
                 "user_id": user_id,
                 "timestamp": get_current_datetime().isoformat(),
-                "version": "1.1.6",
+                "version": "1.1.7",
             }
             
             self.events.append(event)

--- a/src/powermem/version.py
+++ b/src/powermem/version.py
@@ -2,11 +2,12 @@
 Version information management
 """
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 __version_info__ = tuple(map(int, __version__.split(".")))
 
 # Version history
 VERSION_HISTORY = {
+    "1.1.7": "2026-06-30 - Version 1.1.7 release",
     "1.1.6": "2026-06-30 - Version 1.1.6 release",
     "1.1.5": "2026-06-23 - Version 1.1.5 release",
     "1.1.4": "2026-06-14 - Version 1.1.4 release",


### PR DESCRIPTION
## Summary

- bump `powermem` to `1.1.7`
- bump `powermem-mcp` wrapper package to `1.1.7`
- align telemetry/audit version metadata and version history

## Validation

- `make bump-version VERSION=1.1.7`
- `make check-package-versions`
- `git diff --check`