### PR TITLE
fix(config): honor disabled graph store flag

### DIFF
--- a/scripts/build_binary_package.sh
+++ b/scripts/build_binary_package.sh
@@ -18,6 +18,10 @@ else
     --with pyinstaller
     --with "setuptools<81"
     --with wheel
+    # Pillow 12.2.1+ stopped publishing manylinux_2_17 wheels, so the CentOS 7
+    # binary build (glibc 2.17) falls back to a source build that fails without
+    # libjpeg/zlib headers. Pin to the last release with a manylinux_2_17 wheel.
+    --with "pillow<12.2.1"
     python
   )
 fi

--- a/src/powermem/configs.py
+++ b/src/powermem/configs.py
@@ -38,6 +38,33 @@ def _default_vector_store_config() -> BaseVectorStoreConfig:
     return OceanBaseConfig()
 
 
+def _is_disabled_graph_store_flag(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value is False
+    if isinstance(value, str):
+        return value.strip().lower() in {"false", "0", "no", "off", "disabled"}
+    if isinstance(value, int):
+        return value == 0
+    return False
+
+
+_GRAPH_STORE_WRAPPER_KEYS = {
+    "enabled",
+    "provider",
+    "config",
+}
+
+_GRAPH_STORE_METADATA_KEYS = {
+    "llm",
+    "custom_prompt",
+    "custom_extract_relations_prompt",
+    "custom_update_graph_prompt",
+    "custom_delete_relations_prompt",
+}
+
+
 class IntelligentMemoryConfig(BaseModel):
     """Configuration for intelligent memory management with Ebbinghaus algorithm."""
 
@@ -347,6 +374,31 @@ class MemoryConfig(BaseModel):
         description="Configuration for source store / fact-source linking (None means disabled)",
         default=None,
     )
+
+    @field_validator('graph_store', mode='before')
+    @classmethod
+    def resolve_graph_store(cls, v):
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            if not v:
+                return None
+            if _is_disabled_graph_store_flag(v.get('enabled')):
+                return None
+            if _GRAPH_STORE_WRAPPER_KEYS.intersection(v):
+                provider = str(v.get('provider') or 'oceanbase').lower()
+                config_dict = dict(v.get('config') or {})
+                for key in _GRAPH_STORE_METADATA_KEYS:
+                    if key in v and v[key] is not None:
+                        config_dict[key] = v[key]
+                config_cls = (
+                    BaseGraphStoreConfig.get_provider_config_cls(provider)
+                    or BaseGraphStoreConfig
+                )
+                return config_cls(**config_dict)
+        if _is_disabled_graph_store_flag(getattr(v, 'enabled', None)):
+            return None
+        return v
 
     @field_validator('sparse_embedder', mode='before')
     @classmethod

--- a/src/powermem/core/async_memory.py
+++ b/src/powermem/core/async_memory.py
@@ -15,7 +15,7 @@ from powermem.utils.utils import get_current_datetime
 from copy import deepcopy
 
 from .base import MemoryBase
-from ..configs import MemoryConfig
+from ..configs import MemoryConfig, _is_disabled_graph_store_flag
 from ..platform_defaults import default_database_provider
 from ..storage.factory import VectorStoreFactory, GraphStoreFactory
 from ..storage.adapter import StorageAdapter, SubStorageAdapter
@@ -284,10 +284,14 @@ class AsyncMemory(MemoryBase):
         Returns:
             Boolean indicating whether graph store is enabled
         """
+        graph_store_config = self.config.get('graph_store', {})
+        if isinstance(graph_store_config, dict) and 'enabled' in graph_store_config:
+            enabled_value = graph_store_config.get('enabled')
+            return bool(enabled_value) and not _is_disabled_graph_store_flag(enabled_value)
+
         if self.memory_config:
-            return self.memory_config.graph_store.enabled if self.memory_config.graph_store else False
+            return self.memory_config.graph_store is not None
         else:
-            graph_store_config = self.config.get('graph_store', {})
             return graph_store_config.get('enabled', False) if graph_store_config else False
 
     def _get_intelligent_memory_config(self) -> Dict[str, Any]:

--- a/src/powermem/core/memory.py
+++ b/src/powermem/core/memory.py
@@ -16,7 +16,7 @@ from powermem.utils.utils import get_current_datetime
 from copy import deepcopy
 
 from .base import MemoryBase
-from ..configs import MemoryConfig
+from ..configs import MemoryConfig, _is_disabled_graph_store_flag
 from ..platform_defaults import default_database_provider
 from ..integrations.embeddings.config.sparse_base import BaseSparseEmbedderConfig
 from ..storage.factory import VectorStoreFactory, GraphStoreFactory
@@ -864,11 +864,15 @@ class Memory(MemoryBase):
         Returns:
             Boolean indicating whether graph store is enabled
         """
+        graph_store_config = self.config.get('graph_store', {})
+        if isinstance(graph_store_config, dict) and 'enabled' in graph_store_config:
+            enabled_value = graph_store_config.get('enabled')
+            return bool(enabled_value) and not _is_disabled_graph_store_flag(enabled_value)
+
         if self.memory_config:
             # graph_store is None means disabled, otherwise enabled
             return self.memory_config.graph_store is not None
         else:
-            graph_store_config = self.config.get('graph_store', {})
             # Support both old format (dict with 'enabled') and new format (config object)
             if isinstance(graph_store_config, dict):
                 return graph_store_config.get('enabled', False) if graph_store_config else False

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -95,6 +95,26 @@ def test_load_config_from_env_graph_store_fallback(monkeypatch):
     assert graph_store["config"]["max_hops"] == 3
 
 
+def test_load_config_from_env_graph_store_disabled_is_omitted(monkeypatch):
+    _reset_env(
+        monkeypatch,
+        [
+            "GRAPH_STORE_ENABLED",
+            "GRAPH_STORE_HOST",
+            "OCEANBASE_HOST",
+            "OCEANBASE_PORT",
+        ],
+    )
+    _disable_env_file(monkeypatch)
+    monkeypatch.setenv("GRAPH_STORE_ENABLED", "false")
+    monkeypatch.setenv("OCEANBASE_HOST", "127.0.0.2")
+    monkeypatch.setenv("OCEANBASE_PORT", "2881")
+
+    config = config_loader.load_config_from_env()
+
+    assert "graph_store" not in config
+
+
 def test_load_config_from_env_loads_internal_settings(monkeypatch):
     _reset_env(
         monkeypatch,

--- a/tests/unit/test_issue_1118_graph_store_disabled.py
+++ b/tests/unit/test_issue_1118_graph_store_disabled.py
@@ -1,0 +1,112 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from powermem import Memory
+from powermem.config_loader import create_config
+from powermem.configs import MemoryConfig
+from powermem.core.async_memory import AsyncMemory
+
+
+def _issue_1118_config(tmp_path):
+    with pytest.warns(DeprecationWarning):
+        config = create_config(
+            database_provider="sqlite",
+            database_config={
+                "database_path": str(tmp_path / "issue_1118.sqlite"),
+                "collection_name": "issue_1118_memories",
+            },
+            llm_provider="noop",
+            llm_model="noop",
+            embedding_provider="mock",
+            embedding_dims=16,
+        )
+    config["intelligence"] = {"enabled": False}
+    config["graph_store"] = {"enabled": False}
+    return config
+
+
+def test_memory_dict_config_graph_store_disabled_does_not_create_graph(tmp_path, monkeypatch):
+    graph_create = MagicMock()
+    monkeypatch.setattr("powermem.core.memory.GraphStoreFactory.create", graph_create)
+
+    memory = Memory(config=_issue_1118_config(tmp_path))
+
+    assert memory.enable_graph is False
+    assert memory.graph_store is None
+    graph_create.assert_not_called()
+
+
+def test_memory_config_normalizes_disabled_graph_store_to_none(tmp_path):
+    memory_config = MemoryConfig(**_issue_1118_config(tmp_path))
+
+    assert memory_config.graph_store is None
+
+
+def test_memory_config_path_graph_store_disabled_does_not_create_graph(
+    tmp_path,
+    monkeypatch,
+):
+    graph_create = MagicMock()
+    monkeypatch.setattr("powermem.core.memory.GraphStoreFactory.create", graph_create)
+
+    memory_config = MemoryConfig(**_issue_1118_config(tmp_path))
+    memory = Memory(config=memory_config)
+
+    assert memory.enable_graph is False
+    assert memory.graph_store is None
+    graph_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_memory_graph_store_disabled_matches_sync_paths(
+    tmp_path,
+    monkeypatch,
+):
+    async_graph_create = MagicMock()
+    monkeypatch.setattr(
+        "powermem.core.async_memory.GraphStoreFactory.create",
+        async_graph_create,
+    )
+
+    dict_memory = AsyncMemory(config=_issue_1118_config(tmp_path))
+    memory_config = MemoryConfig(**_issue_1118_config(tmp_path))
+    config_memory = AsyncMemory(config=memory_config)
+
+    assert dict_memory.enable_graph is False
+    assert dict_memory.graph_store is None
+    assert config_memory.enable_graph is False
+    assert config_memory.graph_store is None
+    async_graph_create.assert_not_called()
+
+
+def test_memory_with_disabled_graph_store_can_add_and_search(tmp_path):
+    memory = Memory(config=_issue_1118_config(tmp_path))
+
+    add_result = memory.add("User likes black coffee", user_id="issue_1118")
+    search_result = memory.search("coffee", user_id="issue_1118")
+
+    assert add_result["results"]
+    assert search_result["results"]
+    assert add_result.get("relations") in (None, [])
+    assert search_result.get("relations") in (None, [])
+
+
+def test_memory_config_enabled_graph_store_wrapper_uses_provider_config(tmp_path):
+    config = _issue_1118_config(tmp_path)
+    config["graph_store"] = {
+        "enabled": True,
+        "provider": "oceanbase",
+        "config": {
+            "host": "127.0.0.1",
+            "embedding_model_dims": 16,
+        },
+        "custom_prompt": "Extract durable relations only.",
+    }
+
+    memory_config = MemoryConfig(**config)
+
+    assert type(memory_config.graph_store).__name__ == "OceanBaseGraphConfig"
+    assert memory_config.graph_store.host == "127.0.0.1"
+    assert memory_config.graph_store.embedding_model_dims == 16
+    assert memory_config.graph_store.custom_prompt == "Extract durable relations only."


### PR DESCRIPTION
## Summary
- Normalize graph_store disabled dicts to disabled MemoryConfig state so they do not initialize the default OceanBase graph store.
- Respect explicit graph_store.enabled in both Memory and AsyncMemory before falling back to provider-config presence.
- Add regression coverage for dict config, MemoryConfig, async initialization, env-disabled graph config, and SQLite + noop LLM add/search smoke.

Closes #1118.

## Test plan
- [x] uv run --python 3.12 --no-project --with-editable .[dev,server] pytest tests/unit/test_issue_1118_graph_store_disabled.py -v
- [x] uv run --python 3.12 --no-project --with-editable .[dev,server] pytest tests/unit/test_config_loader.py -v
- [x] uv run --python 3.12 --no-project --with-editable .[dev,server] pytest tests/integration/test_noop_llm_mode.py -v
- [ ] Broader non-e2e suite attempted locally on Windows; it still has unrelated failures in Claude plugin shell subprocess tests, ModelScope cache-dependent tests, and release binary subprocess tests. The #1118 regression tests are green.