### PR TITLE
feat(plugin): process env takes priority over runtime.env in hook

### DIFF
--- a/apps/claude-code-plugin/hooks/run-hook.sh
+++ b/apps/claude-code-plugin/hooks/run-hook.sh
@@ -3,15 +3,28 @@
 ROOT=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 PLUGIN_ROOT=$(CDPATH= cd -- "$ROOT/.." && pwd)
 DATA_DIR="${POWERMEM_DATA_DIR:-$HOME/.powermem}"
-load_env_file() {
+# Load an env file at lower priority than the current process environment.
+# Priority: process env (user exports + Claude Code settings.json env injection)
+#           > runtime.env > plugin config/runtime.env > Go binary defaults.
+# runtime.env is a convenience default; explicit user config always wins.
+load_env_file_lower_priority() {
   [ -f "$1" ] || return 0
+  # Capture POWERMEM_* before sourcing, restore after — process env wins.
+  # Heredoc (not pipe | while) keeps the loop in the current shell so exports stick.
+  _pm_saved=$(env | grep '^POWERMEM_' 2>/dev/null || true)
   set -a
   # shellcheck disable=SC1090
   . "$1"
   set +a
+  while IFS= read -r _pm_entry; do
+    [ -n "$_pm_entry" ] || continue
+    export "$_pm_entry" 2>/dev/null || true
+  done << _PM_RESTORE_
+$_pm_saved
+_PM_RESTORE_
 }
-load_env_file "$DATA_DIR/runtime.env"
-load_env_file "$PLUGIN_ROOT/config/runtime.env"
+load_env_file_lower_priority "$DATA_DIR/runtime.env"
+load_env_file_lower_priority "$PLUGIN_ROOT/config/runtime.env"
 # MCP-only mode: runtime.env sets POWERMEM_HOOK_DISABLED=1 so the native
 # binary never runs (and never falls back to a stale POWERMEM_BASE_URL).
 # Must be checked AFTER loading runtime.env so the marker takes effect.


### PR DESCRIPTION
## Problem

`run-hook.sh` sourced `runtime.env` with `set -a; . file; set +a`, which unconditionally overwrote any `POWERMEM_*` variables already in the process environment — including those explicitly exported by the user or injected by Claude Code from `settings.json`'s `env` field.

## Priority after this change

```
process env (user exports + Claude Code settings.json env injection)
  > runtime.env
  > plugin config/runtime.env
  > Go binary hardcoded defaults
```

`runtime.env` is a convenience default that avoids polluting Claude Code global config. If the user explicitly sets `POWERMEM_*` in their shell or in Claude Code's `env` field, those values must win.

## Implementation

`load_env_file_lower_priority()` replaces the plain `load_env_file()` call:

1. Capture all `POWERMEM_*` vars from the current process env **before** sourcing.
2. Source the file normally (may overwrite them).
3. Re-export the saved values, restoring process env priority.

The restore loop uses a heredoc (`while ... done << EOF`) rather than a pipe (`cmd | while`) — the heredoc keeps the loop in the current shell so `export` takes effect in the parent process.

## Validation

Local smoke test verified all three cases:
- var in process env + in file → process env wins
- var not in process env + in file → file value applies
- file missing → no-op

Docker integration (9/9) and E2E (8/8) tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)