### PR TITLE
fix(server): sanitize runtime exception responses

### DIFF
--- a/src/server/api/v1/system.py
+++ b/src/server/api/v1/system.py
@@ -2,6 +2,8 @@
 System management API routes
 """
 
+import logging
+
 from fastapi import APIRouter, Depends, Request, Response, Query
 from slowapi import Limiter
 from typing import Optional
@@ -19,6 +21,8 @@ from ...config import config
 from ...utils.metrics import get_metrics_collector
 from ...utils.health_check import check_all_dependencies
 from ...utils.service_errors import (
+    dependency_unavailable_message,
+    operation_failed_message,
     public_startup_error_message,
     public_startup_error_with_recommendation,
 )
@@ -29,6 +33,14 @@ from powermem.version import __version__ as powermem_version
 from ...state import SERVER_START_TIME
 
 router = APIRouter(prefix="/system", tags=["system"])
+logger = logging.getLogger("server")
+
+
+def _dependency_status_response(name: str, dependency: DependencyStatus) -> dict:
+    data = dependency.model_dump(mode='json')
+    if name in {"database", "llm"} and data.get("error_message"):
+        data["error_message"] = dependency_unavailable_message(name)
+    return data
 
 
 @router.get(
@@ -121,7 +133,7 @@ async def get_status(
         
         # Convert dependencies to dict for response
         dependencies_dict = {
-            name: dep.model_dump(mode='json')
+            name: _dependency_status_response(name, dep)
             for name, dep in dependencies.items()
         }
         
@@ -240,9 +252,10 @@ async def delete_all_memories(
             data={"deleted": result, "filters": filters},
             message=f"All memories{filter_desc} deleted successfully",
         )
-    except Exception as e:
+    except Exception:
+        logger.exception("Failed to delete all memories")
         raise APIError(
             code=ErrorCode.INTERNAL_ERROR,
-            message=f"Failed to delete all memories: {str(e)}",
+            message=operation_failed_message("delete all memories"),
             status_code=500,
         )

--- a/src/server/services/agent_service.py
+++ b/src/server/services/agent_service.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 from powermem import auto_config
 from powermem.agent import AgentMemory
 from ..models.errors import ErrorCode, APIError
+from ..utils.service_errors import operation_failed_message
 
 logger = logging.getLogger("server")
 
@@ -77,7 +78,7 @@ class AgentService:
             logger.error(f"Failed to get agent memories {agent_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to get agent memories: {str(e)}",
+                message=operation_failed_message("get agent memories"),
                 status_code=500,
             )
     
@@ -162,7 +163,7 @@ class AgentService:
             logger.error(f"Failed to create agent memory: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.MEMORY_CREATE_FAILED,
-                message=f"Failed to create agent memory: {str(e)}",
+                message=operation_failed_message("create agent memory"),
                 status_code=500,
             )
     
@@ -312,7 +313,7 @@ class AgentService:
             logger.error(f"Failed to share memories: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.AGENT_MEMORY_SHARE_FAILED,
-                message=f"Failed to share memories: {str(e)}",
+                message=operation_failed_message("share memories"),
                 status_code=500,
             )
     

--- a/src/server/services/memory_service.py
+++ b/src/server/services/memory_service.py
@@ -12,6 +12,7 @@ from ..models.errors import ErrorCode, APIError
 from ..models.request import ObservationIngestRequest
 from ..utils.converters import memory_dict_to_response
 from ..utils.metrics import get_metrics_collector
+from ..utils.service_errors import operation_failed_message
 
 logger = logging.getLogger("server")
 
@@ -315,7 +316,7 @@ class MemoryService:
             logger.error(f"Failed to ingest observation: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.MEMORY_CREATE_FAILED,
-                message=f"Failed to ingest observation: {str(e)}",
+                message=operation_failed_message("ingest observation"),
                 status_code=500,
             )
 
@@ -365,7 +366,7 @@ class MemoryService:
                     "success": False,
                     "observation_id": observation_id,
                     "result": None,
-                    "error": str(e),
+                    "error": operation_failed_message("ingest observation"),
                 })
                 failed_count += 1
 
@@ -500,7 +501,7 @@ class MemoryService:
             
             raise APIError(
                 code=ErrorCode.MEMORY_CREATE_FAILED,
-                message=f"Failed to create memory: {str(e)}",
+                message=operation_failed_message("create memory"),
                 status_code=500,
             )
     
@@ -560,7 +561,7 @@ class MemoryService:
             logger.error(f"Failed to get memory {memory_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to get memory: {str(e)}",
+                message=operation_failed_message("get memory"),
                 status_code=500,
             )
     
@@ -623,7 +624,7 @@ class MemoryService:
             logger.error(f"Failed to list memories: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to list memories: {str(e)}",
+                message=operation_failed_message("list memories"),
                 status_code=500,
             )
     
@@ -1367,7 +1368,7 @@ class MemoryService:
             logger.error(f"Failed to update memory {memory_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.MEMORY_UPDATE_FAILED,
-                message=f"Failed to update memory: {str(e)}",
+                message=operation_failed_message("update memory"),
                 status_code=500,
             )
 
@@ -1447,7 +1448,7 @@ class MemoryService:
             logger.error(f"Failed to delete memory {memory_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.MEMORY_DELETE_FAILED,
-                message=f"Failed to delete memory: {str(e)}",
+                message=operation_failed_message("delete memory"),
                 status_code=500,
             )
     
@@ -1563,7 +1564,7 @@ class MemoryService:
                 failed.append({
                     "index": idx,
                     "content": memory_item.get("content", "N/A"),
-                    "error": str(e),
+                    "error": operation_failed_message("create memory"),
                 })
         
         return {
@@ -1648,7 +1649,7 @@ class MemoryService:
                 failed.append({
                     "index": idx,
                     "memory_id": update_item.get("memory_id"),
-                    "error": str(e),
+                    "error": operation_failed_message("update memory"),
                 })
         
         return {
@@ -1759,6 +1760,6 @@ class MemoryService:
             logger.error(f"Failed to analyze memory quality: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to analyze memory quality: {str(e)}",
+                message=operation_failed_message("analyze memory quality"),
                 status_code=500,
             )

--- a/src/server/services/search_service.py
+++ b/src/server/services/search_service.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 from powermem import Memory, auto_config
 from ..models.errors import ErrorCode, APIError
 from ..utils.metrics import get_metrics_collector
+from ..utils.service_errors import operation_failed_message
 
 logger = logging.getLogger("server")
 
@@ -109,6 +110,6 @@ class SearchService:
             
             raise APIError(
                 code=ErrorCode.SEARCH_FAILED,
-                message=f"Search failed: {str(e)}",
+                message=operation_failed_message("search memories"),
                 status_code=500,
             )

--- a/src/server/services/user_service.py
+++ b/src/server/services/user_service.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Dict, List, Optional
 from powermem import UserMemory, auto_config
 from ..models.errors import ErrorCode, APIError
+from ..utils.service_errors import operation_failed_message
 
 logger = logging.getLogger("server")
 
@@ -64,7 +65,7 @@ class UserService:
             logger.error(f"Failed to get user profile {user_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to get user profile: {str(e)}",
+                message=operation_failed_message("get user profile"),
                 status_code=500,
             )
     
@@ -150,7 +151,7 @@ class UserService:
             logger.error(f"Failed to add user profile {user_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.PROFILE_UPDATE_FAILED,
-                message=f"Failed to add user profile: {str(e)}",
+                message=operation_failed_message("add user profile"),
                 status_code=500,
             )
 
@@ -212,7 +213,7 @@ class UserService:
             logger.error(f"Failed to update user memory {memory_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to update user memory: {str(e)}",
+                message=operation_failed_message("update user memory"),
                 status_code=500,
             )
     
@@ -263,7 +264,7 @@ class UserService:
             logger.error(f"Failed to get user memories {user_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to get user memories: {str(e)}",
+                message=operation_failed_message("get user memories"),
                 status_code=500,
             )
     
@@ -320,7 +321,7 @@ class UserService:
             logger.error(f"Failed to delete user memories {user_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to delete user memories: {str(e)}",
+                message=operation_failed_message("delete user memories"),
                 status_code=500,
             )
     
@@ -378,7 +379,7 @@ class UserService:
             logger.error(f"Failed to delete user profile {user_id}: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to delete user profile: {str(e)}",
+                message=operation_failed_message("delete user profile"),
                 status_code=500,
             )
 
@@ -417,7 +418,7 @@ class UserService:
             logger.error(f"Failed to get profiles: {e}", exc_info=True)
             raise APIError(
                 code=ErrorCode.INTERNAL_ERROR,
-                message=f"Failed to get profiles: {str(e)}",
+                message=operation_failed_message("get profiles"),
                 status_code=500,
             )
 

--- a/src/server/utils/health_check.py
+++ b/src/server/utils/health_check.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, Tuple
 
 from ..models.response import DependencyStatus
 from ..config import config
+from .service_errors import dependency_unavailable_message
 
 
 logger = logging.getLogger("server")
@@ -126,18 +127,15 @@ def _check_database_sync() -> DependencyStatus:
             latency_ms=round(latency_ms, 2),
             last_checked=datetime.utcnow(),
         )
-    except Exception as e:
+    except Exception:
         latency_ms = (time.time() - start_time) * 1000
-        error_msg = str(e)
-        # Truncate long error messages
-        if len(error_msg) > 200:
-            error_msg = error_msg[:197] + "..."
+        logger.exception("Database dependency health check failed")
             
         return DependencyStatus(
             name="database",
             status="unavailable",
             latency_ms=round(latency_ms, 2),
-            error_message=error_msg,
+            error_message=dependency_unavailable_message("database"),
             last_checked=datetime.utcnow(),
         )
 
@@ -219,18 +217,15 @@ def _check_llm_sync() -> DependencyStatus:
             latency_ms=round(latency_ms, 2),
             last_checked=datetime.utcnow(),
         )
-    except Exception as e:
+    except Exception:
         latency_ms = (time.time() - start_time) * 1000
-        error_msg = str(e)
-        # Truncate long error messages
-        if len(error_msg) > 200:
-            error_msg = error_msg[:197] + "..."
+        logger.exception("LLM dependency health check failed")
             
         return DependencyStatus(
             name="llm",
             status="unavailable",
             latency_ms=round(latency_ms, 2),
-            error_message=error_msg,
+            error_message=dependency_unavailable_message("llm"),
             last_checked=datetime.utcnow(),
         )
 

--- a/src/server/utils/service_errors.py
+++ b/src/server/utils/service_errors.py
@@ -11,6 +11,7 @@ STORAGE_RECOMMENDATION_MESSAGE = (
     "For the full PowerMem capability stack, use embedded SeekDB on Linux "
     'with "powermem[seekdb]" or configure remote OceanBase with OCEANBASE_HOST.'
 )
+PUBLIC_DEPENDENCY_ERROR_MESSAGE = "Dependency check failed"
 
 
 def public_startup_error_message() -> str:
@@ -19,6 +20,14 @@ def public_startup_error_message() -> str:
 
 def public_startup_error_with_recommendation() -> str:
     return f"{PUBLIC_STARTUP_ERROR_MESSAGE}. {STORAGE_RECOMMENDATION_MESSAGE}"
+
+
+def dependency_unavailable_message(dependency_name: str) -> str:
+    return f"{dependency_name} {PUBLIC_DEPENDENCY_ERROR_MESSAGE.lower()}"
+
+
+def operation_failed_message(operation: str) -> str:
+    return f"Failed to {operation}"
 
 
 def service_unavailable_message(_request: Request, service_name: str) -> str:

--- a/tests/unit/server/test_health_check.py
+++ b/tests/unit/server/test_health_check.py
@@ -7,6 +7,22 @@ import pytest
 from server.models.response import DependencyStatus
 from server.utils import health_check
 
+SENSITIVE_DEPENDENCY_ERROR = (
+    "failed to connect to postgresql://user:SYNTHETIC_SECRET@db.example/powermem "
+    "from /synthetic/local/path"
+)
+SENSITIVE_FRAGMENTS = (
+    "postgresql://user",
+    "SYNTHETIC_SECRET",
+    "db.example",
+    "/synthetic/local/path",
+)
+
+
+def assert_sensitive_dependency_error_hidden(message: str):
+    for fragment in SENSITIVE_FRAGMENTS:
+        assert fragment not in message
+
 
 @pytest.fixture(autouse=True)
 def clear_dependency_probe_state():
@@ -136,3 +152,35 @@ async def test_dependency_status_coalesces_concurrent_same_dependency(monkeypatc
 
     assert calls == {"database": 1}
     assert {result.status for result in results} == {"healthy"}
+
+
+def test_database_probe_error_message_does_not_expose_raw_exception(monkeypatch):
+    import powermem
+
+    class FailingMemory:
+        def __init__(self, config):
+            raise RuntimeError(SENSITIVE_DEPENDENCY_ERROR)
+
+    monkeypatch.setattr(powermem, "auto_config", lambda: {})
+    monkeypatch.setattr(powermem, "Memory", FailingMemory)
+
+    status = health_check._check_database_sync()
+
+    assert status.status == "unavailable"
+    assert status.error_message
+    assert_sensitive_dependency_error_hidden(status.error_message)
+
+
+def test_llm_probe_error_message_does_not_expose_raw_exception(monkeypatch):
+    import powermem
+
+    def fail_config_load():
+        raise RuntimeError(SENSITIVE_DEPENDENCY_ERROR)
+
+    monkeypatch.setattr(powermem, "auto_config", fail_config_load)
+
+    status = health_check._check_llm_sync()
+
+    assert status.status == "unavailable"
+    assert status.error_message
+    assert_sensitive_dependency_error_hidden(status.error_message)

--- a/tests/unit/server/test_system_health.py
+++ b/tests/unit/server/test_system_health.py
@@ -88,6 +88,43 @@ def test_authenticated_status_does_not_expose_startup_error(monkeypatch):
     assert_sensitive_startup_error_hidden(body)
 
 
+def test_authenticated_status_does_not_expose_dependency_probe_error(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from server.api.v1 import system
+    from server.api.v1.system import router
+    from server.config import config
+    from server.models.response import DependencyStatus
+
+    async def dependency_check_with_raw_error():
+        return {
+            "database": DependencyStatus(
+                name="database",
+                status="unavailable",
+                error_message=SENSITIVE_STARTUP_ERROR,
+            )
+        }
+
+    monkeypatch.setattr(config, "auth_enabled", True)
+    monkeypatch.setattr(config, "api_keys", "secret")
+    monkeypatch.setattr(system, "check_all_dependencies", dependency_check_with_raw_error)
+
+    app = build_app_with_startup_error()
+    app.state.service_startup_error = None
+    app.state.service_ready = True
+    app.include_router(router, prefix="/api/v1")
+
+    response = TestClient(app).get(
+        "/api/v1/system/status",
+        headers={"X-API-Key": "secret"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["dependencies"]["database"]["error_message"]
+    assert_sensitive_startup_error_hidden(body)
+
+
 def test_status_fallback_does_not_expose_startup_error(monkeypatch):
     from fastapi.testclient import TestClient
 
@@ -140,4 +177,75 @@ def test_service_unavailable_response_does_not_expose_startup_error(monkeypatch)
     assert response.status_code == 503
     body = response.json()
     assert body["error"]["message"]
+    assert_sensitive_startup_error_hidden(body)
+
+
+def test_service_layer_error_response_does_not_expose_raw_exception(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from server.api.v1 import router
+    from server.config import config
+    from server.middleware.error_handler import error_handler
+    from server.models.errors import APIError
+    from server.services.user_service import UserService
+
+    class FailingUserMemory:
+        def profile(self, user_id):
+            raise RuntimeError(SENSITIVE_STARTUP_ERROR)
+
+    monkeypatch.setattr(config, "auth_enabled", True)
+    monkeypatch.setattr(config, "api_keys", "secret")
+
+    service = UserService.__new__(UserService)
+    service.user_memory = FailingUserMemory()
+
+    app = build_app_with_startup_error()
+    app.state.user_service = service
+    app.add_exception_handler(APIError, error_handler)
+    app.include_router(router)
+
+    response = TestClient(app).get(
+        "/api/v1/users/user-1/profile",
+        headers={"X-API-Key": "secret"},
+    )
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["error"]["message"]
+    assert_sensitive_startup_error_hidden(body)
+
+
+def test_batch_response_data_does_not_expose_raw_exception(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from server.api.v1 import router
+    from server.config import config
+    from server.middleware.error_handler import error_handler
+    from server.models.errors import APIError
+    from server.services.memory_service import MemoryService
+
+    class FailingMemory:
+        def add(self, **kwargs):
+            raise RuntimeError(SENSITIVE_STARTUP_ERROR)
+
+    monkeypatch.setattr(config, "auth_enabled", True)
+    monkeypatch.setattr(config, "api_keys", "secret")
+
+    service = MemoryService.__new__(MemoryService)
+    service.memory = FailingMemory()
+
+    app = build_app_with_startup_error()
+    app.state.memory_service = service
+    app.add_exception_handler(APIError, error_handler)
+    app.include_router(router)
+
+    response = TestClient(app).post(
+        "/api/v1/memories/batch",
+        headers={"X-API-Key": "secret"},
+        json={"memories": [{"content": "remember this"}]},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["failed"][0]["error"]
     assert_sensitive_startup_error_hidden(body)


### PR DESCRIPTION
## Summary
- Sanitize runtime dependency probe failures before they reach `/api/v1/system/status`, and keep raw probe exceptions in server logs only.
- Replace request-path service `APIError` messages and batch item errors that previously embedded `str(e)` with generic public messages.
- Add regression coverage for synthetic DSN/secret/path exposure in dependency checks, status dependencies, service-layer errors, and batch response data.

## Stack note
- This branch is stacked on #1136 because #1137 reuses the safe startup-error helpers added there.
- The #1137-specific commit is `a37bb5d` (`fix(server): sanitize runtime exception responses`). After #1136 merges, this PR diff should collapse to the #1137 changes only.

## Test plan
- `python -m pytest tests/unit/server/test_health_check.py tests/unit/server/test_system_health.py`
- `python -m pytest tests/unit/server`
- `git diff --check`
- `python -m pytest tests/unit` was attempted locally; it still fails on unrelated local environment/tool assumptions, including API/model environment overrides, missing ModelScope cache, Windows script/tool availability, and an existing sqlite FTS setup error.

Fixes #1137