### PR TITLE
fix(agent): persist agent memory CRUD changes

### DIFF
--- a/src/powermem/agent/agent.py
+++ b/src/powermem/agent/agent.py
@@ -538,7 +538,7 @@ class AgentMemory:
         Update an existing memory.
         
         Args:
-            memory_id: ID of the memory to update
+            memory_id: ID of the memory to update (str or int)
             content: New content for the memory
             user_id: Optional user ID
             agent_id: Optional agent ID
@@ -587,7 +587,7 @@ class AgentMemory:
         Delete a memory.
         
         Args:
-            memory_id: ID of the memory to delete
+            memory_id: ID of the memory to delete (str or int)
             user_id: Optional user ID
             agent_id: Optional agent ID
             

--- a/src/powermem/agent/components/permission_controller.py
+++ b/src/powermem/agent/components/permission_controller.py
@@ -10,11 +10,30 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Set
 
-from typing import Any, Dict
+from powermem.agent.utils.memory_id import memory_key_variants
 from powermem.agent.types import AccessPermission
 from powermem.agent.abstract.permission import AgentPermissionManagerBase
 
 logger = logging.getLogger(__name__)
+
+
+def _permission_value(permission: AccessPermission) -> str:
+    """Normalize permission to lowercase string value for role list comparison."""
+    if isinstance(permission, AccessPermission):
+        return permission.value
+    return str(permission).lower()
+
+
+def _memory_id_keys(memory_id: Any) -> List[Any]:
+    """Return memory id lookup keys while preserving non-numeric legacy ids."""
+    keys = [memory_id]
+    try:
+        for key in memory_key_variants(memory_id):
+            if key not in keys:
+                keys.append(key)
+    except ValueError:
+        pass
+    return keys
 
 
 class PermissionController(AgentPermissionManagerBase):
@@ -103,23 +122,25 @@ class PermissionController(AgentPermissionManagerBase):
         """
         try:
             # Check direct memory permissions
-            if memory_id in self.memory_permissions:
-                if agent_id in self.memory_permissions[memory_id]:
-                    if permission in self.memory_permissions[memory_id][agent_id]:
-                        self._log_access(agent_id, memory_id, permission, "granted")
-                        return True
+            for memory_key in _memory_id_keys(memory_id):
+                if memory_key in self.memory_permissions:
+                    if agent_id in self.memory_permissions[memory_key]:
+                        if permission in self.memory_permissions[memory_key][agent_id]:
+                            self._log_access(agent_id, memory_id, permission, "granted")
+                            return True
             
             # Check role-based permissions
+            perm_value = _permission_value(permission)
             if agent_id in self.agent_roles:
                 for role in self.agent_roles[agent_id]:
                     if role in self.role_permissions:
-                        if permission in self.role_permissions[role]:
+                        if perm_value in self.role_permissions[role]:
                             self._log_access(agent_id, memory_id, permission, "granted_by_role")
                             return True
             
             # Check default permissions
             if "public" in self.role_permissions:
-                if permission in self.role_permissions["public"]:
+                if perm_value in self.role_permissions["public"]:
                     self._log_access(agent_id, memory_id, permission, "granted_by_default")
                     return True
             
@@ -191,6 +212,12 @@ class PermissionController(AgentPermissionManagerBase):
                 'agent_id': agent_id,
             }
     
+    def revoke_all_for_memory(self, memory_id: str) -> None:
+        """Remove all permission records for a memory."""
+        for memory_key in _memory_id_keys(memory_id):
+            if memory_key in self.memory_permissions:
+                del self.memory_permissions[memory_key]
+
     def revoke_permission(
         self,
         memory_id: str,
@@ -511,25 +538,27 @@ class PermissionController(AgentPermissionManagerBase):
             }
             
             # Check direct memory permissions
-            if memory_id in self.memory_permissions:
-                if agent_id in self.memory_permissions[memory_id]:
-                    if permission in self.memory_permissions[memory_id][agent_id]:
-                        validation_result['valid'] = True
-                        validation_result['validation_path'].append('direct_memory_permission')
-                        return validation_result
+            for memory_key in _memory_id_keys(memory_id):
+                if memory_key in self.memory_permissions:
+                    if agent_id in self.memory_permissions[memory_key]:
+                        if permission in self.memory_permissions[memory_key][agent_id]:
+                            validation_result['valid'] = True
+                            validation_result['validation_path'].append('direct_memory_permission')
+                            return validation_result
             
             # Check role-based permissions
+            perm_value = _permission_value(permission)
             if agent_id in self.agent_roles:
                 for role in self.agent_roles[agent_id]:
                     if role in self.role_permissions:
-                        if permission in self.role_permissions[role]:
+                        if perm_value in self.role_permissions[role]:
                             validation_result['valid'] = True
                             validation_result['validation_path'].append(f'role_permission:{role}')
                             return validation_result
             
             # Check default permissions
             if "public" in self.role_permissions:
-                if permission in self.role_permissions["public"]:
+                if perm_value in self.role_permissions["public"]:
                     validation_result['valid'] = True
                     validation_result['validation_path'].append('default_permission')
                     return validation_result

--- a/src/powermem/agent/implementations/hybrid.py
+++ b/src/powermem/agent/implementations/hybrid.py
@@ -7,13 +7,13 @@ which dynamically switches between multi-agent and multi-user modes based on con
 
 import logging
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
-from typing import Any, Dict
 from powermem.intelligence.intelligent_memory_manager import IntelligentMemoryManager
 from powermem.agent.abstract.manager import AgentMemoryManagerBase
 from powermem.agent.implementations.multi_agent import MultiAgentMemoryManager
 from powermem.agent.implementations.multi_user import MultiUserMemoryManager
+from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
 
 logger = logging.getLogger(__name__)
 
@@ -396,7 +396,7 @@ class HybridMemoryManager(AgentMemoryManagerBase):
     
     def update_memory(
         self,
-        memory_id: str,
+        memory_id: Union[str, int],
         agent_id: str,
         updates: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -412,22 +412,23 @@ class HybridMemoryManager(AgentMemoryManagerBase):
             Dictionary containing the updated memory information
         """
         try:
-            # Find which mode the memory belongs to
-            memory_mode = self._get_memory_mode(memory_id)
+            normalized_id = normalize_memory_id(memory_id)
+            memory_mode = self._get_memory_mode(normalized_id)
             
             if not memory_mode:
                 raise ValueError(f"Memory {memory_id} not found in any mode")
             
             # Update with appropriate manager
             if memory_mode == "multi_agent":
-                result = self.multi_agent_manager.update_memory(memory_id, agent_id, updates)
+                result = self.multi_agent_manager.update_memory(normalized_id, agent_id, updates)
             else:
-                result = self.multi_user_manager.update_memory(memory_id, agent_id, updates)
-            
-            # Update unified index
-            if memory_id in self.unified_memory_index:
-                self.unified_memory_index[memory_id]['updated_at'] = datetime.now().isoformat()
-                self.unified_memory_index[memory_id]['updated_by'] = agent_id
+                result = self.multi_user_manager.update_memory(normalized_id, agent_id, updates)
+
+            for key in memory_key_variants(normalized_id):
+                if key in self.unified_memory_index:
+                    self.unified_memory_index[key]['updated_at'] = datetime.now().isoformat()
+                    self.unified_memory_index[key]['updated_by'] = agent_id
+                    break
             
             result['updated_in_mode'] = memory_mode
             logger.info(f"Updated memory {memory_id} in {memory_mode} mode")
@@ -439,7 +440,7 @@ class HybridMemoryManager(AgentMemoryManagerBase):
     
     def delete_memory(
         self,
-        memory_id: str,
+        memory_id: Union[str, int],
         agent_id: str
     ) -> Dict[str, Any]:
         """
@@ -453,26 +454,24 @@ class HybridMemoryManager(AgentMemoryManagerBase):
             Dictionary containing the deletion result
         """
         try:
-            # Find which mode the memory belongs to
-            memory_mode = self._get_memory_mode(memory_id)
+            normalized_id = normalize_memory_id(memory_id)
+            memory_mode = self._get_memory_mode(normalized_id)
             
             if not memory_mode:
                 raise ValueError(f"Memory {memory_id} not found in any mode")
             
             # Delete with appropriate manager
             if memory_mode == "multi_agent":
-                result = self.multi_agent_manager.delete_memory(memory_id, agent_id)
+                result = self.multi_agent_manager.delete_memory(normalized_id, agent_id)
             else:
-                result = self.multi_user_manager.delete_memory(memory_id, agent_id)
-            
-            # Clean up unified index
-            if memory_id in self.unified_memory_index:
-                del self.unified_memory_index[memory_id]
-            
-            # Clean up mode-specific storage
-            if memory_mode in self.mode_specific_memories:
-                if memory_id in self.mode_specific_memories[memory_mode]:
-                    del self.mode_specific_memories[memory_mode][memory_id]
+                result = self.multi_user_manager.delete_memory(normalized_id, agent_id)
+
+            for key in memory_key_variants(normalized_id):
+                if key in self.unified_memory_index:
+                    del self.unified_memory_index[key]
+                if memory_mode in self.mode_specific_memories:
+                    if key in self.mode_specific_memories[memory_mode]:
+                        del self.mode_specific_memories[memory_mode][key]
             
             result['deleted_from_mode'] = memory_mode
             logger.info(f"Deleted memory {memory_id} from {memory_mode} mode")
@@ -484,7 +483,7 @@ class HybridMemoryManager(AgentMemoryManagerBase):
     
     def share_memory(
         self,
-        memory_id: str,
+        memory_id: Union[str, int],
         from_agent: str,
         to_agents: List[str],
         permissions: Optional[List[str]] = None
@@ -502,17 +501,21 @@ class HybridMemoryManager(AgentMemoryManagerBase):
             Dictionary containing the sharing result
         """
         try:
-            # Find which mode the memory belongs to
-            memory_mode = self._get_memory_mode(memory_id)
+            normalized_id = normalize_memory_id(memory_id)
+            memory_mode = self._get_memory_mode(normalized_id)
             
             if not memory_mode:
                 raise ValueError(f"Memory {memory_id} not found in any mode")
             
             # Share with appropriate manager
             if memory_mode == "multi_agent":
-                result = self.multi_agent_manager.share_memory(memory_id, from_agent, to_agents, permissions)
+                result = self.multi_agent_manager.share_memory(
+                    normalized_id, from_agent, to_agents, permissions
+                )
             else:
-                result = self.multi_user_manager.share_memory(memory_id, from_agent, to_agents, permissions)
+                result = self.multi_user_manager.share_memory(
+                    normalized_id, from_agent, to_agents, permissions
+                )
             
             result['shared_from_mode'] = memory_mode
             logger.info(f"Shared memory {memory_id} from {memory_mode} mode")
@@ -616,8 +619,12 @@ class HybridMemoryManager(AgentMemoryManagerBase):
                     cleaned_memory_ids.update(cleanup_result['cleaned_memory_ids'])
             
             for memory_id in cleaned_memory_ids:
-                if memory_id in self.unified_memory_index:
-                    del self.unified_memory_index[memory_id]
+                for key in memory_key_variants(memory_id):
+                    if key in self.unified_memory_index:
+                        del self.unified_memory_index[key]
+                    for mode in self.mode_specific_memories:
+                        if key in self.mode_specific_memories[mode]:
+                            del self.mode_specific_memories[mode][key]
             
             logger.info(f"Cleaned up forgotten memories from both modes: {combined_cleanup}")
             return combined_cleanup
@@ -679,32 +686,40 @@ class HybridMemoryManager(AgentMemoryManagerBase):
             True if the agent/user has the permission, False otherwise
         """
         try:
-            # Find which mode the memory belongs to
-            memory_mode = self._get_memory_mode(memory_id)
-            
+            normalized_id = normalize_memory_id(memory_id)
+            memory_mode = self._get_memory_mode(normalized_id)
+
             if not memory_mode:
                 return False
-            
-            # Check permission with appropriate manager
+
             if memory_mode == "multi_agent":
-                return self.multi_agent_manager.check_permission(agent_id, memory_id, permission)
-            else:
-                return self.multi_user_manager.check_permission(agent_id, memory_id, permission)
+                return self.multi_agent_manager.check_permission(
+                    agent_id, normalized_id, permission
+                )
+            return self.multi_user_manager.check_permission(
+                agent_id, normalized_id, permission
+            )
                 
         except Exception:
             return False
     
-    def _get_memory_mode(self, memory_id: str) -> Optional[str]:
+    def _get_memory_mode(self, memory_id: Union[str, int]) -> Optional[str]:
         """Get the mode that a memory belongs to."""
-        # Check unified index first
-        if memory_id in self.unified_memory_index:
-            return self.unified_memory_index[memory_id]['mode']
-        
-        # Check mode-specific storage
+        normalized_id = normalize_memory_id(memory_id)
+        for key in memory_key_variants(normalized_id):
+            if key in self.unified_memory_index:
+                return self.unified_memory_index[key]['mode']
+
         for mode, memories in self.mode_specific_memories.items():
-            if memory_id in memories:
-                return mode
-        
+            for key in memory_key_variants(normalized_id):
+                if key in memories:
+                    return mode
+
+        if self.multi_agent_manager._find_memory(normalized_id):
+            return "multi_agent"
+        if self.multi_user_manager._find_memory(normalized_id):
+            return "multi_user"
+
         return None
     
     def get_mode_info(self) -> Dict[str, Any]:

--- a/src/powermem/agent/implementations/multi_agent.py
+++ b/src/powermem/agent/implementations/multi_agent.py
@@ -22,6 +22,7 @@ from powermem.agent.components.permission_controller import PermissionController
 from powermem.agent.components.collaboration_coordinator import CollaborationCoordinator
 from powermem.agent.components.privacy_protector import PrivacyProtector
 from powermem.agent.filters import matches_memory_filters
+from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
 
 logger = logging.getLogger(__name__)
 
@@ -311,6 +312,19 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             logger.error(f"Failed to process memory for agent {agent_id}: {e}", exc_info=True)
             raise
     
+    def _get_or_create_memory_instance(self):
+        """Lazy-init and return the underlying Memory instance."""
+        if not hasattr(self, '_memory_instance'):
+            from powermem.core.memory import Memory
+            if hasattr(self.config, '_data'):
+                config_dict = self.config._data
+            elif hasattr(self.config, 'to_dict'):
+                config_dict = self.config.to_dict()
+            else:
+                config_dict = self.config
+            self._memory_instance = Memory(config_dict)
+        return self._memory_instance
+
     def _persist_memory_to_storage(self, memory_data: Dict[str, Any]) -> int:
         """
         Persist memory data to database and vector store.
@@ -322,23 +336,12 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             Snowflake ID (int) from database
         """
         try:
-            # Use existing Memory infrastructure
-            if not hasattr(self, '_memory_instance'):
-                from powermem.core.memory import Memory
-                # Convert ConfigObject back to dict for Memory class
-                if hasattr(self.config, '_data'):
-                    config_dict = self.config._data
-                elif hasattr(self.config, 'to_dict'):
-                    config_dict = self.config.to_dict()
-                else:
-                    config_dict = self.config
-                
-                self._memory_instance = Memory(config_dict)
-            
+            memory_instance = self._get_or_create_memory_instance()
+
             # Use the existing Memory.add() method
             # Get the Snowflake ID returned from database to ensure consistency
             # Use infer=False to use simple mode since intelligent processing is already done at agent layer
-            add_result = self._memory_instance.add(
+            add_result = memory_instance.add(
                 messages=memory_data['content'],
                 user_id=memory_data.get('user_id'),
                 agent_id=memory_data.get('agent_id'),
@@ -663,7 +666,7 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
     
     def update_memory(
         self,
-        memory_id: str,
+        memory_id: Union[str, int],
         agent_id: str,
         updates: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -679,48 +682,65 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             Dictionary containing the updated memory information
         """
         try:
-            # Find the memory
-            memory_data = self._find_memory(memory_id)
-            if not memory_data:
+            location = self._locate_memory(memory_id)
+            if not location:
                 raise ValueError(f"Memory {memory_id} not found")
-            
-            # Check permissions
+
+            normalized_id = location['memory_id']
+            memory_data = location['memory_data']
+
             if not self.permission_controller.check_permission(
-                agent_id, memory_id, AccessPermission.WRITE
+                agent_id, normalized_id, AccessPermission.WRITE
             ):
-                raise PermissionError(f"Agent {agent_id} does not have write permission for memory {memory_id}")
-            
-            # Apply updates
-            for key, value in updates.items():
-                if key in memory_data:
-                    memory_data[key] = value
-            
-            memory_data['updated_at'] = datetime.now().isoformat()
-            
-            # Update intelligent memory manager if content changed
-            if 'content' in updates:
-                self.intelligent_manager.update_memory(
-                    memory_id=memory_id,
-                    content=updates['content'],
-                    metadata=memory_data.get('metadata', {})
+                raise PermissionError(
+                    f"Agent {agent_id} does not have write permission for memory {normalized_id}"
                 )
-            
-            logger.info(f"Updated memory {memory_id} by agent {agent_id}")
-            
+
+            merged_metadata = None
+            if 'content' in updates or 'metadata' in updates:
+                merged_metadata = dict(memory_data.get('metadata') or {})
+                if 'metadata' in updates and updates['metadata']:
+                    merged_metadata.update(updates['metadata'])
+                content = updates.get('content', memory_data.get('content'))
+                memory_instance = self._get_or_create_memory_instance()
+                memory_instance.update(
+                    memory_id=normalized_id,
+                    content=content,
+                    user_id=memory_data.get('user_id'),
+                    agent_id=memory_data.get('agent_id'),
+                    metadata=merged_metadata,
+                )
+
+            for key, value in updates.items():
+                if key in memory_data and key != 'metadata':
+                    memory_data[key] = value
+
+            if merged_metadata is not None and 'metadata' in updates:
+                memory_data['metadata'] = merged_metadata
+            memory_data['updated_at'] = datetime.now().isoformat()
+            self._sync_scope_storage_entry(
+                location['scope'],
+                location['memory_type'],
+                normalized_id,
+                memory_data,
+            )
+
+            logger.info(f"Updated memory {normalized_id} by agent {agent_id}")
+
             return {
-                'id': memory_id,
+                'id': normalized_id,
                 'memory': memory_data['content'],
                 'updated_at': memory_data['updated_at'],
                 'agent_id': agent_id,
             }
-            
+
         except Exception as e:
             logger.error(f"Failed to update memory {memory_id}: {e}", exc_info=True)
             raise
-    
+
     def delete_memory(
         self,
-        memory_id: str,
+        memory_id: Union[str, int],
         agent_id: str
     ) -> Dict[str, Any]:
         """
@@ -734,49 +754,49 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             Dictionary containing the deletion result
         """
         try:
-            # Find the memory
-            memory_data = self._find_memory(memory_id)
-            if not memory_data:
+            location = self._locate_memory(memory_id)
+            if not location:
                 raise ValueError(f"Memory {memory_id} not found")
-            
-            # Check permissions
+
+            normalized_id = location['memory_id']
+            memory_data = location['memory_data']
+
             if not self.permission_controller.check_permission(
-                agent_id, memory_id, AccessPermission.DELETE
+                agent_id, normalized_id, AccessPermission.DELETE
             ):
-                raise PermissionError(f"Agent {agent_id} does not have delete permission for memory {memory_id}")
-            
-            # Remove from scope-based storage
-            scope = memory_data['scope']
-            memory_type = memory_data['memory_type']
-            del self.scope_memories[scope][memory_type][memory_id]
-            
-            # Clean up permissions
-            self.permission_controller.revoke_permission(
-                memory_id=memory_id,
-                agent_id=agent_id,
-                permission=AccessPermission.DELETE,
-                revoked_by=agent_id
+                raise PermissionError(
+                    f"Agent {agent_id} does not have delete permission for memory {normalized_id}"
+                )
+
+            memory_instance = self._get_or_create_memory_instance()
+            memory_instance.delete(
+                memory_id=normalized_id,
+                user_id=memory_data.get('user_id'),
+                agent_id=memory_data.get('agent_id'),
             )
-            
-            # Clean up collaboration if applicable
-            if memory_id in self.collaboration_memories:
-                del self.collaboration_memories[memory_id]
-            
-            logger.info(f"Deleted memory {memory_id} by agent {agent_id}")
-            
+
+            self._remove_memory_from_cache(location)
+            self._revoke_memory_permissions(normalized_id)
+
+            for key in memory_key_variants(normalized_id):
+                if key in self.collaboration_memories:
+                    del self.collaboration_memories[key]
+
+            logger.info(f"Deleted memory {normalized_id} by agent {agent_id}")
+
             return {
                 'success': True,
-                'deleted_id': memory_id,
+                'deleted_id': normalized_id,
                 'deleted_by': agent_id,
             }
-            
+
         except Exception as e:
             logger.error(f"Failed to delete memory {memory_id}: {e}", exc_info=True)
             raise
-    
+
     def share_memory(
         self,
-        memory_id: str,
+        memory_id: Union[str, int],
         from_agent: str,
         to_agents: List[str],
         permissions: Optional[List[str]] = None
@@ -794,65 +814,63 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             Dictionary containing the sharing result
         """
         try:
-            # Find the memory
-            memory_data = self._find_memory(memory_id)
-            if not memory_data:
+            location = self._locate_memory(memory_id)
+            if not location:
                 raise ValueError(f"Memory {memory_id} not found")
-            
-            # Check if sharing agent has share permission
+
+            normalized_id = location['memory_id']
+            memory_data = location['memory_data']
+
             if not self.permission_controller.check_permission(
-                from_agent, memory_id, AccessPermission.SHARE
+                from_agent, normalized_id, AccessPermission.SHARE
             ):
-                raise PermissionError(f"Agent {from_agent} does not have share permission for memory {memory_id}")
-            
-            # Grant permissions to target agents
+                raise PermissionError(
+                    f"Agent {from_agent} does not have share permission for memory {normalized_id}"
+                )
+
             shared_with = []
             default_permissions = permissions or ['read']
-            
-            for agent_id in to_agents:
+
+            for target_agent in to_agents:
                 for perm in default_permissions:
                     try:
-                        # Handle both string and AccessPermission enum inputs
                         if isinstance(perm, AccessPermission):
                             permission = perm
                         else:
-                            # Convert to AccessPermission enum (case insensitive)
                             permission = AccessPermission(perm.lower())
                         self.permission_controller.grant_permission(
-                            memory_id=memory_id,
-                            agent_id=agent_id,
+                            memory_id=normalized_id,
+                            agent_id=target_agent,
                             permission=permission,
                             granted_by=from_agent
                         )
-                        shared_with.append(agent_id)
+                        if target_agent not in shared_with:
+                            shared_with.append(target_agent)
                     except ValueError:
                         logger.warning(f"Invalid permission: {perm}")
-            
-            # Update memory data to include shared_with list for scope access
-            memory_data = self._find_memory(memory_id)
-            if memory_data:
-                if 'shared_with' not in memory_data:
-                    memory_data['shared_with'] = []
-                memory_data['shared_with'].extend(shared_with)
-                
-                # Also update in scope controller's storage
-                if self.scope_controller:
-                    for scope in MemoryScope:
-                        for memory_type in MemoryType:
-                            if memory_id in self.scope_controller.scope_storage[scope][memory_type]:
-                                self.scope_controller.scope_storage[scope][memory_type][memory_id] = memory_data
-                                break
-            
-            logger.info(f"Shared memory {memory_id} from {from_agent} to {len(shared_with)} agents")
-            
+
+            if 'shared_with' not in memory_data:
+                memory_data['shared_with'] = []
+            memory_data['shared_with'].extend(shared_with)
+            self._sync_scope_storage_entry(
+                location['scope'],
+                location['memory_type'],
+                normalized_id,
+                memory_data,
+            )
+
+            logger.info(
+                f"Shared memory {normalized_id} from {from_agent} to {len(shared_with)} agents"
+            )
+
             return {
                 'success': True,
-                'memory_id': memory_id,
+                'memory_id': normalized_id,
                 'shared_from': from_agent,
                 'shared_with': shared_with,
                 'permissions': default_permissions,
             }
-            
+
         except Exception as e:
             logger.error(f"Failed to share memory {memory_id}: {e}", exc_info=True)
             raise
@@ -915,14 +933,6 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             for scope in MemoryScope:
                 for memory_type in MemoryType:
                     for memory_id, memory_data in self.scope_memories[scope][memory_type].items():
-                        # Update decay using intelligent memory manager
-                        # Note: IntelligentMemoryManager.update_memory_decay() updates all memories
-                        # We'll call it once and then process individual results
-                        if not hasattr(self, '_decay_updated'):
-                            self.intelligent_manager.update_memory_decay()
-                            self._decay_updated = True
-                        
-                        # For individual memory processing, we'll use a simplified approach
                         current_score = memory_data.get('retention_score', 1.0)
                         access_count = memory_data.get('access_count', 0)
                         last_accessed = memory_data.get('last_accessed')
@@ -980,30 +990,60 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                 'cleaned_memories': 0,
                 'archived_memories': 0,
                 'deleted_memories': 0,
+                'cleaned_memory_ids': [],
             }
-            
-            # Clean up forgotten memories
+            memory_instance = self._get_or_create_memory_instance()
+
             for scope in MemoryScope:
                 for memory_type in MemoryType:
                     memories_to_remove = []
-                    
-                    for memory_id, memory_data in self.scope_memories[scope][memory_type].items():
+                    processed_ids = set()
+
+                    for cache_key, memory_data in list(
+                        self.scope_memories[scope][memory_type].items()
+                    ):
                         retention_score = memory_data.get('retention_score', 1.0)
-                        
-                        # Check if memory should be cleaned up
-                        if retention_score < 0.1:  # Forgotten threshold
-                            memories_to_remove.append(memory_id)
+                        normalized_id = normalize_memory_id(
+                            memory_data.get('id', cache_key)
+                        )
+                        if normalized_id in processed_ids:
+                            continue
+                        processed_ids.add(normalized_id)
+
+                        if retention_score < 0.1:
+                            memories_to_remove.append((cache_key, normalized_id, memory_data))
                             cleanup_results['deleted_memories'] += 1
-                        elif retention_score < 0.3:  # Archive threshold
-                            # Archive memory instead of deleting
+                        elif retention_score < 0.3:
                             memory_data['archived'] = True
+                            metadata = dict(memory_data.get('metadata') or {})
+                            metadata['archived'] = True
+                            memory_instance.update(
+                                memory_id=normalized_id,
+                                content=memory_data.get('content', ''),
+                                user_id=memory_data.get('user_id'),
+                                agent_id=memory_data.get('agent_id'),
+                                metadata=metadata,
+                            )
+                            memory_data['metadata'] = metadata
                             cleanup_results['archived_memories'] += 1
-                    
-                    # Remove forgotten memories
-                    for memory_id in memories_to_remove:
-                        del self.scope_memories[scope][memory_type][memory_id]
+
+                    for cache_key, normalized_id, memory_data in memories_to_remove:
+                        memory_instance.delete(
+                            memory_id=normalized_id,
+                            user_id=memory_data.get('user_id'),
+                            agent_id=memory_data.get('agent_id'),
+                        )
+                        location = {
+                            'scope': scope,
+                            'memory_type': memory_type,
+                            'cache_key': cache_key,
+                            'memory_id': normalized_id,
+                        }
+                        self._remove_memory_from_cache(location)
+                        self._revoke_memory_permissions(normalized_id)
                         cleanup_results['cleaned_memories'] += 1
-            
+                        cleanup_results['cleaned_memory_ids'].append(normalized_id)
+
             logger.info(f"Cleaned up forgotten memories: {cleanup_results}")
             return cleanup_results
             
@@ -1087,19 +1127,71 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             if isinstance(permission, AccessPermission):
                 permission_enum = permission
             else:
-                permission_enum = AccessPermission(permission.upper())
+                permission_enum = AccessPermission(str(permission).lower())
             return self.permission_controller.check_permission(agent_id, memory_id, permission_enum)
         except (ValueError, Exception):
             return False
     
-    def _find_memory(self, memory_id: str) -> Optional[Dict[str, Any]]:
+    def _find_memory(self, memory_id: Union[str, int]) -> Optional[Dict[str, Any]]:
         """Find a memory by ID across all scopes and types."""
+        location = self._locate_memory(memory_id)
+        if location:
+            return location['memory_data']
+        return None
+
+    def _locate_memory(self, memory_id: Union[str, int]) -> Optional[Dict[str, Any]]:
+        """Locate memory data and cache coordinates by id."""
+        normalized_id = normalize_memory_id(memory_id)
         for scope in MemoryScope:
             for memory_type in MemoryType:
-                if memory_id in self.scope_memories[scope][memory_type]:
-                    return self.scope_memories[scope][memory_type][memory_id]
+                storage = self.scope_memories[scope][memory_type]
+                for key in memory_key_variants(normalized_id):
+                    if key in storage:
+                        return {
+                            'memory_data': storage[key],
+                            'scope': scope,
+                            'memory_type': memory_type,
+                            'cache_key': key,
+                            'memory_id': normalized_id,
+                        }
         return None
-    
+
+    def _remove_memory_from_cache(self, location: Dict[str, Any]) -> None:
+        """Remove a memory entry from scope and scope-controller caches."""
+        scope = location['scope']
+        memory_type = location['memory_type']
+        normalized_id = location['memory_id']
+
+        for key in memory_key_variants(normalized_id):
+            if key in self.scope_memories[scope][memory_type]:
+                del self.scope_memories[scope][memory_type][key]
+
+        if self.scope_controller:
+            for key in memory_key_variants(normalized_id):
+                if key in self.scope_controller.scope_storage[scope][memory_type]:
+                    del self.scope_controller.scope_storage[scope][memory_type][key]
+
+    def _sync_scope_storage_entry(
+        self,
+        scope: MemoryScope,
+        memory_type: MemoryType,
+        memory_id: int,
+        memory_data: Dict[str, Any],
+    ) -> None:
+        """Keep scope_memories and scope_controller storage in sync."""
+        for key in memory_key_variants(memory_id):
+            self.scope_memories[scope][memory_type].pop(key, None)
+        self.scope_memories[scope][memory_type][memory_id] = memory_data
+        if self.scope_controller:
+            for key in memory_key_variants(memory_id):
+                self.scope_controller.scope_storage[scope][memory_type].pop(key, None)
+            self.scope_controller.scope_storage[scope][memory_type][memory_id] = memory_data
+
+    def _revoke_memory_permissions(self, memory_id: Union[str, int]) -> None:
+        """Clear permission records for all id key variants."""
+        for key in memory_key_variants(memory_id):
+            self.permission_controller.revoke_all_for_memory(key)
+
     def create_group(self, group_name: str, agent_ids: List[str], permissions: Optional[Dict[str, List[str]]] = None) -> Dict[str, Any]:
         """
         Create an agent group.

--- a/src/powermem/agent/implementations/multi_user.py
+++ b/src/powermem/agent/implementations/multi_user.py
@@ -16,6 +16,7 @@ from powermem.agent.types import (
     AccessPermission
 )
 from powermem.agent.filters import matches_memory_filters
+from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
 from powermem.intelligence.intelligent_memory_manager import IntelligentMemoryManager
 from powermem.agent.abstract.manager import AgentMemoryManagerBase
 
@@ -237,6 +238,14 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             logger.error(f"Failed to process memory for user {agent_id}: {e}", exc_info=True)
             raise
     
+    def _get_or_create_memory_instance(self):
+        """Lazy-init and return the underlying Memory instance."""
+        if not hasattr(self, '_memory_instance'):
+            from powermem.core.memory import Memory
+            config_dict = self.config._data if hasattr(self.config, '_data') else self.config
+            self._memory_instance = Memory(config_dict)
+        return self._memory_instance
+
     def _persist_memory_to_storage(self, memory_data: Dict[str, Any]) -> int:
         """
         Persist memory data to database and vector store.
@@ -248,17 +257,9 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             Snowflake ID (int) from database
         """
         try:
-            # Use existing Memory infrastructure
-            if not hasattr(self, '_memory_instance'):
-                from powermem.core.memory import Memory
-                # Convert ConfigObject back to dict for Memory class
-                config_dict = self.config._data if hasattr(self.config, '_data') else self.config
-                self._memory_instance = Memory(config_dict)
-            
-            # Use the existing Memory.add() method
-            # Get the Snowflake ID returned from database to ensure consistency
-            # Use infer=False to use simple mode since intelligent processing is already done at agent layer
-            add_result = self._memory_instance.add(
+            memory_instance = self._get_or_create_memory_instance()
+
+            add_result = memory_instance.add(
                 messages=memory_data['content'],
                 user_id=memory_data.get('user_id'),
                 agent_id=memory_data.get('agent_id'),
@@ -668,7 +669,7 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
     
     def update_memory(
         self,
-        memory_id: str,
+        memory_id: Union[str, int],
         agent_id: str,
         updates: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -684,59 +685,71 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             Dictionary containing the updated memory information
         """
         try:
-            # Find the memory
-            memory_data = self._find_memory(memory_id)
-            if not memory_data:
+            location = self._locate_memory(memory_id)
+            if not location:
                 raise ValueError(f"Memory {memory_id} not found")
-            
+
+            normalized_id = location['memory_id']
+            memory_data = location['memory_data']
             user_id = self._extract_user_id(agent_id, None, None)
-            
-            # Check if user owns the memory or has write permission
+
             if memory_data['user_id'] != user_id:
-                # Check shared access
-                if memory_id not in self.shared_memories:
-                    raise PermissionError(f"User {user_id} does not have permission to update memory {memory_id}")
-                
-                sharing_data = self.shared_memories[memory_id]
+                sharing_key = self._shared_memory_key(normalized_id)
+                if sharing_key not in self.shared_memories:
+                    raise PermissionError(
+                        f"User {user_id} does not have permission to update memory {normalized_id}"
+                    )
+                sharing_data = self.shared_memories[sharing_key]
                 if user_id not in sharing_data['shared_with']:
-                    raise PermissionError(f"User {user_id} does not have permission to update memory {memory_id}")
-                
+                    raise PermissionError(
+                        f"User {user_id} does not have permission to update memory {normalized_id}"
+                    )
                 user_permissions = sharing_data['permissions'].get(user_id, [])
                 if 'write' not in user_permissions:
-                    raise PermissionError(f"User {user_id} does not have write permission for memory {memory_id}")
-            
-            # Apply updates
-            for key, value in updates.items():
-                if key in memory_data:
-                    memory_data[key] = value
-            
-            memory_data['updated_at'] = datetime.now().isoformat()
-            
-            # Update intelligent memory manager if content changed
-            if 'content' in updates:
-                self.intelligent_manager.update_memory(
-                    memory_id=memory_id,
-                    content=updates['content'],
-                    metadata=memory_data.get('metadata', {})
+                    raise PermissionError(
+                        f"User {user_id} does not have write permission for memory {normalized_id}"
+                    )
+
+            merged_metadata = None
+            if 'content' in updates or 'metadata' in updates:
+                merged_metadata = dict(memory_data.get('metadata') or {})
+                if 'metadata' in updates and updates['metadata']:
+                    merged_metadata.update(updates['metadata'])
+                content = updates.get('content', memory_data.get('content'))
+                memory_instance = self._get_or_create_memory_instance()
+                memory_instance.update(
+                    memory_id=normalized_id,
+                    content=content,
+                    user_id=memory_data.get('user_id'),
+                    agent_id=memory_data.get('agent_id'),
+                    metadata=merged_metadata,
                 )
-            
-            logger.info(f"Updated memory {memory_id} by user {user_id}")
-            
+
+            for key, value in updates.items():
+                if key in memory_data and key != 'metadata':
+                    memory_data[key] = value
+
+            if merged_metadata is not None and 'metadata' in updates:
+                memory_data['metadata'] = merged_metadata
+            memory_data['updated_at'] = datetime.now().isoformat()
+
+            logger.info(f"Updated memory {normalized_id} by user {user_id}")
+
             return {
-                'id': memory_id,
+                'id': normalized_id,
                 'memory': memory_data['content'],
                 'updated_at': memory_data['updated_at'],
                 'user_id': user_id,
                 'agent_id': agent_id,
             }
-            
+
         except Exception as e:
             logger.error(f"Failed to update memory {memory_id}: {e}", exc_info=True)
             raise
-    
+
     def delete_memory(
         self,
-        memory_id: str,
+        memory_id: Union[str, int],
         agent_id: str
     ) -> Dict[str, Any]:
         """
@@ -750,49 +763,44 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             Dictionary containing the deletion result
         """
         try:
-            # Find the memory
-            memory_data = self._find_memory(memory_id)
-            if not memory_data:
+            location = self._locate_memory(memory_id)
+            if not location:
                 raise ValueError(f"Memory {memory_id} not found")
-            
+
+            normalized_id = location['memory_id']
+            memory_data = location['memory_data']
             user_id = self._extract_user_id(agent_id, None, None)
-            
-            # Check if user owns the memory
+
             if memory_data['user_id'] != user_id:
-                raise PermissionError(f"User {user_id} does not have permission to delete memory {memory_id}")
-            
-            # Remove from user storage
-            user_id = memory_data['user_id']
-            memory_type = memory_data['memory_type']
-            
-            if user_id in self.user_memories and memory_type in self.user_memories[user_id]:
-                if memory_id in self.user_memories[user_id][memory_type]:
-                    del self.user_memories[user_id][memory_type][memory_id]
-            
-            # Clean up sharing data
-            if memory_id in self.shared_memories:
-                del self.shared_memories[memory_id]
-            
-            # Clean up consent records
-            for user_consents in self.consent_records.values():
-                if memory_id in user_consents:
-                    del user_consents[memory_id]
-            
-            logger.info(f"Deleted memory {memory_id} by user {user_id}")
-            
+                raise PermissionError(
+                    f"User {user_id} does not have permission to delete memory {normalized_id}"
+                )
+
+            memory_instance = self._get_or_create_memory_instance()
+            memory_instance.delete(
+                memory_id=normalized_id,
+                user_id=memory_data.get('user_id'),
+                agent_id=memory_data.get('agent_id'),
+            )
+
+            self._remove_memory_from_cache(location)
+            self._clear_shared_records(normalized_id)
+
+            logger.info(f"Deleted memory {normalized_id} by user {user_id}")
+
             return {
                 'success': True,
-                'deleted_id': memory_id,
+                'deleted_id': normalized_id,
                 'deleted_by': user_id,
             }
-            
+
         except Exception as e:
             logger.error(f"Failed to delete memory {memory_id}: {e}", exc_info=True)
             raise
-    
+
     def share_memory(
         self,
-        memory_id: str,
+        memory_id: Union[str, int],
         from_agent: str,
         to_agents: List[str],
         permissions: Optional[List[str]] = None
@@ -810,39 +818,42 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             Dictionary containing the sharing result
         """
         try:
-            # Find the memory
-            memory_data = self._find_memory(memory_id)
-            if not memory_data:
+            location = self._locate_memory(memory_id)
+            if not location:
                 raise ValueError(f"Memory {memory_id} not found")
-            
+
+            normalized_id = location['memory_id']
+            memory_data = location['memory_data']
             from_user_id = self._extract_user_id(from_agent, None, None)
-            
-            # Check if user owns the memory
+
             if memory_data['user_id'] != from_user_id:
-                raise PermissionError(f"User {from_user_id} does not own memory {memory_id}")
-            
-            # Grant shared access
+                raise PermissionError(
+                    f"User {from_user_id} does not own memory {normalized_id}"
+                )
+
             shared_with = []
             default_permissions = permissions or ['read']
-            
-            self._grant_shared_access(memory_id, from_user_id, to_agents)
-            
-            # Update sharing data with permissions
-            if memory_id in self.shared_memories:
-                for user_id in to_agents:
-                    self.shared_memories[memory_id]['permissions'][user_id] = default_permissions
-                    shared_with.append(user_id)
-            
-            logger.info(f"Shared memory {memory_id} from {from_user_id} to {len(shared_with)} users")
-            
+
+            self._grant_shared_access(normalized_id, from_user_id, to_agents)
+
+            sharing_key = self._shared_memory_key(normalized_id)
+            if sharing_key in self.shared_memories:
+                for target_user in to_agents:
+                    self.shared_memories[sharing_key]['permissions'][target_user] = default_permissions
+                    shared_with.append(target_user)
+
+            logger.info(
+                f"Shared memory {normalized_id} from {from_user_id} to {len(shared_with)} users"
+            )
+
             return {
                 'success': True,
-                'memory_id': memory_id,
+                'memory_id': normalized_id,
                 'shared_from': from_user_id,
                 'shared_with': shared_with,
                 'permissions': default_permissions,
             }
-            
+
         except Exception as e:
             logger.error(f"Failed to share memory {memory_id}: {e}", exc_info=True)
             raise
@@ -905,14 +916,6 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             for user_id, user_memory_types in self.user_memories.items():
                 for memory_type in MemoryType:
                     for memory_id, memory_data in user_memory_types[memory_type].items():
-                        # Update decay using intelligent memory manager
-                        # Note: IntelligentMemoryManager.update_memory_decay() updates all memories
-                        # We'll call it once and then process individual results
-                        if not hasattr(self, '_decay_updated'):
-                            self.intelligent_manager.update_memory_decay()
-                            self._decay_updated = True
-                        
-                        # For individual memory processing, we'll use a simplified approach
                         current_score = memory_data.get('retention_score', 1.0)
                         access_count = memory_data.get('access_count', 0)
                         last_accessed = memory_data.get('last_accessed')
@@ -970,30 +973,58 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                 'cleaned_memories': 0,
                 'archived_memories': 0,
                 'deleted_memories': 0,
+                'cleaned_memory_ids': [],
             }
-            
-            # Clean up forgotten memories for all users
+            memory_instance = self._get_or_create_memory_instance()
+
             for user_id, user_memory_types in self.user_memories.items():
                 for memory_type in MemoryType:
                     memories_to_remove = []
-                    
-                    for memory_id, memory_data in user_memory_types[memory_type].items():
+                    processed_ids = set()
+
+                    for cache_key, memory_data in list(user_memory_types[memory_type].items()):
                         retention_score = memory_data.get('retention_score', 1.0)
-                        
-                        # Check if memory should be cleaned up
-                        if retention_score < 0.1:  # Forgotten threshold
-                            memories_to_remove.append(memory_id)
+                        normalized_id = normalize_memory_id(
+                            memory_data.get('id', cache_key)
+                        )
+                        if normalized_id in processed_ids:
+                            continue
+                        processed_ids.add(normalized_id)
+
+                        if retention_score < 0.1:
+                            memories_to_remove.append((cache_key, normalized_id, memory_data))
                             cleanup_results['deleted_memories'] += 1
-                        elif retention_score < 0.3:  # Archive threshold
-                            # Archive memory instead of deleting
+                        elif retention_score < 0.3:
                             memory_data['archived'] = True
+                            metadata = dict(memory_data.get('metadata') or {})
+                            metadata['archived'] = True
+                            memory_instance.update(
+                                memory_id=normalized_id,
+                                content=memory_data.get('content', ''),
+                                user_id=memory_data.get('user_id'),
+                                agent_id=memory_data.get('agent_id'),
+                                metadata=metadata,
+                            )
+                            memory_data['metadata'] = metadata
                             cleanup_results['archived_memories'] += 1
-                    
-                    # Remove forgotten memories
-                    for memory_id in memories_to_remove:
-                        del user_memory_types[memory_type][memory_id]
+
+                    for cache_key, normalized_id, memory_data in memories_to_remove:
+                        memory_instance.delete(
+                            memory_id=normalized_id,
+                            user_id=memory_data.get('user_id'),
+                            agent_id=memory_data.get('agent_id'),
+                        )
+                        location = {
+                            'user_id': user_id,
+                            'memory_type': memory_type,
+                            'cache_key': cache_key,
+                            'memory_id': normalized_id,
+                        }
+                        self._remove_memory_from_cache(location)
+                        self._clear_shared_records(normalized_id)
                         cleanup_results['cleaned_memories'] += 1
-            
+                        cleanup_results['cleaned_memory_ids'].append(normalized_id)
+
             logger.info(f"Cleaned up forgotten memories: {cleanup_results}")
             return cleanup_results
             
@@ -1067,22 +1098,30 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
         try:
             user_id = self._extract_user_id(agent_id, None, None)
             
-            # Find the memory
-            memory_data = self._find_memory(memory_id)
-            if not memory_data:
+            location = self._locate_memory(memory_id)
+            if not location:
                 return False
-            
-            # Check if user owns the memory
+
+            normalized_id = location['memory_id']
+            memory_data = location['memory_data']
+            user_id = self._extract_user_id(agent_id, None, None)
+
             if memory_data['user_id'] == user_id:
                 return True
-            
-            # Check shared access
-            if memory_id in self.shared_memories:
-                sharing_data = self.shared_memories[memory_id]
+
+            perm_value = (
+                permission.value
+                if isinstance(permission, AccessPermission)
+                else str(permission).lower()
+            )
+
+            sharing_key = self._shared_memory_key(normalized_id)
+            if sharing_key in self.shared_memories:
+                sharing_data = self.shared_memories[sharing_key]
                 if user_id in sharing_data['shared_with']:
                     user_permissions = sharing_data['permissions'].get(user_id, [])
-                    return permission.lower() in user_permissions
-            
+                    return perm_value in user_permissions
+
             return False
             
         except Exception:
@@ -1124,10 +1163,53 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             memory_id, memory_type, _ = all_memories[i]
             del self.user_memories[user_id][memory_type][memory_id]
     
-    def _find_memory(self, memory_id: str) -> Optional[Dict[str, Any]]:
+    def _find_memory(self, memory_id: Union[str, int]) -> Optional[Dict[str, Any]]:
         """Find a memory by ID across all users and types."""
+        location = self._locate_memory(memory_id)
+        if location:
+            return location['memory_data']
+        return None
+
+    def _locate_memory(self, memory_id: Union[str, int]) -> Optional[Dict[str, Any]]:
+        """Locate memory data and cache coordinates by id."""
+        normalized_id = normalize_memory_id(memory_id)
         for user_id, user_memory_types in self.user_memories.items():
             for memory_type in MemoryType:
-                if memory_id in user_memory_types[memory_type]:
-                    return user_memory_types[memory_type][memory_id]
+                storage = user_memory_types[memory_type]
+                for key in memory_key_variants(normalized_id):
+                    if key in storage:
+                        return {
+                            'memory_data': storage[key],
+                            'user_id': user_id,
+                            'memory_type': memory_type,
+                            'cache_key': key,
+                            'memory_id': normalized_id,
+                        }
         return None
+
+    def _shared_memory_key(self, memory_id: Union[str, int]) -> Union[int, str]:
+        """Return the canonical shared-memory dict key if present."""
+        for key in memory_key_variants(memory_id):
+            if key in self.shared_memories:
+                return key
+        return normalize_memory_id(memory_id)
+
+    def _remove_memory_from_cache(self, location: Dict[str, Any]) -> None:
+        """Remove a memory entry from user cache."""
+        user_id = location['user_id']
+        memory_type = location['memory_type']
+        if (
+            user_id in self.user_memories
+            and memory_type in self.user_memories[user_id]
+        ):
+            for key in memory_key_variants(location['memory_id']):
+                self.user_memories[user_id][memory_type].pop(key, None)
+
+    def _clear_shared_records(self, memory_id: Union[str, int]) -> None:
+        """Remove sharing and consent records for all id variants."""
+        for key in memory_key_variants(memory_id):
+            if key in self.shared_memories:
+                del self.shared_memories[key]
+            for user_consents in self.consent_records.values():
+                if key in user_consents:
+                    del user_consents[key]

--- a/src/powermem/agent/utils/__init__.py
+++ b/src/powermem/agent/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Agent layer utility helpers."""
+
+from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+
+__all__ = ["normalize_memory_id", "memory_key_variants"]

--- a/src/powermem/agent/utils/memory_id.py
+++ b/src/powermem/agent/utils/memory_id.py
@@ -1,0 +1,26 @@
+"""Memory ID normalization helpers for AgentMemory layer."""
+
+from typing import List, Union
+
+
+MemoryIdInput = Union[str, int]
+
+
+def normalize_memory_id(memory_id: MemoryIdInput) -> int:
+    """Normalize Snowflake memory id to int; raise ValueError for invalid input."""
+    if isinstance(memory_id, bool):
+        raise ValueError(f"Invalid memory_id type: {type(memory_id)}")
+    if isinstance(memory_id, int):
+        return memory_id
+    if isinstance(memory_id, str):
+        stripped = memory_id.strip()
+        if not stripped:
+            raise ValueError("memory_id cannot be empty")
+        return int(stripped)
+    raise ValueError(f"Invalid memory_id type: {type(memory_id)}")
+
+
+def memory_key_variants(memory_id: MemoryIdInput) -> List[Union[int, str]]:
+    """Return int/str key variants for transitional cache lookup."""
+    normalized = normalize_memory_id(memory_id)
+    return [normalized, str(normalized)]

--- a/src/server/services/agent_service.py
+++ b/src/server/services/agent_service.py
@@ -256,7 +256,7 @@ class AgentService:
                     if use_share_method:
                         try:
                             share_result = self.agent_memory.share_memory(
-                                memory_id=str(mem_id),
+                                memory_id=mem_id,
                                 from_agent=agent_id,
                                 to_agents=[target_agent_id],
                             )

--- a/tests/unit/agent/test_hybrid_cleanup.py
+++ b/tests/unit/agent/test_hybrid_cleanup.py
@@ -1,0 +1,39 @@
+"""Unit tests for hybrid manager cleanup index synchronization."""
+
+from unittest.mock import MagicMock
+
+from powermem.agent.implementations.hybrid import HybridMemoryManager
+
+
+def test_cleanup_forgotten_memories_removes_cleaned_ids_from_indexes():
+    manager = HybridMemoryManager.__new__(HybridMemoryManager)
+    manager.multi_agent_manager = MagicMock()
+    manager.multi_user_manager = MagicMock()
+    manager.multi_agent_manager.cleanup_forgotten_memories.return_value = {
+        "cleaned_memories": 1,
+        "archived_memories": 0,
+        "deleted_memories": 1,
+        "cleaned_memory_ids": [123],
+    }
+    manager.multi_user_manager.cleanup_forgotten_memories.return_value = {
+        "cleaned_memories": 0,
+        "archived_memories": 0,
+        "deleted_memories": 0,
+        "cleaned_memory_ids": [],
+    }
+    manager.unified_memory_index = {
+        "123": {"mode": "multi_agent"},
+        456: {"mode": "multi_user"},
+    }
+    manager.mode_specific_memories = {
+        "multi_agent": {123: {"id": 123}},
+        "multi_user": {456: {"id": 456}},
+    }
+
+    result = manager.cleanup_forgotten_memories()
+
+    assert result["total_cleaned"] == 1
+    assert "123" not in manager.unified_memory_index
+    assert 123 not in manager.mode_specific_memories["multi_agent"]
+    assert 456 in manager.unified_memory_index
+    assert 456 in manager.mode_specific_memories["multi_user"]

--- a/tests/unit/agent/test_memory_id_normalize.py
+++ b/tests/unit/agent/test_memory_id_normalize.py
@@ -1,0 +1,25 @@
+"""Unit tests for memory id normalization helpers."""
+
+import pytest
+
+from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+
+
+def test_normalize_memory_id_accepts_int_and_string():
+    assert normalize_memory_id(123) == 123
+    assert normalize_memory_id("123") == 123
+    assert normalize_memory_id(" 456 ") == 456
+
+
+def test_memory_key_variants_include_int_and_str():
+    assert memory_key_variants(123) == [123, "123"]
+
+
+def test_normalize_memory_id_rejects_empty_string():
+    with pytest.raises(ValueError):
+        normalize_memory_id("")
+
+
+def test_normalize_memory_id_rejects_invalid_type():
+    with pytest.raises(ValueError):
+        normalize_memory_id(True)

--- a/tests/unit/agent/test_multi_agent_crud.py
+++ b/tests/unit/agent/test_multi_agent_crud.py
@@ -1,0 +1,143 @@
+"""Unit tests for multi-agent CRUD/id lookup behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from powermem.agent.implementations.multi_agent import MultiAgentMemoryManager
+from powermem.agent.types import AccessPermission, MemoryScope, MemoryType
+
+
+def _build_manager() -> MultiAgentMemoryManager:
+    manager = MultiAgentMemoryManager.__new__(MultiAgentMemoryManager)
+    manager.scope_memories = {
+        scope: {memory_type: {} for memory_type in MemoryType}
+        for scope in MemoryScope
+    }
+    manager.scope_controller = SimpleNamespace(
+        scope_storage={
+            scope: {memory_type: {} for memory_type in MemoryType}
+            for scope in MemoryScope
+        }
+    )
+    manager.permission_controller = MagicMock()
+    manager.permission_controller.check_permission.return_value = True
+    manager.permission_controller.revoke_all_for_memory = MagicMock()
+    manager.collaboration_memories = {}
+    manager._memory_instance = MagicMock()
+    manager._get_or_create_memory_instance = MagicMock(
+        return_value=manager._memory_instance
+    )
+    memory_data = {
+        "id": 123,
+        "content": "hello",
+        "agent_id": "agent-1",
+        "user_id": "user-1",
+        "scope": MemoryScope.PRIVATE,
+        "memory_type": MemoryType.WORKING,
+        "metadata": {},
+    }
+    manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING][123] = memory_data
+    manager.scope_controller.scope_storage[MemoryScope.PRIVATE][MemoryType.WORKING][123] = (
+        memory_data
+    )
+    return manager
+
+
+def _move_memory_to_string_cache_key(manager: MultiAgentMemoryManager) -> None:
+    memory_data = manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING].pop(123)
+    manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING]["123"] = memory_data
+    manager.scope_controller.scope_storage[MemoryScope.PRIVATE][MemoryType.WORKING].pop(123)
+    manager.scope_controller.scope_storage[MemoryScope.PRIVATE][MemoryType.WORKING]["123"] = (
+        memory_data
+    )
+
+
+def test_find_memory_accepts_string_and_int_ids():
+    manager = _build_manager()
+
+    assert manager._find_memory("123")["content"] == "hello"
+    assert manager._find_memory(123)["content"] == "hello"
+
+
+def test_update_memory_persists_to_db_and_does_not_call_dead_intelligent_method():
+    manager = _build_manager()
+    manager.intelligent_manager = MagicMock()
+
+    result = manager.update_memory("123", "agent-1", {"content": "updated"})
+
+    manager._memory_instance.update.assert_called_once()
+    manager.intelligent_manager.update_memory.assert_not_called()
+    assert result["id"] == 123
+    assert result["memory"] == "updated"
+
+
+def test_update_memory_keeps_merged_metadata_in_cache():
+    manager = _build_manager()
+    memory_data = manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING][123]
+    memory_data["metadata"] = {"source": "original"}
+
+    manager.update_memory("123", "agent-1", {"metadata": {"topic": "agent"}})
+
+    assert memory_data["metadata"] == {"source": "original", "topic": "agent"}
+    manager._memory_instance.update.assert_called_once_with(
+        memory_id=123,
+        content="hello",
+        user_id="user-1",
+        agent_id="agent-1",
+        metadata={"source": "original", "topic": "agent"},
+    )
+
+
+def test_update_memory_rekeys_string_cache_entry_without_duplicate():
+    manager = _build_manager()
+    _move_memory_to_string_cache_key(manager)
+
+    manager.update_memory("123", "agent-1", {"content": "updated"})
+
+    storage = manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING]
+    scope_storage = manager.scope_controller.scope_storage[MemoryScope.PRIVATE][
+        MemoryType.WORKING
+    ]
+    assert list(storage.keys()) == [123]
+    assert list(scope_storage.keys()) == [123]
+
+
+def test_delete_memory_calls_db_delete_before_cache_cleanup():
+    manager = _build_manager()
+
+    result = manager.delete_memory("123", "agent-1")
+
+    manager._memory_instance.delete.assert_called_once_with(
+        memory_id=123,
+        user_id="user-1",
+        agent_id="agent-1",
+    )
+    assert manager._find_memory(123) is None
+    assert result["success"] is True
+
+
+def test_delete_memory_removes_all_cache_key_variants():
+    manager = _build_manager()
+    memory_data = manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING][123]
+    manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING]["123"] = memory_data
+    manager.scope_controller.scope_storage[MemoryScope.PRIVATE][MemoryType.WORKING][
+        "123"
+    ] = memory_data
+
+    manager.delete_memory("123", "agent-1")
+
+    assert manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING] == {}
+    assert manager.scope_controller.scope_storage[MemoryScope.PRIVATE][
+        MemoryType.WORKING
+    ] == {}
+
+
+def test_cleanup_forgotten_memories_returns_cleaned_memory_ids():
+    manager = _build_manager()
+    memory_data = manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING][123]
+    memory_data["retention_score"] = 0.05
+
+    result = manager.cleanup_forgotten_memories()
+
+    assert result["cleaned_memory_ids"] == [123]
+    assert manager._find_memory(123) is None

--- a/tests/unit/agent/test_multi_user_crud.py
+++ b/tests/unit/agent/test_multi_user_crud.py
@@ -1,0 +1,96 @@
+"""Unit tests for multi-user CRUD/id lookup behavior."""
+
+from unittest.mock import MagicMock
+
+from powermem.agent.implementations.multi_user import MultiUserMemoryManager
+from powermem.agent.types import MemoryType
+
+
+def _build_manager() -> MultiUserMemoryManager:
+    manager = MultiUserMemoryManager.__new__(MultiUserMemoryManager)
+    manager.user_memories = {"user-1": {memory_type: {} for memory_type in MemoryType}}
+    manager.shared_memories = {}
+    manager.consent_records = {}
+    manager._memory_instance = MagicMock()
+    manager._get_or_create_memory_instance = MagicMock(
+        return_value=manager._memory_instance
+    )
+    memory_data = {
+        "id": 123,
+        "content": "hello",
+        "agent_id": "agent-1",
+        "user_id": "user-1",
+        "memory_type": MemoryType.WORKING,
+        "metadata": {},
+    }
+    manager.user_memories["user-1"][MemoryType.WORKING][123] = memory_data
+    return manager
+
+
+def test_find_memory_accepts_string_and_int_ids():
+    manager = _build_manager()
+
+    assert manager._find_memory("123")["content"] == "hello"
+    assert manager._find_memory(123)["content"] == "hello"
+
+
+def test_update_memory_keeps_merged_metadata_in_cache():
+    manager = _build_manager()
+    memory_data = manager.user_memories["user-1"][MemoryType.WORKING][123]
+    memory_data["metadata"] = {"source": "original"}
+
+    manager.update_memory("123", "user-1", {"metadata": {"topic": "agent"}})
+
+    assert memory_data["metadata"] == {"source": "original", "topic": "agent"}
+    manager._memory_instance.update.assert_called_once_with(
+        memory_id=123,
+        content="hello",
+        user_id="user-1",
+        agent_id="agent-1",
+        metadata={"source": "original", "topic": "agent"},
+    )
+
+
+def test_update_memory_persists_content_to_db():
+    manager = _build_manager()
+
+    result = manager.update_memory("123", "user-1", {"content": "updated"})
+
+    manager._memory_instance.update.assert_called_once_with(
+        memory_id=123,
+        content="updated",
+        user_id="user-1",
+        agent_id="agent-1",
+        metadata={},
+    )
+    assert result["memory"] == "updated"
+
+
+def test_delete_memory_removes_all_cache_key_variants():
+    manager = _build_manager()
+    memory_data = manager.user_memories["user-1"][MemoryType.WORKING][123]
+    manager.user_memories["user-1"][MemoryType.WORKING]["123"] = memory_data
+    manager.shared_memories[123] = {"shared_with": ["user-2"], "permissions": {}}
+    manager.consent_records["user-2"] = {123: {"consent_given": True}}
+
+    manager.delete_memory("123", "user-1")
+
+    assert manager.user_memories["user-1"][MemoryType.WORKING] == {}
+    assert manager.shared_memories == {}
+    assert manager.consent_records["user-2"] == {}
+
+
+def test_cleanup_forgotten_memories_calls_db_delete_and_returns_ids():
+    manager = _build_manager()
+    memory_data = manager.user_memories["user-1"][MemoryType.WORKING][123]
+    memory_data["retention_score"] = 0.05
+
+    result = manager.cleanup_forgotten_memories()
+
+    manager._memory_instance.delete.assert_called_once_with(
+        memory_id=123,
+        user_id="user-1",
+        agent_id="agent-1",
+    )
+    assert result["cleaned_memory_ids"] == [123]
+    assert manager._find_memory(123) is None

--- a/tests/unit/agent/test_permission_controller.py
+++ b/tests/unit/agent/test_permission_controller.py
@@ -1,0 +1,97 @@
+"""Unit tests for permission controller enum/string comparison fixes."""
+
+from types import SimpleNamespace
+
+from powermem.agent.components.permission_controller import PermissionController
+from powermem.agent.implementations.multi_agent import MultiAgentMemoryManager
+from powermem.agent.types import AccessPermission
+
+
+def _build_permission_controller() -> PermissionController:
+    controller = PermissionController.__new__(PermissionController)
+    controller.config = SimpleNamespace(
+        agent_memory=SimpleNamespace(
+            multi_agent_config=SimpleNamespace(
+                default_permissions={
+                    "owner": ["read", "write", "delete", "share", "admin"],
+                    "public": ["read"],
+                },
+                agent_groups={},
+            )
+        )
+    )
+    controller.multi_agent_config = controller.config.agent_memory.multi_agent_config
+    controller.memory_permissions = {}
+    controller.role_permissions = controller.multi_agent_config.default_permissions
+    controller.access_log = []
+    controller.agent_roles = {"agent-1": ["owner"]}
+    return controller
+
+
+def test_role_fallback_grants_read_with_enum():
+    controller = _build_permission_controller()
+
+    assert controller.check_permission(
+        "agent-1", "memory-1", AccessPermission.READ
+    ) is True
+
+
+def test_default_public_permission_grants_read_with_enum():
+    controller = _build_permission_controller()
+
+    assert controller.check_permission(
+        "agent-without-role", "memory-1", AccessPermission.READ
+    ) is True
+
+
+def test_direct_grant_still_works():
+    controller = _build_permission_controller()
+    controller.grant_permission(
+        memory_id="memory-1",
+        agent_id="agent-2",
+        permission=AccessPermission.WRITE,
+        granted_by="agent-1",
+    )
+
+    assert controller.check_permission(
+        "agent-2", "memory-1", AccessPermission.WRITE
+    ) is True
+
+
+def test_direct_grant_matches_int_and_string_memory_ids():
+    controller = _build_permission_controller()
+    controller.grant_permission(
+        memory_id=123,
+        agent_id="agent-2",
+        permission=AccessPermission.WRITE,
+        granted_by="agent-1",
+    )
+
+    assert controller.check_permission(
+        "agent-2", "123", AccessPermission.WRITE
+    ) is True
+
+
+def test_revoke_all_for_memory_removes_bulk_permission_records():
+    controller = _build_permission_controller()
+    controller.grant_permission(
+        memory_id="memory-1",
+        agent_id="agent-2",
+        permission=AccessPermission.WRITE,
+        granted_by="agent-1",
+    )
+
+    controller.revoke_all_for_memory("memory-1")
+
+    assert "memory-1" not in controller.memory_permissions
+
+
+def test_multi_agent_wrapper_accepts_read_string_variants():
+    manager = MultiAgentMemoryManager.__new__(MultiAgentMemoryManager)
+    manager.permission_controller = _build_permission_controller()
+
+    assert manager.check_permission("agent-1", "memory-1", "read") is True
+    assert manager.check_permission("agent-1", "memory-1", "READ") is True
+    assert manager.check_permission(
+        "agent-1", "memory-1", AccessPermission.READ
+    ) is True


### PR DESCRIPTION
## Summary
- Persist AgentMemory update/delete/cleanup operations through Memory.update() and Memory.delete().
- Normalize Snowflake memory IDs for int/string cache lookup across multi-agent, multi-user, and hybrid managers.
- Return cleaned_memory_ids from cleanup so hybrid indexes can remove stale entries.

Depends on #1146. Until #1146 is merged, this PR includes the permission normalization base commit as part of the stacked branch.

Fixes #1145

## Test plan
- pytest tests/unit/agent/test_permission_controller.py tests/unit/agent/test_memory_id_normalize.py tests/unit/agent/test_multi_agent_crud.py tests/unit/agent/test_multi_user_crud.py tests/unit/agent/test_hybrid_cleanup.py