### PR TITLE
fix(agent): normalize permission checks

### DIFF
--- a/src/powermem/agent/components/permission_controller.py
+++ b/src/powermem/agent/components/permission_controller.py
@@ -10,11 +10,30 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Set
 
-from typing import Any, Dict
+from powermem.agent.utils.memory_id import memory_key_variants
 from powermem.agent.types import AccessPermission
 from powermem.agent.abstract.permission import AgentPermissionManagerBase
 
 logger = logging.getLogger(__name__)
+
+
+def _permission_value(permission: AccessPermission) -> str:
+    """Normalize permission to lowercase string value for role list comparison."""
+    if isinstance(permission, AccessPermission):
+        return permission.value
+    return str(permission).lower()
+
+
+def _memory_id_keys(memory_id: Any) -> List[Any]:
+    """Return memory id lookup keys while preserving non-numeric legacy ids."""
+    keys = [memory_id]
+    try:
+        for key in memory_key_variants(memory_id):
+            if key not in keys:
+                keys.append(key)
+    except ValueError:
+        pass
+    return keys
 
 
 class PermissionController(AgentPermissionManagerBase):
@@ -103,23 +122,25 @@ class PermissionController(AgentPermissionManagerBase):
         """
         try:
             # Check direct memory permissions
-            if memory_id in self.memory_permissions:
-                if agent_id in self.memory_permissions[memory_id]:
-                    if permission in self.memory_permissions[memory_id][agent_id]:
-                        self._log_access(agent_id, memory_id, permission, "granted")
-                        return True
+            for memory_key in _memory_id_keys(memory_id):
+                if memory_key in self.memory_permissions:
+                    if agent_id in self.memory_permissions[memory_key]:
+                        if permission in self.memory_permissions[memory_key][agent_id]:
+                            self._log_access(agent_id, memory_id, permission, "granted")
+                            return True
             
             # Check role-based permissions
+            perm_value = _permission_value(permission)
             if agent_id in self.agent_roles:
                 for role in self.agent_roles[agent_id]:
                     if role in self.role_permissions:
-                        if permission in self.role_permissions[role]:
+                        if perm_value in self.role_permissions[role]:
                             self._log_access(agent_id, memory_id, permission, "granted_by_role")
                             return True
             
             # Check default permissions
             if "public" in self.role_permissions:
-                if permission in self.role_permissions["public"]:
+                if perm_value in self.role_permissions["public"]:
                     self._log_access(agent_id, memory_id, permission, "granted_by_default")
                     return True
             
@@ -191,6 +212,12 @@ class PermissionController(AgentPermissionManagerBase):
                 'agent_id': agent_id,
             }
     
+    def revoke_all_for_memory(self, memory_id: str) -> None:
+        """Remove all permission records for a memory."""
+        for memory_key in _memory_id_keys(memory_id):
+            if memory_key in self.memory_permissions:
+                del self.memory_permissions[memory_key]
+
     def revoke_permission(
         self,
         memory_id: str,
@@ -511,25 +538,27 @@ class PermissionController(AgentPermissionManagerBase):
             }
             
             # Check direct memory permissions
-            if memory_id in self.memory_permissions:
-                if agent_id in self.memory_permissions[memory_id]:
-                    if permission in self.memory_permissions[memory_id][agent_id]:
-                        validation_result['valid'] = True
-                        validation_result['validation_path'].append('direct_memory_permission')
-                        return validation_result
+            for memory_key in _memory_id_keys(memory_id):
+                if memory_key in self.memory_permissions:
+                    if agent_id in self.memory_permissions[memory_key]:
+                        if permission in self.memory_permissions[memory_key][agent_id]:
+                            validation_result['valid'] = True
+                            validation_result['validation_path'].append('direct_memory_permission')
+                            return validation_result
             
             # Check role-based permissions
+            perm_value = _permission_value(permission)
             if agent_id in self.agent_roles:
                 for role in self.agent_roles[agent_id]:
                     if role in self.role_permissions:
-                        if permission in self.role_permissions[role]:
+                        if perm_value in self.role_permissions[role]:
                             validation_result['valid'] = True
                             validation_result['validation_path'].append(f'role_permission:{role}')
                             return validation_result
             
             # Check default permissions
             if "public" in self.role_permissions:
-                if permission in self.role_permissions["public"]:
+                if perm_value in self.role_permissions["public"]:
                     validation_result['valid'] = True
                     validation_result['validation_path'].append('default_permission')
                     return validation_result

--- a/src/powermem/agent/implementations/multi_agent.py
+++ b/src/powermem/agent/implementations/multi_agent.py
@@ -1087,7 +1087,7 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             if isinstance(permission, AccessPermission):
                 permission_enum = permission
             else:
-                permission_enum = AccessPermission(permission.upper())
+                permission_enum = AccessPermission(str(permission).lower())
             return self.permission_controller.check_permission(agent_id, memory_id, permission_enum)
         except (ValueError, Exception):
             return False

--- a/src/powermem/agent/utils/__init__.py
+++ b/src/powermem/agent/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Agent layer utility helpers."""
+
+from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+
+__all__ = ["normalize_memory_id", "memory_key_variants"]

--- a/src/powermem/agent/utils/memory_id.py
+++ b/src/powermem/agent/utils/memory_id.py
@@ -1,0 +1,26 @@
+"""Memory ID normalization helpers for AgentMemory layer."""
+
+from typing import List, Union
+
+
+MemoryIdInput = Union[str, int]
+
+
+def normalize_memory_id(memory_id: MemoryIdInput) -> int:
+    """Normalize Snowflake memory id to int; raise ValueError for invalid input."""
+    if isinstance(memory_id, bool):
+        raise ValueError(f"Invalid memory_id type: {type(memory_id)}")
+    if isinstance(memory_id, int):
+        return memory_id
+    if isinstance(memory_id, str):
+        stripped = memory_id.strip()
+        if not stripped:
+            raise ValueError("memory_id cannot be empty")
+        return int(stripped)
+    raise ValueError(f"Invalid memory_id type: {type(memory_id)}")
+
+
+def memory_key_variants(memory_id: MemoryIdInput) -> List[Union[int, str]]:
+    """Return int/str key variants for transitional cache lookup."""
+    normalized = normalize_memory_id(memory_id)
+    return [normalized, str(normalized)]

--- a/tests/unit/agent/test_memory_id_normalize.py
+++ b/tests/unit/agent/test_memory_id_normalize.py
@@ -1,0 +1,25 @@
+"""Unit tests for memory id normalization helpers."""
+
+import pytest
+
+from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+
+
+def test_normalize_memory_id_accepts_int_and_string():
+    assert normalize_memory_id(123) == 123
+    assert normalize_memory_id("123") == 123
+    assert normalize_memory_id(" 456 ") == 456
+
+
+def test_memory_key_variants_include_int_and_str():
+    assert memory_key_variants(123) == [123, "123"]
+
+
+def test_normalize_memory_id_rejects_empty_string():
+    with pytest.raises(ValueError):
+        normalize_memory_id("")
+
+
+def test_normalize_memory_id_rejects_invalid_type():
+    with pytest.raises(ValueError):
+        normalize_memory_id(True)

--- a/tests/unit/agent/test_permission_controller.py
+++ b/tests/unit/agent/test_permission_controller.py
@@ -1,0 +1,97 @@
+"""Unit tests for permission controller enum/string comparison fixes."""
+
+from types import SimpleNamespace
+
+from powermem.agent.components.permission_controller import PermissionController
+from powermem.agent.implementations.multi_agent import MultiAgentMemoryManager
+from powermem.agent.types import AccessPermission
+
+
+def _build_permission_controller() -> PermissionController:
+    controller = PermissionController.__new__(PermissionController)
+    controller.config = SimpleNamespace(
+        agent_memory=SimpleNamespace(
+            multi_agent_config=SimpleNamespace(
+                default_permissions={
+                    "owner": ["read", "write", "delete", "share", "admin"],
+                    "public": ["read"],
+                },
+                agent_groups={},
+            )
+        )
+    )
+    controller.multi_agent_config = controller.config.agent_memory.multi_agent_config
+    controller.memory_permissions = {}
+    controller.role_permissions = controller.multi_agent_config.default_permissions
+    controller.access_log = []
+    controller.agent_roles = {"agent-1": ["owner"]}
+    return controller
+
+
+def test_role_fallback_grants_read_with_enum():
+    controller = _build_permission_controller()
+
+    assert controller.check_permission(
+        "agent-1", "memory-1", AccessPermission.READ
+    ) is True
+
+
+def test_default_public_permission_grants_read_with_enum():
+    controller = _build_permission_controller()
+
+    assert controller.check_permission(
+        "agent-without-role", "memory-1", AccessPermission.READ
+    ) is True
+
+
+def test_direct_grant_still_works():
+    controller = _build_permission_controller()
+    controller.grant_permission(
+        memory_id="memory-1",
+        agent_id="agent-2",
+        permission=AccessPermission.WRITE,
+        granted_by="agent-1",
+    )
+
+    assert controller.check_permission(
+        "agent-2", "memory-1", AccessPermission.WRITE
+    ) is True
+
+
+def test_direct_grant_matches_int_and_string_memory_ids():
+    controller = _build_permission_controller()
+    controller.grant_permission(
+        memory_id=123,
+        agent_id="agent-2",
+        permission=AccessPermission.WRITE,
+        granted_by="agent-1",
+    )
+
+    assert controller.check_permission(
+        "agent-2", "123", AccessPermission.WRITE
+    ) is True
+
+
+def test_revoke_all_for_memory_removes_bulk_permission_records():
+    controller = _build_permission_controller()
+    controller.grant_permission(
+        memory_id="memory-1",
+        agent_id="agent-2",
+        permission=AccessPermission.WRITE,
+        granted_by="agent-1",
+    )
+
+    controller.revoke_all_for_memory("memory-1")
+
+    assert "memory-1" not in controller.memory_permissions
+
+
+def test_multi_agent_wrapper_accepts_read_string_variants():
+    manager = MultiAgentMemoryManager.__new__(MultiAgentMemoryManager)
+    manager.permission_controller = _build_permission_controller()
+
+    assert manager.check_permission("agent-1", "memory-1", "read") is True
+    assert manager.check_permission("agent-1", "memory-1", "READ") is True
+    assert manager.check_permission(
+        "agent-1", "memory-1", AccessPermission.READ
+    ) is True


### PR DESCRIPTION
## Summary
- Normalize enum permissions before comparing against string role/default permission lists.
- Add bulk permission revocation for memory cleanup.
- Preserve int/string memory-id compatibility for direct permission records.

Fixes #1144

## Test plan
- pytest tests/unit/agent/test_permission_controller.py tests/unit/agent/test_memory_id_normalize.py
- pytest tests/unit/agent/test_permission_controller.py tests/unit/agent/test_memory_id_normalize.py tests/unit/agent/test_multi_agent_crud.py tests/unit/agent/test_multi_user_crud.py tests/unit/agent/test_hybrid_cleanup.py