### PR TITLE
fix(server): sanitize startup errors in API responses

### DIFF
--- a/src/server/api/v1/system.py
+++ b/src/server/api/v1/system.py
@@ -18,6 +18,10 @@ from ...middleware.rate_limit import limiter, get_rate_limit_string
 from ...config import config
 from ...utils.metrics import get_metrics_collector
 from ...utils.health_check import check_all_dependencies
+from ...utils.service_errors import (
+    public_startup_error_message,
+    public_startup_error_with_recommendation,
+)
 from powermem import auto_config
 from powermem.version import __version__ as powermem_version
 
@@ -94,7 +98,9 @@ async def get_status(
         dependencies["memory_service"] = DependencyStatus(
             name="memory_service",
             status="healthy" if memory_service_ready else "unavailable",
-            error_message=(str(startup_error)[:200] if startup_error else None),
+            error_message=(
+                public_startup_error_with_recommendation() if startup_error else None
+            ),
             last_checked=datetime.utcnow(),
         )
 
@@ -125,7 +131,7 @@ async def get_status(
             storage_type=storage_type,
             llm_provider=llm_provider,
             memory_service_ready=memory_service_ready,
-            startup_error=(str(startup_error)[:200] if startup_error else None),
+            startup_error=(public_startup_error_message() if startup_error else None),
             storage_capabilities=storage_capabilities,
             uptime_seconds=uptime_seconds,
             started_at=SERVER_START_TIME,
@@ -137,7 +143,7 @@ async def get_status(
             data=status_data.model_dump(mode='json'),
             message="System status retrieved successfully",
         )
-    except Exception as e:
+    except Exception:
         # Fallback: return basic status even if dependencies check fails
         now = datetime.now(timezone.utc)
         uptime_seconds = (now - SERVER_START_TIME).total_seconds()
@@ -148,7 +154,11 @@ async def get_status(
             storage_type=None,
             llm_provider=None,
             memory_service_ready=bool(getattr(request.app.state, "service_ready", False)),
-            startup_error=str(getattr(request.app.state, "service_startup_error", "") or e)[:200],
+            startup_error=(
+                public_startup_error_message()
+                if getattr(request.app.state, "service_startup_error", None)
+                else None
+            ),
             storage_capabilities=getattr(request.app.state, "storage_capabilities", None),
             uptime_seconds=uptime_seconds,
             started_at=SERVER_START_TIME,
@@ -158,7 +168,7 @@ async def get_status(
         return APIResponse(
             success=True,
             data=status_data.model_dump(mode='json'),
-            message=f"System status retrieved with errors: {str(e)[:100]}",
+            message="System status retrieved with limited dependency details",
         )
 
 

--- a/src/server/utils/service_errors.py
+++ b/src/server/utils/service_errors.py
@@ -5,14 +5,24 @@ from __future__ import annotations
 from fastapi import Request
 
 
-def service_unavailable_message(request: Request, service_name: str) -> str:
-    message = f"{service_name} service unavailable: storage backend initialization failed"
-    startup_error = getattr(request.app.state, "service_startup_error", None)
-    if startup_error:
-        message += f" ({str(startup_error)[:200]})"
-    message += (
-        ". For local basic storage, set DATABASE_PROVIDER=sqlite. "
-        "For the full PowerMem capability stack, use embedded SeekDB on Linux "
-        'with "powermem[seekdb]" or configure remote OceanBase with OCEANBASE_HOST.'
+PUBLIC_STARTUP_ERROR_MESSAGE = "Storage backend initialization failed"
+STORAGE_RECOMMENDATION_MESSAGE = (
+    "For local basic storage, set DATABASE_PROVIDER=sqlite. "
+    "For the full PowerMem capability stack, use embedded SeekDB on Linux "
+    'with "powermem[seekdb]" or configure remote OceanBase with OCEANBASE_HOST.'
+)
+
+
+def public_startup_error_message() -> str:
+    return PUBLIC_STARTUP_ERROR_MESSAGE
+
+
+def public_startup_error_with_recommendation() -> str:
+    return f"{PUBLIC_STARTUP_ERROR_MESSAGE}. {STORAGE_RECOMMENDATION_MESSAGE}"
+
+
+def service_unavailable_message(_request: Request, service_name: str) -> str:
+    return (
+        f"{service_name} service unavailable: "
+        f"{PUBLIC_STARTUP_ERROR_MESSAGE.lower()}. {STORAGE_RECOMMENDATION_MESSAGE}"
     )
-    return message

--- a/tests/unit/server/test_system_health.py
+++ b/tests/unit/server/test_system_health.py
@@ -3,21 +3,47 @@ import json
 import pytest
 
 
-def test_public_health_does_not_expose_startup_error():
+SENSITIVE_STARTUP_ERROR = (
+    "failed to connect to postgresql://user:SYNTHETIC_SECRET@db.example/powermem "
+    "from /synthetic/local/path"
+)
+SENSITIVE_FRAGMENTS = (
+    "postgresql://user",
+    "SYNTHETIC_SECRET",
+    "db.example",
+    "/synthetic/local/path",
+)
+
+
+def assert_sensitive_startup_error_hidden(body):
+    response_text = json.dumps(body)
+    for fragment in SENSITIVE_FRAGMENTS:
+        assert fragment not in response_text
+
+
+def build_app_with_startup_error():
     pytest.importorskip("fastapi", exc_type=ImportError)
 
     from fastapi import FastAPI
-    from fastapi.testclient import TestClient
-
-    from server.api.v1.system import router
 
     app = FastAPI()
     app.state.service_ready = False
     app.state.storage_type = "sqlite"
-    app.state.service_startup_error = (
-        "failed to connect to postgresql://user:secret@db.internal/powermem "
-        "from C:/sensitive/path"
-    )
+    app.state.service_startup_error = SENSITIVE_STARTUP_ERROR
+    app.state.storage_capabilities = None
+    app.state.memory_service = None
+    app.state.search_service = None
+    app.state.user_service = None
+    app.state.agent_service = None
+    return app
+
+
+def test_public_health_does_not_expose_startup_error():
+    from fastapi.testclient import TestClient
+
+    from server.api.v1.system import router
+
+    app = build_app_with_startup_error()
     app.include_router(router, prefix="/api/v1")
 
     response = TestClient(app).get("/api/v1/system/health")
@@ -28,7 +54,90 @@ def test_public_health_does_not_expose_startup_error():
     assert body["data"]["memory_service_ready"] is False
     assert "startup_error" not in body["data"]
 
-    response_text = json.dumps(body)
-    assert "secret" not in response_text
-    assert "db.internal" not in response_text
-    assert "sensitive/path" not in response_text
+    assert_sensitive_startup_error_hidden(body)
+
+
+def test_authenticated_status_does_not_expose_startup_error(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from server.api.v1 import system
+    from server.api.v1.system import router
+    from server.config import config
+
+    async def empty_dependency_check():
+        return {}
+
+    monkeypatch.setattr(config, "auth_enabled", True)
+    monkeypatch.setattr(config, "api_keys", "secret")
+    monkeypatch.setattr(system, "check_all_dependencies", empty_dependency_check)
+
+    app = build_app_with_startup_error()
+    app.include_router(router, prefix="/api/v1")
+
+    response = TestClient(app).get(
+        "/api/v1/system/status",
+        headers={"X-API-Key": "secret"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["memory_service_ready"] is False
+    assert body["data"]["startup_error"]
+    assert body["data"]["dependencies"]["memory_service"]["status"] == "unavailable"
+    assert body["data"]["dependencies"]["memory_service"]["error_message"]
+    assert_sensitive_startup_error_hidden(body)
+
+
+def test_status_fallback_does_not_expose_startup_error(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from server.api.v1 import system
+    from server.api.v1.system import router
+    from server.config import config
+
+    async def fail_dependency_check():
+        raise RuntimeError(SENSITIVE_STARTUP_ERROR)
+
+    monkeypatch.setattr(config, "auth_enabled", True)
+    monkeypatch.setattr(config, "api_keys", "secret")
+    monkeypatch.setattr(system, "check_all_dependencies", fail_dependency_check)
+
+    app = build_app_with_startup_error()
+    app.include_router(router, prefix="/api/v1")
+
+    response = TestClient(app).get(
+        "/api/v1/system/status",
+        headers={"X-API-Key": "secret"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["memory_service_ready"] is False
+    assert body["data"]["startup_error"]
+    assert_sensitive_startup_error_hidden(body)
+
+
+def test_service_unavailable_response_does_not_expose_startup_error(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from server.api.v1 import router
+    from server.config import config
+    from server.middleware.error_handler import error_handler
+    from server.models.errors import APIError
+
+    monkeypatch.setattr(config, "auth_enabled", True)
+    monkeypatch.setattr(config, "api_keys", "secret")
+
+    app = build_app_with_startup_error()
+    app.add_exception_handler(APIError, error_handler)
+    app.include_router(router)
+
+    response = TestClient(app).get(
+        "/api/v1/users/user-1/profile",
+        headers={"X-API-Key": "secret"},
+    )
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["message"]
+    assert_sensitive_startup_error_hidden(body)


### PR DESCRIPTION
## Summary
- Stop appending raw service startup exceptions to user-facing 503 responses.
- Return sanitized startup failure summaries from `/api/v1/system/status` and its fallback path while keeping raw errors internal.
- Add regression coverage for synthetic DSN/secret/path exposure in health, status, fallback, and service-unavailable responses.

## Test plan
- `python -m pytest tests/unit/server/test_system_health.py`
- `python -m pytest tests/unit/server`
- `git diff --check`
- `python -m pytest tests/unit` was also attempted locally; it fails on unrelated local environment/tool assumptions, including existing API/model environment overrides, missing ModelScope cache, and Windows script/tool availability.

Fixes #1133