### PR TITLE
fix(ci): align main action checks with current CLI behavior

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -47,3 +47,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          timeout: '1200000'

--- a/tests/regression/test_powermem_cli.py
+++ b/tests/regression/test_powermem_cli.py
@@ -363,9 +363,12 @@ class TestMemoryAdd:
         assert_contains(rc, out, err, ["[SUCCESS]", "Memory ADD", "ID="])
     
     def test_memory_add_empty_content(self, cli_runner):
-        """memory add with empty content should show warning"""
+        """memory add with empty content should fail with a clear validation error"""
         rc, out, err = cli_runner.pmem('memory add ""')
-        assert_contains(rc, out, err, ["WARNING", "No memory"])
+        assert rc != 0, (
+            f"Expected non-zero exit code for empty content\nstdout: {out}\nstderr: {err}"
+        )
+        assert_contains(rc, out, err, ["ERROR", "Missing argument 'CONTENT'"])
     
     def test_memory_add_with_scope_and_type(self, cli_runner, test_data):
         """memory add --scope --memory-type should succeed, output format [SUCCESS] Memory ADD: ID=xxx"""

--- a/tests/unit/test_cli_export_import.py
+++ b/tests/unit/test_cli_export_import.py
@@ -58,6 +58,17 @@ def mock_memory():
     return _make_mock_memory()
 
 
+class TestMemoryAddValidation:
+
+    def test_add_empty_content_fails_before_backend(self, runner, mock_memory):
+        with patch("powermem.cli.commands.memory.CLIContext.memory",
+                   new_callable=PropertyMock, return_value=mock_memory):
+            result = runner.invoke(cli, ["memory", "add", ""])
+        assert result.exit_code != 0
+        assert "Missing argument 'CONTENT'" in result.output
+        mock_memory.add.assert_not_called()
+
+
 # ==================== Export ====================
 
 class TestExport:


### PR DESCRIPTION
## Summary

- update the empty-content CLI regression expectation to match the current validation error
- add a unit guard so `memory add ""` fails before calling the backend
- extend the GitHub Pages deployment queue timeout for `actions/deploy-pages`

## Testing

- `python -m pytest tests/unit/test_cli_export_import.py -q`
- `python -m pytest tests/regression/test_powermem_cli.py::TestMemoryAdd::test_memory_add_empty_content -q`
- `pmem -f .env.example memory add ""`
- parsed `.github/workflows/deploy_pages.yml` and verified the Pages timeout input
- `git diff --check`
