### PR TITLE
fix(agent): persist retention metadata

### DIFF
--- a/src/powermem/agent/implementations/multi_agent.py
+++ b/src/powermem/agent/implementations/multi_agent.py
@@ -23,6 +23,10 @@ from powermem.agent.components.collaboration_coordinator import CollaborationCoo
 from powermem.agent.components.privacy_protector import PrivacyProtector
 from powermem.agent.filters import matches_memory_filters
 from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+from powermem.utils.intelligence_metadata import (
+    extract_importance_level,
+    extract_retention_score,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -220,6 +224,8 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             
             # Determine memory type from enhanced metadata
             memory_type = self._determine_memory_type_from_metadata(enhanced_metadata)
+            retention_score = extract_retention_score(enhanced_metadata)
+            importance_level = extract_importance_level(enhanced_metadata)
             
             # Persist to database first to get Snowflake ID
             # Use temporary memory data for database insertion
@@ -228,6 +234,8 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                 'agent_id': agent_id,
                 'scope': scope,
                 'memory_type': memory_type,
+                'retention_score': retention_score,
+                'importance_level': importance_level,
                 'metadata': enhanced_metadata,
             }
             
@@ -249,8 +257,8 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                 'updated_at': datetime.now().isoformat(),
                 'access_count': 0,
                 'last_accessed': None,
-                'retention_score': enhanced_metadata.get('intelligence', {}).get('current_retention', 1.0),
-                'importance_level': enhanced_metadata.get('intelligence', {}).get('importance_score'),
+                'retention_score': retention_score if retention_score is not None else 1.0,
+                'importance_level': importance_level,
             }
             
             # Store in appropriate scope and type
@@ -341,17 +349,25 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             # Use the existing Memory.add() method
             # Get the Snowflake ID returned from database to ensure consistency
             # Use infer=False to use simple mode since intelligent processing is already done at agent layer
+            metadata = memory_data.get('metadata') or {}
+            retention_score = memory_data.get('retention_score')
+            if retention_score is None:
+                retention_score = extract_retention_score(metadata)
+            importance_level = memory_data.get('importance_level')
+            if importance_level is None:
+                importance_level = extract_importance_level(metadata)
+
             add_result = memory_instance.add(
                 messages=memory_data['content'],
                 user_id=memory_data.get('user_id'),
                 agent_id=memory_data.get('agent_id'),
                 run_id=memory_data.get('run_id'),
                 metadata={
+                    **metadata,
                     'scope': getattr(memory_data.get('scope'), 'value', memory_data.get('scope')),
                     'memory_type': getattr(memory_data.get('memory_type'), 'value', memory_data.get('memory_type')),
-                    'retention_score': memory_data.get('retention_score'),
-                    'importance_level': memory_data.get('importance_level'),
-                    **memory_data.get('metadata', {})
+                    'retention_score': retention_score,
+                    'importance_level': importance_level,
                 },
                 infer=False  # Use simple mode to avoid intelligent processing returning empty results
             )

--- a/src/powermem/agent/implementations/multi_user.py
+++ b/src/powermem/agent/implementations/multi_user.py
@@ -19,6 +19,10 @@ from powermem.agent.filters import matches_memory_filters
 from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
 from powermem.intelligence.intelligent_memory_manager import IntelligentMemoryManager
 from powermem.agent.abstract.manager import AgentMemoryManagerBase
+from powermem.utils.intelligence_metadata import (
+    extract_importance_level,
+    extract_retention_score,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +156,8 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             
             # Determine scope based on sharing settings
             scope = self._determine_user_scope(user_id, context, enhanced_metadata)
+            retention_score = extract_retention_score(enhanced_metadata)
+            importance_level = extract_importance_level(enhanced_metadata)
             
             # Persist to database first to get Snowflake ID
             # Use temporary memory data for database insertion
@@ -165,6 +171,8 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                 'run_id': run_id,
                 'scope': scope,
                 'memory_type': memory_type,
+                'retention_score': retention_score,
+                'importance_level': importance_level,
                 'metadata': enhanced_metadata,
             }
             
@@ -187,8 +195,8 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                 'updated_at': datetime.now().isoformat(),
                 'access_count': 0,
                 'last_accessed': None,
-                'retention_score': enhanced_metadata.get('intelligence', {}).get('current_retention', 1.0),
-                'importance_level': enhanced_metadata.get('intelligence', {}).get('importance_score'),
+                'retention_score': retention_score if retention_score is not None else 1.0,
+                'importance_level': importance_level,
                 'privacy_level': self._determine_privacy_level(enhanced_metadata),
                 'shared_with': enhanced_metadata.get('share_with', []),
             }
@@ -258,6 +266,18 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
         """
         try:
             memory_instance = self._get_or_create_memory_instance()
+            metadata = memory_data.get('metadata') or {}
+            retention_score = memory_data.get('retention_score')
+            if retention_score is None:
+                retention_score = extract_retention_score(metadata)
+            importance_level = memory_data.get('importance_level')
+            if importance_level is None:
+                importance_level = extract_importance_level(metadata)
+            privacy_level = memory_data.get('privacy_level')
+            if privacy_level is None:
+                privacy_level = metadata.get('privacy_level')
+            else:
+                privacy_level = getattr(privacy_level, 'value', privacy_level)
 
             add_result = memory_instance.add(
                 messages=memory_data['content'],
@@ -265,12 +285,12 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                 agent_id=memory_data.get('agent_id'),
                 run_id=memory_data.get('run_id'),
                 metadata={
+                    **metadata,
                     'scope': memory_data.get('scope').value if memory_data.get('scope') else None,
                     'memory_type': memory_data.get('memory_type').value if memory_data.get('memory_type') else None,
-                    'retention_score': memory_data.get('retention_score'),
-                    'importance_level': memory_data.get('importance_level'),
-                    'privacy_level': memory_data.get('privacy_level').value if memory_data.get('privacy_level') else None,
-                    **memory_data.get('metadata', {})
+                    'retention_score': retention_score,
+                    'importance_level': importance_level,
+                    'privacy_level': privacy_level,
                 },
                 infer=False  # Use simple mode to avoid intelligent processing returning empty results
             )

--- a/src/powermem/cli/commands/manage.py
+++ b/src/powermem/cli/commands/manage.py
@@ -25,6 +25,7 @@ from ..utils.output import (
     print_warning,
     print_info,
 )
+from powermem.utils.intelligence_metadata import extract_retention_score
 
 logger = logging.getLogger(__name__)
 
@@ -352,8 +353,8 @@ def cleanup_cmd(ctx: CLIContext, threshold, archive_threshold, user_id, agent_id
         to_archive = []
         
         for mem in memories:
-            metadata = mem.get("metadata", {})
-            retention_score = metadata.get("retention_score")
+            metadata = mem.get("metadata") or {}
+            retention_score = extract_retention_score(metadata)
             
             # If no retention score, check access count and age
             if retention_score is None:
@@ -396,7 +397,7 @@ def cleanup_cmd(ctx: CLIContext, threshold, archive_threshold, user_id, agent_id
                 for mem in to_delete[:5]:
                     content = mem.get("memory") or mem.get("content", "N/A")
                     content = content[:40] + "..." if len(content) > 40 else content
-                    score = mem.get("metadata", {}).get("retention_score", "N/A")
+                    score = extract_retention_score(mem.get("metadata") or {})
                     click.echo(f"  - {content} (score: {score})")
                 if len(to_delete) > 5:
                     click.echo(f"  ... and {len(to_delete) - 5} more")

--- a/src/powermem/utils/intelligence_metadata.py
+++ b/src/powermem/utils/intelligence_metadata.py
@@ -1,0 +1,41 @@
+"""Helpers for reading Ebbinghaus intelligence metadata."""
+
+from collections.abc import Mapping
+from typing import Any, Optional
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def extract_intelligence_metadata(metadata: Any) -> Mapping[str, Any]:
+    """Return nested Ebbinghaus metadata when present."""
+    return _as_mapping(_as_mapping(metadata).get("intelligence"))
+
+
+def extract_retention_score(metadata: Any) -> Optional[float]:
+    """Read retention from legacy top-level or canonical intelligence metadata."""
+    metadata_map = _as_mapping(metadata)
+    retention_score = metadata_map.get("retention_score")
+    if retention_score is not None:
+        return retention_score
+
+    intelligence = extract_intelligence_metadata(metadata)
+    return intelligence.get("current_retention")
+
+
+def extract_importance_level(metadata: Any) -> Optional[float]:
+    """Read importance from legacy top-level or canonical intelligence metadata."""
+    metadata_map = _as_mapping(metadata)
+    importance_level = metadata_map.get("importance_level")
+    if importance_level is not None:
+        return importance_level
+
+    intelligence = extract_intelligence_metadata(metadata)
+    importance_score = intelligence.get("importance_score")
+    if importance_score is not None:
+        return importance_score
+
+    return metadata_map.get("importance_score")

--- a/tests/unit/agent/test_multi_agent_crud.py
+++ b/tests/unit/agent/test_multi_agent_crud.py
@@ -132,6 +132,32 @@ def test_delete_memory_removes_all_cache_key_variants():
     ] == {}
 
 
+def test_persist_memory_copies_intelligence_retention_to_top_level_metadata():
+    manager = _build_manager()
+    manager._memory_instance.add.return_value = {"results": [{"id": 456}]}
+
+    memory_id = manager._persist_memory_to_storage(
+        {
+            "content": "remember agent preference",
+            "agent_id": "agent-1",
+            "scope": MemoryScope.PRIVATE,
+            "memory_type": MemoryType.LONG_TERM,
+            "metadata": {
+                "intelligence": {
+                    "current_retention": 0.42,
+                    "importance_score": 0.77,
+                }
+            },
+        }
+    )
+
+    assert memory_id == 456
+    add_metadata = manager._memory_instance.add.call_args.kwargs["metadata"]
+    assert add_metadata["retention_score"] == 0.42
+    assert add_metadata["importance_level"] == 0.77
+    assert add_metadata["intelligence"]["current_retention"] == 0.42
+
+
 def test_cleanup_forgotten_memories_returns_cleaned_memory_ids():
     manager = _build_manager()
     memory_data = manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING][123]

--- a/tests/unit/agent/test_multi_user_crud.py
+++ b/tests/unit/agent/test_multi_user_crud.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock
 
 from powermem.agent.implementations.multi_user import MultiUserMemoryManager
-from powermem.agent.types import MemoryType
+from powermem.agent.types import MemoryScope, MemoryType
 
 
 def _build_manager() -> MultiUserMemoryManager:
@@ -78,6 +78,55 @@ def test_delete_memory_removes_all_cache_key_variants():
     assert manager.user_memories["user-1"][MemoryType.WORKING] == {}
     assert manager.shared_memories == {}
     assert manager.consent_records["user-2"] == {}
+
+
+def test_persist_memory_copies_intelligence_retention_to_top_level_metadata():
+    manager = _build_manager()
+    manager._memory_instance.add.return_value = {"results": [{"id": 456}]}
+
+    memory_id = manager._persist_memory_to_storage(
+        {
+            "content": "remember user preference",
+            "user_id": "user-1",
+            "agent_id": "agent-1",
+            "scope": MemoryScope.PRIVATE,
+            "memory_type": MemoryType.LONG_TERM,
+            "metadata": {
+                "intelligence": {
+                    "current_retention": 0.42,
+                    "importance_score": 0.77,
+                }
+            },
+        }
+    )
+
+    assert memory_id == 456
+    add_metadata = manager._memory_instance.add.call_args.kwargs["metadata"]
+    assert add_metadata["retention_score"] == 0.42
+    assert add_metadata["importance_level"] == 0.77
+    assert add_metadata["intelligence"]["current_retention"] == 0.42
+
+
+def test_persist_memory_preserves_metadata_privacy_level_when_not_overridden():
+    manager = _build_manager()
+    manager._memory_instance.add.return_value = {"results": [{"id": 456}]}
+
+    manager._persist_memory_to_storage(
+        {
+            "content": "remember private user preference",
+            "user_id": "user-1",
+            "agent_id": "agent-1",
+            "scope": MemoryScope.PRIVATE,
+            "memory_type": MemoryType.LONG_TERM,
+            "metadata": {
+                "privacy_level": "confidential",
+                "intelligence": {"current_retention": 0.42},
+            },
+        }
+    )
+
+    add_metadata = manager._memory_instance.add.call_args.kwargs["metadata"]
+    assert add_metadata["privacy_level"] == "confidential"
 
 
 def test_cleanup_forgotten_memories_calls_db_delete_and_returns_ids():

--- a/tests/unit/test_cli_manage_retention.py
+++ b/tests/unit/test_cli_manage_retention.py
@@ -1,0 +1,51 @@
+"""Unit tests for CLI retention cleanup metadata handling."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from click.testing import CliRunner
+
+from powermem.cli.main import cli
+
+
+def test_cleanup_uses_intelligence_retention_when_top_level_score_is_missing():
+    memory = MagicMock()
+    memory.get_all.return_value = {
+        "results": [
+            {
+                "id": 1,
+                "memory": "low retention memory",
+                "metadata": {
+                    "retention_score": None,
+                    "intelligence": {"current_retention": 0.05},
+                },
+            },
+            {
+                "id": 2,
+                "memory": "archive retention memory",
+                "metadata": {
+                    "intelligence": {"current_retention": 0.2},
+                },
+            },
+            {
+                "id": 3,
+                "memory": "healthy retention memory",
+                "metadata": {
+                    "intelligence": {"current_retention": 0.8},
+                },
+            },
+        ],
+    }
+
+    with patch(
+        "powermem.cli.commands.manage.CLIContext.memory",
+        new_callable=PropertyMock,
+        return_value=memory,
+    ):
+        result = CliRunner().invoke(
+            cli,
+            ["manage", "cleanup", "--dry-run", "--json"],
+        )
+
+    assert result.exit_code == 0
+    assert '"would_delete": 1' in result.output
+    assert '"would_archive": 1' in result.output


### PR DESCRIPTION
## Summary
- Fix AgentMemory persistence so `metadata.retention_score` and `metadata.importance_level` are populated from canonical `metadata.intelligence` fields before `Memory.add(..., infer=False)`.
- Add shared metadata helpers and make CLI cleanup read `metadata.intelligence.current_retention` when the legacy top-level score is missing.
- Add regression tests for multi-agent, multi-user, CLI cleanup, and preserving multi-user `privacy_level` during metadata merge.

## Test plan
- `python -m pytest tests/unit/agent/test_multi_agent_crud.py tests/unit/agent/test_multi_user_crud.py tests/unit/test_cli_manage_retention.py -q`
- `git diff --check HEAD~1 HEAD`

Closes #1143