### PR TITLE
fix: verify powermem-mcp PyPI release publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,3 +115,25 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+
+  pypi-verify:
+    if: startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'v') && !startsWith(github.event.release.tag_name || github.event.inputs.release_tag, 'plugins-')
+    runs-on: ubuntu-latest
+    needs:
+      - pypi-publish-powermem-mcp
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Verify PyPI release visibility
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag }}
+        run: |
+          python scripts/check_pypi_release.py --tag "$RELEASE_TAG" --packages powermem powermem-mcp

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -937,27 +937,42 @@ class ExampleClass:
 
 ### Prerequisites
 
-Before publishing to PyPI, ensure you have:
+PowerMem publishes two PyPI projects from this repository:
 
-1. **PyPI account**: Create an account at [pypi.org](https://pypi.org)
-2. **API tokens**: Generate API tokens from your PyPI account settings
-3. **Configure credentials**: Set up `~/.pypirc` or use environment variables
+- `powermem`: the main SDK, CLI, server, and optional MCP implementation.
+- `powermem-mcp`: a thin wrapper for zero-install MCP clients. Its version
+  must match `powermem`, and it depends on `powermem[server,seekdb]` for the
+  same version.
+
+Normal releases use GitHub Actions OIDC and PyPI Trusted Publishers through
+`.github/workflows/publish.yml`; do not rely on long-lived PyPI API tokens for
+the standard release path. Before publishing, ensure both PyPI projects have a
+Trusted Publisher entry that matches:
+
+1. **Owner**: `oceanbase`
+2. **Repository**: `powermem`
+3. **Workflow filename**: `publish.yml`
+4. **Environment**: leave blank unless the publish job declares a GitHub
+   environment; if an environment is added to the workflow, the same name must
+   be configured in PyPI for the matching project.
 
 ### Publishing Process
 
-1. **Update version** in `pyproject.toml`:
-
-```toml
-[project]
-version = "0.1.1"  # Increment version number
-```
-
-2. **Update changelog** (if you maintain one)
-
-3. **Build and check the package**:
+1. **Update versions** in both Python projects:
 
 ```bash
-make build-check
+make bump-version VERSION=1.1.8
+```
+
+This updates `pyproject.toml` and `packages/powermem-mcp/pyproject.toml`,
+including the wrapper dependency pin.
+
+2. **Update changelog or release notes** if the release needs them.
+
+3. **Build and check both Python packages**:
+
+```bash
+make build-all-python-packages
 ```
 
 4. **Test locally**:
@@ -968,22 +983,34 @@ make install-local
 python -c "import powermem; print(powermem.__version__)"
 ```
 
-5. **Publish to TestPyPI first** (recommended):
+5. **Create and push a release tag**:
 
 ```bash
-make publish-testpypi
+git tag -a v1.1.8 -m "Release version 1.1.8"
+git push origin v1.1.8
 ```
 
-6. **Test installation from TestPyPI**:
+The `Build Package` workflow creates the GitHub Release and dispatches
+`Upload Python Package`, which publishes `powermem` first, then
+`powermem-mcp`, then verifies both versions on PyPI.
+
+6. **Backfill a missing PyPI release** if a publish job failed after the
+   GitHub Release already exists:
 
 ```bash
-pip install --index-url https://test.pypi.org/simple/ powermem
+gh workflow run publish.yml --repo oceanbase/powermem --ref main -f release_tag=v1.1.8
 ```
 
-7. **Publish to PyPI**:
+The publish workflow uses `skip-existing: true`, so already-published files are
+skipped while missing package versions can still be uploaded. Use `--ref main`
+for backfills so the workflow and verification script come from the latest
+release automation, while `release_tag` still selects the package source tag.
+
+7. **Verify PyPI visibility**:
 
 ```bash
-make publish-pypi
+python scripts/check_pypi_release.py --version 1.1.8
+python -m pip install --no-cache-dir powermem-mcp==1.1.8
 ```
 
 ### Version Management
@@ -996,11 +1023,11 @@ Follow [Semantic Versioning](https://semver.org/):
 
 ### Git Tagging
 
-After publishing, create a git tag:
+Release tags use the `vX.Y.Z` format:
 
 ```bash
-git tag -a v0.1.1 -m "Release version 0.1.1"
-git push origin v0.1.1
+git tag -a v1.1.8 -m "Release version 1.1.8"
+git push origin v1.1.8
 ```
 
 ## Debugging

--- a/docs/website/i18n/zh/docusaurus-plugin-content-docs/current/development/overview.md
+++ b/docs/website/i18n/zh/docusaurus-plugin-content-docs/current/development/overview.md
@@ -872,24 +872,37 @@ class ExampleClass:
 
 ### 前置条件 {#prerequisites-1}
 
-在发布到 PyPI 之前，请确保您已完成以下操作：
+本仓库会发布两个 PyPI 项目：
 
-1. **PyPI 账户**：在 [pypi.org](https://pypi.org) 创建一个账户
-2. **API tokens**：从您的 PyPI 账户设置中生成 API tokens
-3. **配置凭据**：设置 `~/.pypirc` 或使用环境变量
+- `powermem`：主 SDK、CLI、服务端以及可选 MCP 实现。
+- `powermem-mcp`：面向零安装 MCP 客户端的薄封装包。它必须与
+  `powermem` 保持同版本，并依赖同版本的 `powermem[server,seekdb]`。
+
+标准发布流程通过 `.github/workflows/publish.yml` 使用 GitHub Actions
+OIDC 和 PyPI Trusted Publishers，不应依赖长期有效的 PyPI API token。
+发布前请确认两个 PyPI 项目都配置了匹配的 Trusted Publisher：
+
+1. **Owner**：`oceanbase`
+2. **Repository**：`powermem`
+3. **Workflow filename**：`publish.yml`
+4. **Environment**：如果 workflow 的发布 job 没有声明 GitHub environment，
+   这里保持为空；如果后续添加了 environment，PyPI 中也必须填写同名
+   environment。
 
 ### 发布流程 {#publishing-process}
 
-1. 在 `pyproject.toml` 中**更新版本**：
-```toml
-[project]
-version = "0.1.1"  # 增加版本号
-```
-2. **更新变更日志**（如果您维护了一个）
-
-3. **构建并检查包**：
+1. **同步更新两个 Python 项目的版本**：
 ```bash
-make build-check
+make bump-version VERSION=1.1.8
+```
+该命令会更新 `pyproject.toml` 和 `packages/powermem-mcp/pyproject.toml`，
+包括 wrapper 包对主包的依赖版本。
+
+2. **更新变更日志或 Release Notes**（如果本次发布需要）。
+
+3. **构建并检查两个 Python 包**：
+```bash
+make build-all-python-packages
 ```
 4. **本地测试**：
 ```bash
@@ -897,17 +910,27 @@ make install-local
 # 测试已安装的包
 python -c "import powermem; print(powermem.__version__)"
 ```
-5. **先发布到 TestPyPI**（推荐）：
+5. **创建并推送发布 tag**：
 ```bash
-make publish-testpypi
+git tag -a v1.1.8 -m "Release version 1.1.8"
+git push origin v1.1.8
 ```
-6. **从 TestPyPI 测试安装**：
+`Build Package` workflow 会创建 GitHub Release 并触发 `Upload Python Package`，
+该 workflow 会先发布 `powermem`，再发布 `powermem-mcp`，最后校验两个版本在
+PyPI 上都可见。
+
+6. **补发已存在 GitHub Release 但 PyPI 缺失的版本**：
 ```bash
-pip install --index-url https://test.pypi.org/simple/ powermem
+gh workflow run publish.yml --repo oceanbase/powermem --ref main -f release_tag=v1.1.8
 ```
-7. **发布到 PyPI**：
+发布 workflow 配置了 `skip-existing: true`，已存在的文件会跳过，缺失的包版本
+仍可继续上传。补发旧版本时使用 `--ref main`，确保 workflow 与校验脚本来自最新发布自动化，
+同时通过 `release_tag` 指定实际要构建和发布的源码 tag。
+
+7. **验证 PyPI 可见性**：
 ```bash
-make publish-pypi
+python scripts/check_pypi_release.py --version 1.1.8
+python -m pip install --no-cache-dir powermem-mcp==1.1.8
 ```
 ### 版本管理 {#version-management}
 
@@ -919,10 +942,10 @@ make publish-pypi
 
 ### Git 标签 {#git-tagging}
 
-发布后，创建一个 git 标签：
+发布标签使用 `vX.Y.Z` 格式：
 ```bash
-git tag -a v0.1.1 -m "Release version 0.1.1"
-git push origin v0.1.1
+git tag -a v1.1.8 -m "Release version 1.1.8"
+git push origin v1.1.8
 ```
 ## 调试 {#debugging}
 

--- a/scripts/check_pypi_release.py
+++ b/scripts/check_pypi_release.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Verify that expected PowerMem packages are visible on PyPI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from typing import Callable
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+
+DEFAULT_PACKAGES = ("powermem", "powermem-mcp")
+PYPI_JSON_URL = "https://pypi.org/pypi/{package}/json"
+
+
+class ReleaseCheckError(RuntimeError):
+    """Raised when a package release is missing or incomplete on PyPI."""
+
+
+def parse_version(value: str) -> str:
+    version = value.strip()
+    if version.startswith("v"):
+        version = version[1:]
+    if not version:
+        raise ReleaseCheckError("release version cannot be empty")
+    return version
+
+
+def _expected_filename_prefix(package: str, version: str) -> str:
+    normalized_package = package.replace("-", "_")
+    return f"{normalized_package}-{version}"
+
+
+def fetch_pypi_json(package: str) -> dict:
+    url = PYPI_JSON_URL.format(package=package)
+    try:
+        with urlopen(url, timeout=30) as response:
+            return json.load(response)
+    except (HTTPError, URLError, TimeoutError) as error:
+        raise ReleaseCheckError(f"failed to fetch PyPI metadata for {package}: {error}")
+
+
+def check_package_release(package: str, version: str, pypi_data: dict) -> None:
+    releases = pypi_data.get("releases") or {}
+    files = releases.get(version)
+    if not files:
+        raise ReleaseCheckError(f"{package} missing release {version} on PyPI")
+
+    expected_prefix = _expected_filename_prefix(package, version)
+    filenames = [file_info.get("filename", "") for file_info in files]
+    matching_filenames = [
+        filename for filename in filenames if filename.startswith(expected_prefix)
+    ]
+    if not matching_filenames:
+        raise ReleaseCheckError(
+            f"{package} release {version} has no files starting with {expected_prefix}"
+        )
+
+    has_wheel = any(filename.endswith(".whl") for filename in matching_filenames)
+    has_sdist = any(filename.endswith(".tar.gz") for filename in matching_filenames)
+    missing_types = []
+    if not has_wheel:
+        missing_types.append("wheel")
+    if not has_sdist:
+        missing_types.append("sdist")
+    if missing_types:
+        missing = ", ".join(missing_types)
+        raise ReleaseCheckError(f"{package} release {version} is missing {missing}")
+
+
+def check_packages(
+    packages: list[str],
+    version: str,
+    *,
+    fetcher: Callable[[str], dict] = fetch_pypi_json,
+    retries: int = 6,
+    delay_seconds: float = 10,
+) -> None:
+    if retries < 1:
+        raise ReleaseCheckError("retries must be at least 1")
+    if delay_seconds < 0:
+        raise ReleaseCheckError("delay_seconds cannot be negative")
+
+    last_error: ReleaseCheckError | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            for package in packages:
+                check_package_release(package, version, fetcher(package))
+            return
+        except ReleaseCheckError as error:
+            last_error = error
+            if attempt < retries:
+                time.sleep(delay_seconds)
+    if last_error is not None:
+        raise last_error
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify that powermem release packages are available on PyPI."
+    )
+    release = parser.add_mutually_exclusive_group(required=True)
+    release.add_argument("--version", help="Release version, for example 1.1.6")
+    release.add_argument("--tag", help="Release tag, for example v1.1.6")
+    parser.add_argument("--packages", nargs="+", default=list(DEFAULT_PACKAGES))
+    parser.add_argument("--retries", type=int, default=6)
+    parser.add_argument("--delay-seconds", type=float, default=10)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    version = parse_version(args.version or args.tag)
+
+    try:
+        check_packages(
+            args.packages,
+            version,
+            retries=args.retries,
+            delay_seconds=args.delay_seconds,
+        )
+    except ReleaseCheckError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    joined_packages = ", ".join(args.packages)
+    print(f"PyPI release {version} verified for: {joined_packages}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_check_pypi_release.py
+++ b/tests/unit/test_check_pypi_release.py
@@ -1,0 +1,137 @@
+import pytest
+
+from scripts import check_pypi_release as checker
+
+
+def _pypi_data(version: str, filenames: list[str]) -> dict:
+    return {
+        "releases": {
+            version: [{"filename": filename} for filename in filenames],
+        }
+    }
+
+
+def test_parse_version_accepts_plain_version_and_v_tag() -> None:
+    assert checker.parse_version("1.1.6") == "1.1.6"
+    assert checker.parse_version("v1.1.6") == "1.1.6"
+
+
+def test_check_package_release_accepts_wheel_and_sdist() -> None:
+    data = _pypi_data(
+        "1.1.6",
+        [
+            "powermem_mcp-1.1.6-py3-none-any.whl",
+            "powermem_mcp-1.1.6.tar.gz",
+        ],
+    )
+
+    checker.check_package_release("powermem-mcp", "1.1.6", data)
+
+
+def test_check_package_release_reports_missing_version() -> None:
+    data = _pypi_data("0.2.0", ["powermem_mcp-0.2.0-py3-none-any.whl"])
+
+    with pytest.raises(checker.ReleaseCheckError) as error:
+        checker.check_package_release("powermem-mcp", "1.1.6", data)
+
+    message = str(error.value)
+    assert "powermem-mcp" in message
+    assert "1.1.6" in message
+
+
+def test_check_package_release_requires_wheel_and_sdist() -> None:
+    data = _pypi_data("1.1.6", ["powermem_mcp-1.1.6-py3-none-any.whl"])
+
+    with pytest.raises(checker.ReleaseCheckError) as error:
+        checker.check_package_release("powermem-mcp", "1.1.6", data)
+
+    assert "sdist" in str(error.value)
+
+
+def test_check_package_release_rejects_wrong_filename_prefix() -> None:
+    data = _pypi_data(
+        "1.1.6",
+        [
+            "powermem-1.1.6-py3-none-any.whl",
+            "powermem-1.1.6.tar.gz",
+        ],
+    )
+
+    with pytest.raises(checker.ReleaseCheckError) as error:
+        checker.check_package_release("powermem-mcp", "1.1.6", data)
+
+    assert "powermem_mcp-1.1.6" in str(error.value)
+
+
+def test_check_packages_fetches_every_requested_package() -> None:
+    requested: list[str] = []
+
+    def fetcher(package: str) -> dict:
+        requested.append(package)
+        normalized = package.replace("-", "_")
+        return _pypi_data(
+            "1.1.6",
+            [
+                f"{normalized}-1.1.6-py3-none-any.whl",
+                f"{normalized}-1.1.6.tar.gz",
+            ],
+        )
+
+    checker.check_packages(
+        ["powermem", "powermem-mcp"],
+        "1.1.6",
+        fetcher=fetcher,
+        retries=1,
+        delay_seconds=0,
+    )
+
+    assert requested == ["powermem", "powermem-mcp"]
+
+
+def test_check_packages_retries_until_release_is_visible() -> None:
+    attempts = 0
+
+    def fetcher(package: str) -> dict:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return _pypi_data("0.2.0", ["powermem_mcp-0.2.0-py3-none-any.whl"])
+        return _pypi_data(
+            "1.1.6",
+            [
+                "powermem_mcp-1.1.6-py3-none-any.whl",
+                "powermem_mcp-1.1.6.tar.gz",
+            ],
+        )
+
+    checker.check_packages(
+        ["powermem-mcp"],
+        "1.1.6",
+        fetcher=fetcher,
+        retries=2,
+        delay_seconds=0,
+    )
+
+    assert attempts == 2
+
+
+def test_check_packages_rejects_non_positive_retries() -> None:
+    with pytest.raises(checker.ReleaseCheckError) as error:
+        checker.check_packages(
+            ["powermem-mcp"],
+            "1.1.6",
+            fetcher=lambda package: {},
+            retries=0,
+            delay_seconds=0,
+        )
+
+    assert "retries" in str(error.value)
+
+
+def test_main_returns_failure_for_invalid_retries(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = checker.main(
+        ["--version", "1.1.6", "--retries", "0", "--delay-seconds", "0"]
+    )
+
+    assert exit_code == 1
+    assert "retries" in capsys.readouterr().err

--- a/tests/unit/test_release_binary_ci.py
+++ b/tests/unit/test_release_binary_ci.py
@@ -243,6 +243,17 @@ def test_release_uploads_arch_named_binary_assets() -> None:
     )
 
 
+def test_pypi_publish_workflow_verifies_both_python_packages() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "publish.yml").read_text()
+
+    assert "pypi-publish-powermem-mcp:" in workflow
+    assert "pypi-verify:" in workflow
+    assert "      - pypi-publish-powermem-mcp" in workflow
+    assert "ref: ${{ github.ref }}" in workflow
+    assert "scripts/check_pypi_release.py" in workflow
+    assert "powermem powermem-mcp" in workflow
+
+
 def test_smoke_script_maps_archive_names_to_package_dirs() -> None:
     assert (
         _package_name(Path("powermem-1.1.4-linux-amd64-binaries.tar.gz"))


### PR DESCRIPTION
## Summary
- Add a PyPI release verification script that checks both `powermem` and `powermem-mcp` publish the requested version with wheel and sdist artifacts.
- Run the verification after the `powermem-mcp` publish job so missing wrapper releases fail the publish workflow instead of passing silently.
- Update release docs to describe the two PyPI projects, Trusted Publisher setup, and the backfill flow for missing package versions.

## Test Plan
- [x] `python -m pytest tests/unit/test_check_pypi_release.py -v`
- [x] `python -m pytest tests/unit/test_release_binary_ci.py::test_pypi_publish_workflow_verifies_both_python_packages -v`
- [x] `python scripts/check_package_versions.py`
- [x] `git diff --cached --check`

## Notes
- The `powermem-mcp` PyPI project still needs a Trusted Publisher entry for `oceanbase/powermem` and `publish.yml` before the failed release can be backfilled.

Closes #1117