### PR TITLE
fix(agent): align AgentMemory decay with EbbinghausAlgorithm

### DIFF
--- a/src/powermem/agent/implementations/multi_agent.py
+++ b/src/powermem/agent/implementations/multi_agent.py
@@ -22,7 +22,12 @@ from powermem.agent.components.permission_controller import PermissionController
 from powermem.agent.components.collaboration_coordinator import CollaborationCoordinator
 from powermem.agent.components.privacy_protector import PrivacyProtector
 from powermem.agent.filters import matches_memory_filters
-from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+from powermem.agent.utils.memory_id import (
+    memory_cache_key,
+    memory_cache_key_variants,
+    memory_key_variants,
+    normalize_memory_id,
+)
 from powermem.agent.utils.retention import (
     RETENTION_ACTION_ARCHIVE,
     RETENTION_ACTION_DELETE,
@@ -579,7 +584,7 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                 self._sync_scope_storage_entry(
                     scope,
                     memory_type,
-                    normalize_memory_id(memory_id),
+                    memory_id,
                     memory_data,
                 )
                 
@@ -1178,23 +1183,24 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
         self,
         scope: MemoryScope,
         memory_type: MemoryType,
-        memory_id: int,
+        memory_id: Union[str, int],
         memory_data: Dict[str, Any],
     ) -> None:
         """Keep scope_memories and scope_controller storage in sync."""
+        cache_key = memory_cache_key(memory_id)
         for existing_scope in MemoryScope:
             for existing_type in MemoryType:
-                for key in memory_key_variants(memory_id):
+                for key in memory_cache_key_variants(memory_id):
                     self.scope_memories[existing_scope][existing_type].pop(key, None)
-        self.scope_memories[scope][memory_type][memory_id] = memory_data
+        self.scope_memories[scope][memory_type][cache_key] = memory_data
         if self.scope_controller:
             for existing_scope in MemoryScope:
                 for existing_type in MemoryType:
-                    for key in memory_key_variants(memory_id):
+                    for key in memory_cache_key_variants(memory_id):
                         self.scope_controller.scope_storage[existing_scope][
                             existing_type
                         ].pop(key, None)
-            self.scope_controller.scope_storage[scope][memory_type][memory_id] = memory_data
+            self.scope_controller.scope_storage[scope][memory_type][cache_key] = memory_data
 
     def _revoke_memory_permissions(self, memory_id: Union[str, int]) -> None:
         """Clear permission records for all id key variants."""

--- a/src/powermem/agent/implementations/multi_agent.py
+++ b/src/powermem/agent/implementations/multi_agent.py
@@ -23,6 +23,16 @@ from powermem.agent.components.collaboration_coordinator import CollaborationCoo
 from powermem.agent.components.privacy_protector import PrivacyProtector
 from powermem.agent.filters import matches_memory_filters
 from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+from powermem.agent.utils.retention import (
+    RETENTION_ACTION_ARCHIVE,
+    RETENTION_ACTION_DELETE,
+    apply_agent_retention,
+    calculate_agent_retention,
+    classify_agent_retention,
+    get_agent_ebbinghaus_algorithm,
+    persist_agent_retention_metadata,
+    restore_effective_retention_fields,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -518,6 +528,9 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
             total_memories = len(db_memories)
             scope_access_passed = 0
             permission_passed = 0
+            algorithm = get_agent_ebbinghaus_algorithm(
+                getattr(self, 'intelligent_manager', None)
+            )
             
             for db_memory in db_memories:
                 memory_id = db_memory.get('id')
@@ -542,6 +555,7 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                     'access_count': 0,
                     'last_accessed': None,
                 }
+                restore_effective_retention_fields(memory_data, algorithm)
                 
                 # Extract scope and memory_type from metadata
                 metadata = memory_data.get('metadata', {})
@@ -561,13 +575,13 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                 memory_data['scope'] = scope
                 memory_data['memory_type'] = memory_type
                 
-                # Load into memory cache for future fast access
-                if memory_id not in self.scope_memories[scope][memory_type]:
-                    self.scope_memories[scope][memory_type][memory_id] = memory_data
-                
-                # Also load into scope controller's storage for access control
-                if self.scope_controller and memory_id not in self.scope_controller.scope_storage[scope][memory_type]:
-                    self.scope_controller.scope_storage[scope][memory_type][memory_id] = memory_data
+                # Keep database-loaded state authoritative for Agent caches.
+                self._sync_scope_storage_entry(
+                    scope,
+                    memory_type,
+                    normalize_memory_id(memory_id),
+                    memory_data,
+                )
                 
                 # Restore permissions from metadata if available
                 # Check if this memory was created by the current agent
@@ -928,48 +942,31 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                 'forgotten_memories': 0,
                 'reinforced_memories': 0,
             }
+            algorithm = get_agent_ebbinghaus_algorithm(
+                getattr(self, 'intelligent_manager', None)
+            )
+            memory_instance = self._get_or_create_memory_instance()
             
             # Update decay for all memories
             for scope in MemoryScope:
                 for memory_type in MemoryType:
                     for memory_id, memory_data in self.scope_memories[scope][memory_type].items():
-                        current_score = memory_data.get('retention_score', 1.0)
-                        access_count = memory_data.get('access_count', 0)
-                        last_accessed = memory_data.get('last_accessed')
-                        
-                        # Simple decay calculation (this should be replaced with proper Ebbinghaus algorithm)
-                        decay_rate = 0.1
-                        if last_accessed:
-                            # Parse ISO format string to datetime
-                            if isinstance(last_accessed, str):
-                                last_accessed_dt = datetime.fromisoformat(last_accessed.replace('Z', '+00:00'))
-                            else:
-                                last_accessed_dt = last_accessed
-                            time_since_access = (datetime.now() - last_accessed_dt).total_seconds() / 3600
-                        else:
-                            time_since_access = 24
-                        new_score = current_score * (1 - decay_rate * time_since_access / 24)
-                        new_score = max(0.0, min(1.0, new_score))
-                        
-                        decay_result = {
-                            'new_score': new_score,
-                            'decay_rate': decay_rate,
-                            'forgotten': new_score < 0.1
-                        }
-                        
-                        # Update memory data
-                        memory_data['retention_score'] = decay_result.get('new_score', memory_data.get('retention_score', 1.0))
-                        memory_data['decay_rate'] = decay_result.get('decay_rate', 0.1)
-                        
+                        retention_update = calculate_agent_retention(
+                            memory_data, algorithm, reinforce_due=True
+                        )
+                        apply_agent_retention(memory_data, retention_update)
+                        persist_agent_retention_metadata(memory_instance, memory_data)
                         decay_results['updated_memories'] += 1
+                        if retention_update.reinforced:
+                            decay_results['reinforced_memories'] += 1
                         
                         # Check if memory should be forgotten
-                        if decay_result.get('forgotten', False):
+                        if classify_agent_retention(
+                            memory_data,
+                            retention_update,
+                            algorithm,
+                        ) == RETENTION_ACTION_DELETE:
                             decay_results['forgotten_memories'] += 1
-                        
-                        # Check if memory should be reinforced
-                        if decay_result.get('reinforced', False):
-                            decay_results['reinforced_memories'] += 1
             
             logger.info(f"Updated memory decay: {decay_results}")
             return decay_results
@@ -993,16 +990,27 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                 'cleaned_memory_ids': [],
             }
             memory_instance = self._get_or_create_memory_instance()
+            algorithm = get_agent_ebbinghaus_algorithm(
+                getattr(self, 'intelligent_manager', None)
+            )
 
+            processed_ids = set()
             for scope in MemoryScope:
                 for memory_type in MemoryType:
                     memories_to_remove = []
-                    processed_ids = set()
 
                     for cache_key, memory_data in list(
                         self.scope_memories[scope][memory_type].items()
                     ):
-                        retention_score = memory_data.get('retention_score', 1.0)
+                        retention_update = calculate_agent_retention(
+                            memory_data, algorithm
+                        )
+                        metadata = apply_agent_retention(memory_data, retention_update)
+                        retention_action = classify_agent_retention(
+                            memory_data,
+                            retention_update,
+                            algorithm,
+                        )
                         normalized_id = normalize_memory_id(
                             memory_data.get('id', cache_key)
                         )
@@ -1010,21 +1018,14 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
                             continue
                         processed_ids.add(normalized_id)
 
-                        if retention_score < 0.1:
+                        if retention_action == RETENTION_ACTION_DELETE:
                             memories_to_remove.append((cache_key, normalized_id, memory_data))
                             cleanup_results['deleted_memories'] += 1
-                        elif retention_score < 0.3:
+                        elif retention_action == RETENTION_ACTION_ARCHIVE:
                             memory_data['archived'] = True
-                            metadata = dict(memory_data.get('metadata') or {})
                             metadata['archived'] = True
-                            memory_instance.update(
-                                memory_id=normalized_id,
-                                content=memory_data.get('content', ''),
-                                user_id=memory_data.get('user_id'),
-                                agent_id=memory_data.get('agent_id'),
-                                metadata=metadata,
-                            )
                             memory_data['metadata'] = metadata
+                            persist_agent_retention_metadata(memory_instance, memory_data)
                             cleanup_results['archived_memories'] += 1
 
                     for cache_key, normalized_id, memory_data in memories_to_remove:
@@ -1158,18 +1159,20 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
 
     def _remove_memory_from_cache(self, location: Dict[str, Any]) -> None:
         """Remove a memory entry from scope and scope-controller caches."""
-        scope = location['scope']
-        memory_type = location['memory_type']
         normalized_id = location['memory_id']
 
-        for key in memory_key_variants(normalized_id):
-            if key in self.scope_memories[scope][memory_type]:
-                del self.scope_memories[scope][memory_type][key]
+        for scope in MemoryScope:
+            for memory_type in MemoryType:
+                for key in memory_key_variants(normalized_id):
+                    self.scope_memories[scope][memory_type].pop(key, None)
 
         if self.scope_controller:
-            for key in memory_key_variants(normalized_id):
-                if key in self.scope_controller.scope_storage[scope][memory_type]:
-                    del self.scope_controller.scope_storage[scope][memory_type][key]
+            for scope in MemoryScope:
+                for memory_type in MemoryType:
+                    for key in memory_key_variants(normalized_id):
+                        self.scope_controller.scope_storage[scope][memory_type].pop(
+                            key, None
+                        )
 
     def _sync_scope_storage_entry(
         self,
@@ -1179,12 +1182,18 @@ class MultiAgentMemoryManager(AgentMemoryManagerBase):
         memory_data: Dict[str, Any],
     ) -> None:
         """Keep scope_memories and scope_controller storage in sync."""
-        for key in memory_key_variants(memory_id):
-            self.scope_memories[scope][memory_type].pop(key, None)
+        for existing_scope in MemoryScope:
+            for existing_type in MemoryType:
+                for key in memory_key_variants(memory_id):
+                    self.scope_memories[existing_scope][existing_type].pop(key, None)
         self.scope_memories[scope][memory_type][memory_id] = memory_data
         if self.scope_controller:
-            for key in memory_key_variants(memory_id):
-                self.scope_controller.scope_storage[scope][memory_type].pop(key, None)
+            for existing_scope in MemoryScope:
+                for existing_type in MemoryType:
+                    for key in memory_key_variants(memory_id):
+                        self.scope_controller.scope_storage[existing_scope][
+                            existing_type
+                        ].pop(key, None)
             self.scope_controller.scope_storage[scope][memory_type][memory_id] = memory_data
 
     def _revoke_memory_permissions(self, memory_id: Union[str, int]) -> None:

--- a/src/powermem/agent/implementations/multi_user.py
+++ b/src/powermem/agent/implementations/multi_user.py
@@ -17,6 +17,16 @@ from powermem.agent.types import (
 )
 from powermem.agent.filters import matches_memory_filters
 from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+from powermem.agent.utils.retention import (
+    RETENTION_ACTION_ARCHIVE,
+    RETENTION_ACTION_DELETE,
+    apply_agent_retention,
+    calculate_agent_retention,
+    classify_agent_retention,
+    get_agent_ebbinghaus_algorithm,
+    persist_agent_retention_metadata,
+    restore_effective_retention_fields,
+)
 from powermem.intelligence.intelligent_memory_manager import IntelligentMemoryManager
 from powermem.agent.abstract.manager import AgentMemoryManagerBase
 
@@ -550,6 +560,9 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
             
             # Convert database format to user memory format and load into memory cache
             processed_memory_ids = set()
+            algorithm = get_agent_ebbinghaus_algorithm(
+                getattr(self, 'intelligent_manager', None)
+            )
             
             for db_memory in db_memories:
                 memory_id = db_memory.get('id')
@@ -590,9 +603,7 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                 memory_data['scope'] = metadata.get('scope') or 'private'
                 
                 # Extract additional fields from metadata
-                if 'intelligence' in metadata:
-                    memory_data['retention_score'] = metadata['intelligence'].get('current_retention', 1.0)
-                    memory_data['importance_level'] = metadata['intelligence'].get('importance_score')
+                restore_effective_retention_fields(memory_data, algorithm)
                 
                 # Load into memory cache for future fast access
                 if user_id not in self.user_memories:
@@ -609,8 +620,11 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                         MemoryType.GROUP_CONSENSUS: {},
                     }
                 
-                if memory_id not in self.user_memories[user_id][memory_type]:
-                    self.user_memories[user_id][memory_type][memory_id] = memory_data
+                normalized_id = normalize_memory_id(memory_id)
+                for cached_type in MemoryType:
+                    for key in memory_key_variants(normalized_id):
+                        self.user_memories[user_id][cached_type].pop(key, None)
+                self.user_memories[user_id][memory_type][normalized_id] = memory_data
                 
                 # Check if this memory belongs to the user
                 if memory_data['user_id'] == user_id:
@@ -911,48 +925,31 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                 'forgotten_memories': 0,
                 'reinforced_memories': 0,
             }
+            algorithm = get_agent_ebbinghaus_algorithm(
+                getattr(self, 'intelligent_manager', None)
+            )
+            memory_instance = self._get_or_create_memory_instance()
             
             # Update decay for all user memories
             for user_id, user_memory_types in self.user_memories.items():
                 for memory_type in MemoryType:
                     for memory_id, memory_data in user_memory_types[memory_type].items():
-                        current_score = memory_data.get('retention_score', 1.0)
-                        access_count = memory_data.get('access_count', 0)
-                        last_accessed = memory_data.get('last_accessed')
-                        
-                        # Simple decay calculation (this should be replaced with proper Ebbinghaus algorithm)
-                        decay_rate = 0.1
-                        if last_accessed:
-                            # Parse ISO format string to datetime
-                            if isinstance(last_accessed, str):
-                                last_accessed_dt = datetime.fromisoformat(last_accessed.replace('Z', '+00:00'))
-                            else:
-                                last_accessed_dt = last_accessed
-                            time_since_access = (datetime.now() - last_accessed_dt).total_seconds() / 3600
-                        else:
-                            time_since_access = 24
-                        new_score = current_score * (1 - decay_rate * time_since_access / 24)
-                        new_score = max(0.0, min(1.0, new_score))
-                        
-                        decay_result = {
-                            'new_score': new_score,
-                            'decay_rate': decay_rate,
-                            'forgotten': new_score < 0.1
-                        }
-                        
-                        # Update memory data
-                        memory_data['retention_score'] = decay_result.get('new_score', memory_data.get('retention_score', 1.0))
-                        memory_data['decay_rate'] = decay_result.get('decay_rate', 0.1)
-                        
+                        retention_update = calculate_agent_retention(
+                            memory_data, algorithm, reinforce_due=True
+                        )
+                        apply_agent_retention(memory_data, retention_update)
+                        persist_agent_retention_metadata(memory_instance, memory_data)
                         decay_results['updated_memories'] += 1
+                        if retention_update.reinforced:
+                            decay_results['reinforced_memories'] += 1
                         
                         # Check if memory should be forgotten
-                        if decay_result.get('forgotten', False):
+                        if classify_agent_retention(
+                            memory_data,
+                            retention_update,
+                            algorithm,
+                        ) == RETENTION_ACTION_DELETE:
                             decay_results['forgotten_memories'] += 1
-                        
-                        # Check if memory should be reinforced
-                        if decay_result.get('reinforced', False):
-                            decay_results['reinforced_memories'] += 1
             
             logger.info(f"Updated memory decay: {decay_results}")
             return decay_results
@@ -976,14 +973,25 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                 'cleaned_memory_ids': [],
             }
             memory_instance = self._get_or_create_memory_instance()
+            algorithm = get_agent_ebbinghaus_algorithm(
+                getattr(self, 'intelligent_manager', None)
+            )
 
+            processed_ids = set()
             for user_id, user_memory_types in self.user_memories.items():
                 for memory_type in MemoryType:
                     memories_to_remove = []
-                    processed_ids = set()
 
                     for cache_key, memory_data in list(user_memory_types[memory_type].items()):
-                        retention_score = memory_data.get('retention_score', 1.0)
+                        retention_update = calculate_agent_retention(
+                            memory_data, algorithm
+                        )
+                        metadata = apply_agent_retention(memory_data, retention_update)
+                        retention_action = classify_agent_retention(
+                            memory_data,
+                            retention_update,
+                            algorithm,
+                        )
                         normalized_id = normalize_memory_id(
                             memory_data.get('id', cache_key)
                         )
@@ -991,21 +999,14 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                             continue
                         processed_ids.add(normalized_id)
 
-                        if retention_score < 0.1:
+                        if retention_action == RETENTION_ACTION_DELETE:
                             memories_to_remove.append((cache_key, normalized_id, memory_data))
                             cleanup_results['deleted_memories'] += 1
-                        elif retention_score < 0.3:
+                        elif retention_action == RETENTION_ACTION_ARCHIVE:
                             memory_data['archived'] = True
-                            metadata = dict(memory_data.get('metadata') or {})
                             metadata['archived'] = True
-                            memory_instance.update(
-                                memory_id=normalized_id,
-                                content=memory_data.get('content', ''),
-                                user_id=memory_data.get('user_id'),
-                                agent_id=memory_data.get('agent_id'),
-                                metadata=metadata,
-                            )
                             memory_data['metadata'] = metadata
+                            persist_agent_retention_metadata(memory_instance, memory_data)
                             cleanup_results['archived_memories'] += 1
 
                     for cache_key, normalized_id, memory_data in memories_to_remove:
@@ -1196,14 +1197,11 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
 
     def _remove_memory_from_cache(self, location: Dict[str, Any]) -> None:
         """Remove a memory entry from user cache."""
-        user_id = location['user_id']
-        memory_type = location['memory_type']
-        if (
-            user_id in self.user_memories
-            and memory_type in self.user_memories[user_id]
-        ):
-            for key in memory_key_variants(location['memory_id']):
-                self.user_memories[user_id][memory_type].pop(key, None)
+        for user_memory_types in self.user_memories.values():
+            for memory_type in MemoryType:
+                if memory_type in user_memory_types:
+                    for key in memory_key_variants(location['memory_id']):
+                        user_memory_types[memory_type].pop(key, None)
 
     def _clear_shared_records(self, memory_id: Union[str, int]) -> None:
         """Remove sharing and consent records for all id variants."""

--- a/src/powermem/agent/implementations/multi_user.py
+++ b/src/powermem/agent/implementations/multi_user.py
@@ -16,7 +16,12 @@ from powermem.agent.types import (
     AccessPermission
 )
 from powermem.agent.filters import matches_memory_filters
-from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+from powermem.agent.utils.memory_id import (
+    memory_cache_key,
+    memory_cache_key_variants,
+    memory_key_variants,
+    normalize_memory_id,
+)
 from powermem.agent.utils.retention import (
     RETENTION_ACTION_ARCHIVE,
     RETENTION_ACTION_DELETE,
@@ -620,11 +625,11 @@ class MultiUserMemoryManager(AgentMemoryManagerBase):
                         MemoryType.GROUP_CONSENSUS: {},
                     }
                 
-                normalized_id = normalize_memory_id(memory_id)
+                cache_key = memory_cache_key(memory_id)
                 for cached_type in MemoryType:
-                    for key in memory_key_variants(normalized_id):
+                    for key in memory_cache_key_variants(memory_id):
                         self.user_memories[user_id][cached_type].pop(key, None)
-                self.user_memories[user_id][memory_type][normalized_id] = memory_data
+                self.user_memories[user_id][memory_type][cache_key] = memory_data
                 
                 # Check if this memory belongs to the user
                 if memory_data['user_id'] == user_id:

--- a/src/powermem/agent/utils/memory_id.py
+++ b/src/powermem/agent/utils/memory_id.py
@@ -24,3 +24,23 @@ def memory_key_variants(memory_id: MemoryIdInput) -> List[Union[int, str]]:
     """Return int/str key variants for transitional cache lookup."""
     normalized = normalize_memory_id(memory_id)
     return [normalized, str(normalized)]
+
+
+def memory_cache_key(memory_id: MemoryIdInput) -> Union[int, str]:
+    """Return the canonical cache key while preserving legacy string ids."""
+    try:
+        return normalize_memory_id(memory_id)
+    except ValueError:
+        if isinstance(memory_id, str):
+            stripped = memory_id.strip()
+            if stripped:
+                return stripped
+        raise
+
+
+def memory_cache_key_variants(memory_id: MemoryIdInput) -> List[Union[int, str]]:
+    """Return cache lookup variants without rejecting legacy string ids."""
+    try:
+        return memory_key_variants(memory_id)
+    except ValueError:
+        return [memory_cache_key(memory_id)]

--- a/src/powermem/agent/utils/retention.py
+++ b/src/powermem/agent/utils/retention.py
@@ -1,0 +1,313 @@
+"""Retention helpers shared by AgentMemory managers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from powermem.agent.utils.memory_id import normalize_memory_id
+from powermem.intelligence.ebbinghaus_algorithm import EbbinghausAlgorithm
+from powermem.utils.utils import get_current_datetime
+
+DELETE_RETENTION_THRESHOLD = 0.1
+ARCHIVE_RETENTION_THRESHOLD = 0.3
+
+RETENTION_ACTION_DELETE = "delete"
+RETENTION_ACTION_ARCHIVE = "archive"
+RETENTION_ACTION_KEEP = "keep"
+
+
+@dataclass(frozen=True)
+class AgentRetentionUpdate:
+    """Calculated retention state for a cached Agent memory."""
+
+    score: float
+    snapshot_time: Any
+    has_intelligence: bool
+    access_count: int = 0
+    reinforced: bool = False
+    intelligence_updates: Optional[Dict[str, Any]] = None
+
+
+def get_agent_ebbinghaus_algorithm(intelligent_manager: Any) -> EbbinghausAlgorithm:
+    """Return the manager's configured Ebbinghaus algorithm."""
+    algorithm = getattr(intelligent_manager, "ebbinghaus_algorithm", None)
+    if isinstance(algorithm, EbbinghausAlgorithm):
+        return algorithm
+    return EbbinghausAlgorithm({})
+
+
+def calculate_agent_retention(
+    memory_data: Dict[str, Any],
+    algorithm: EbbinghausAlgorithm,
+    *,
+    reinforce_due: bool = False,
+) -> AgentRetentionUpdate:
+    """Calculate effective retention using intelligence metadata when present."""
+    metadata = memory_data.get("metadata") or {}
+    intelligence = metadata.get("intelligence") or {}
+    snapshot_time = get_current_datetime()
+    access_count = _resolve_access_count(memory_data, metadata, intelligence)
+    intelligence_updates = None
+    reinforced = False
+    if intelligence:
+        normalized = _build_algorithm_memory(
+            memory_data, metadata, intelligence, access_count
+        )
+        if reinforce_due and _should_reinforce(memory_data, intelligence, snapshot_time):
+            intelligence_updates = algorithm.reinforce(normalized)
+            intelligence = {**intelligence, **intelligence_updates}
+            normalized = _build_algorithm_memory(
+                memory_data, metadata, intelligence, access_count
+            )
+            reinforced = True
+        score = algorithm.calculate_current_retention(normalized)
+    else:
+        score = _coerce_score(memory_data.get("retention_score"), default=1.0)
+    return AgentRetentionUpdate(
+        score=_clamp_score(score),
+        snapshot_time=snapshot_time,
+        has_intelligence=bool(intelligence),
+        access_count=access_count,
+        reinforced=reinforced,
+        intelligence_updates=intelligence_updates,
+    )
+
+
+def apply_agent_retention(
+    memory_data: Dict[str, Any],
+    retention_update: AgentRetentionUpdate,
+) -> Dict[str, Any]:
+    """Synchronize effective retention to cache and metadata."""
+    score = _clamp_score(retention_update.score)
+    metadata = dict(memory_data.get("metadata") or {})
+    metadata["retention_score"] = score
+    memory_data["retention_score"] = score
+
+    intelligence = dict(metadata.get("intelligence") or {})
+    if retention_update.has_intelligence:
+        if retention_update.intelligence_updates:
+            intelligence.update(retention_update.intelligence_updates)
+        intelligence["current_retention"] = score
+        intelligence["last_reviewed"] = retention_update.snapshot_time.isoformat()
+        intelligence["access_count"] = retention_update.access_count
+        metadata["intelligence"] = intelligence
+        if intelligence.get("decay_rate") is not None:
+            memory_data["decay_rate"] = intelligence["decay_rate"]
+
+    memory_data["metadata"] = metadata
+    return metadata
+
+
+def classify_agent_retention(
+    memory_data: Dict[str, Any],
+    retention_update: AgentRetentionUpdate,
+    algorithm: EbbinghausAlgorithm,
+) -> str:
+    """Classify cleanup action using Core Ebbinghaus decisions when available."""
+    metadata = memory_data.get("metadata") or {}
+    intelligence = metadata.get("intelligence") or {}
+    if not intelligence:
+        return classify_retention(retention_update.score)
+
+    normalized = _build_algorithm_memory(
+        memory_data,
+        metadata,
+        intelligence,
+        retention_update.access_count,
+    )
+    if algorithm.should_forget(normalized):
+        return RETENTION_ACTION_DELETE
+    if algorithm.should_archive(normalized):
+        return RETENTION_ACTION_ARCHIVE
+    return RETENTION_ACTION_KEEP
+
+
+def classify_retention(score: float) -> str:
+    """Classify retention score for Agent cleanup thresholds."""
+    bounded = _clamp_score(score)
+    if bounded < DELETE_RETENTION_THRESHOLD:
+        return RETENTION_ACTION_DELETE
+    if bounded < ARCHIVE_RETENTION_THRESHOLD:
+        return RETENTION_ACTION_ARCHIVE
+    return RETENTION_ACTION_KEEP
+
+
+def restore_agent_retention_fields(memory_data: Dict[str, Any]) -> None:
+    """Restore cache-level retention fields from persisted metadata."""
+    metadata = memory_data.get("metadata") or {}
+    intelligence = metadata.get("intelligence") or {}
+    retention = _first_present(
+        intelligence.get("current_retention"),
+        metadata.get("retention_score"),
+        memory_data.get("retention_score"),
+    )
+    importance = _first_present(
+        intelligence.get("importance_score"),
+        metadata.get("importance_level"),
+        memory_data.get("importance_level"),
+    )
+    if retention is not None:
+        memory_data["retention_score"] = _clamp_score(retention)
+    if importance is not None:
+        memory_data["importance_level"] = importance
+
+
+def restore_effective_retention_fields(
+    memory_data: Dict[str, Any],
+    algorithm: EbbinghausAlgorithm,
+) -> None:
+    """Restore cache-level fields with effective runtime retention."""
+    restore_agent_retention_fields(memory_data)
+    metadata = dict(memory_data.get("metadata") or {})
+    if not metadata.get("intelligence"):
+        return
+
+    retention_update = calculate_agent_retention(memory_data, algorithm)
+    apply_agent_retention(memory_data, retention_update)
+
+
+def persist_agent_retention_metadata(
+    memory_instance: Any,
+    memory_data: Dict[str, Any],
+) -> None:
+    """Persist synchronized Agent retention metadata without plugin reprocessing."""
+    memory_id = memory_data.get("id")
+    if not memory_instance or memory_id is None:
+        return
+    try:
+        normalized_id = normalize_memory_id(memory_id)
+    except (TypeError, ValueError):
+        return
+    storage = getattr(memory_instance, "storage", None)
+    update_memory = getattr(storage, "update_memory", None)
+    if not callable(update_memory):
+        return
+
+    update_memory(
+        normalized_id,
+        {
+            "metadata": memory_data.get("metadata") or {},
+            "updated_at": get_current_datetime(),
+        },
+        memory_data.get("user_id"),
+        memory_data.get("agent_id"),
+    )
+
+
+def _build_algorithm_memory(
+    memory_data: Dict[str, Any],
+    metadata: Dict[str, Any],
+    intelligence: Dict[str, Any],
+    access_count: int,
+) -> Dict[str, Any]:
+    normalized = dict(memory_data)
+    normalized_metadata = dict(metadata)
+    normalized_metadata["intelligence"] = intelligence
+    normalized["metadata"] = normalized_metadata
+    normalized["access_count"] = access_count
+    memory_type = _normalize_memory_type(
+        memory_data.get("memory_type"),
+        metadata.get("memory_type"),
+        intelligence.get("memory_type"),
+    )
+    if memory_type:
+        normalized["memory_type"] = memory_type
+    importance = _first_present(
+        memory_data.get("importance_score"),
+        metadata.get("importance_score"),
+        intelligence.get("importance_score"),
+    )
+    if importance is not None:
+        normalized["importance_score"] = importance
+    return normalized
+
+
+def _should_reinforce(
+    memory_data: Dict[str, Any],
+    intelligence: Dict[str, Any],
+    snapshot_time: datetime,
+) -> bool:
+    next_review = _parse_datetime(intelligence.get("next_review"))
+    last_accessed = _parse_datetime(memory_data.get("last_accessed"))
+    if next_review is None or last_accessed is None:
+        return False
+    next_review = _align_timezone(next_review, snapshot_time)
+    last_accessed = _align_timezone(last_accessed, snapshot_time)
+    return last_accessed >= next_review and snapshot_time >= next_review
+
+
+def _align_timezone(value: datetime, reference: datetime) -> datetime:
+    if value.tzinfo is None and reference.tzinfo is not None:
+        return value.replace(tzinfo=reference.tzinfo)
+    if value.tzinfo is not None and reference.tzinfo is None:
+        return value.replace(tzinfo=None)
+    return value
+
+
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str) and value:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return None
+
+
+def _resolve_access_count(
+    memory_data: Dict[str, Any],
+    metadata: Dict[str, Any],
+    intelligence: Dict[str, Any],
+) -> int:
+    counts = [
+        _coerce_non_negative_int(memory_data.get("access_count")),
+        _coerce_non_negative_int(metadata.get("access_count")),
+        _coerce_non_negative_int(intelligence.get("access_count")),
+    ]
+    valid_counts = [count for count in counts if count is not None]
+    if not valid_counts:
+        return 0
+    return max(valid_counts)
+
+
+def _normalize_memory_type(*values: Any) -> Optional[str]:
+    mapping = {
+        "working": "working",
+        "working_memory": "working",
+        "short_term": "short_term",
+        "short_term_memory": "short_term",
+        "long_term": "long_term",
+        "long_term_memory": "long_term",
+    }
+    for value in values:
+        raw_value = getattr(value, "value", value)
+        if raw_value in mapping:
+            return mapping[raw_value]
+    return None
+
+
+def _first_present(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _coerce_score(value: Any, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_non_negative_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clamp_score(value: Any) -> float:
+    return max(0.0, min(1.0, _coerce_score(value, default=1.0)))

--- a/tests/unit/agent/test_agent_retention_decay.py
+++ b/tests/unit/agent/test_agent_retention_decay.py
@@ -1,0 +1,569 @@
+"""Regression tests for AgentMemory Ebbinghaus retention decay."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import ANY, MagicMock
+
+import pytest
+
+from powermem.agent.implementations.multi_agent import MultiAgentMemoryManager
+from powermem.agent.implementations.multi_user import MultiUserMemoryManager
+from powermem.agent.types import MemoryScope, MemoryType
+from powermem.agent.utils.retention import persist_agent_retention_metadata
+from powermem.intelligence.ebbinghaus_algorithm import EbbinghausAlgorithm
+from powermem.utils.utils import get_current_datetime
+
+
+def _build_multi_agent_manager(memory_data):
+    manager = MultiAgentMemoryManager.__new__(MultiAgentMemoryManager)
+    manager.scope_memories = {
+        scope: {memory_type: {} for memory_type in MemoryType}
+        for scope in MemoryScope
+    }
+    manager.scope_controller = SimpleNamespace(
+        scope_storage={
+            scope: {memory_type: {} for memory_type in MemoryType}
+            for scope in MemoryScope
+        }
+    )
+    manager.permission_controller = MagicMock()
+    manager.collaboration_memories = {}
+    manager._memory_instance = MagicMock()
+    manager._get_or_create_memory_instance = MagicMock(
+        return_value=manager._memory_instance
+    )
+    manager.intelligent_manager = SimpleNamespace(
+        ebbinghaus_algorithm=EbbinghausAlgorithm(
+            {"decay_rate": 1.5, "initial_retention": 1.0}
+        )
+    )
+    manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING][
+        memory_data["id"]
+    ] = memory_data
+    return manager
+
+
+def _build_multi_user_manager(memory_data):
+    manager = MultiUserMemoryManager.__new__(MultiUserMemoryManager)
+    manager.user_memories = {
+        memory_data["user_id"]: {memory_type: {} for memory_type in MemoryType}
+    }
+    manager.shared_memories = {}
+    manager.consent_records = {}
+    manager._memory_instance = MagicMock()
+    manager._get_or_create_memory_instance = MagicMock(
+        return_value=manager._memory_instance
+    )
+    manager.intelligent_manager = SimpleNamespace(
+        ebbinghaus_algorithm=EbbinghausAlgorithm(
+            {"decay_rate": 1.5, "initial_retention": 1.0}
+        )
+    )
+    manager.user_memories[memory_data["user_id"]][MemoryType.WORKING][
+        memory_data["id"]
+    ] = memory_data
+    return manager
+
+
+def _memory_with_reviewed_retention(memory_id, user_id, hours_since_review):
+    reviewed_at = get_current_datetime() - timedelta(hours=hours_since_review)
+    return {
+        "id": memory_id,
+        "content": "hello",
+        "agent_id": "agent-1",
+        "user_id": user_id,
+        "scope": MemoryScope.PRIVATE,
+        "memory_type": MemoryType.WORKING,
+        "metadata": {
+            "memory_type": "working",
+            "intelligence": {
+                "memory_type": "working",
+                "initial_retention": 0.8,
+                "current_retention": 0.8,
+                "decay_rate": 1.5,
+                "last_reviewed": reviewed_at.isoformat(),
+                "review_count": 0,
+                "access_count": 0,
+                "reinforcement_factor": 0.3,
+            },
+        },
+        "retention_score": 0.8,
+        "access_count": 0,
+        "last_accessed": None,
+    }
+
+
+def _set_review_schedule(memory_data, *hours_from_now):
+    now = get_current_datetime()
+    memory_data["metadata"]["intelligence"]["review_schedule"] = [
+        (now + timedelta(hours=hours)).isoformat()
+        for hours in hours_from_now
+    ]
+
+
+def test_multi_agent_update_memory_decay_uses_ebbinghaus_retention():
+    memory_data = _memory_with_reviewed_retention(123, "user-1", 24)
+    manager = _build_multi_agent_manager(memory_data)
+    expected = manager.intelligent_manager.ebbinghaus_algorithm.calculate_current_retention(
+        memory_data
+    )
+
+    manager.update_memory_decay()
+
+    assert memory_data["retention_score"] == pytest.approx(expected)
+    assert memory_data["retention_score"] != pytest.approx(0.72)
+
+
+def test_multi_user_update_memory_decay_uses_ebbinghaus_retention():
+    memory_data = _memory_with_reviewed_retention(123, "user-1", 24)
+    manager = _build_multi_user_manager(memory_data)
+    expected = manager.intelligent_manager.ebbinghaus_algorithm.calculate_current_retention(
+        memory_data
+    )
+
+    manager.update_memory_decay()
+
+    assert memory_data["retention_score"] == pytest.approx(expected)
+    assert memory_data["retention_score"] != pytest.approx(0.72)
+
+
+def test_cleanup_deletes_by_ebbinghaus_effective_retention_not_stale_cache_score():
+    memory_data = _memory_with_reviewed_retention(123, "user-1", 100)
+    memory_data["retention_score"] = 1.0
+    manager = _build_multi_agent_manager(memory_data)
+
+    result = manager.cleanup_forgotten_memories()
+
+    assert result["cleaned_memory_ids"] == [123]
+    manager._memory_instance.delete.assert_called_once_with(
+        memory_id=123,
+        user_id="user-1",
+        agent_id="agent-1",
+    )
+
+
+def test_cleanup_archives_by_ebbinghaus_effective_retention():
+    memory_data = _memory_with_reviewed_retention(123, "user-1", 1)
+    memory_data["created_at"] = (
+        get_current_datetime() - timedelta(days=31)
+    ).isoformat()
+    memory_data["retention_score"] = 1.0
+    manager = _build_multi_user_manager(memory_data)
+
+    result = manager.cleanup_forgotten_memories()
+
+    assert result["archived_memories"] == 1
+    assert result["deleted_memories"] == 0
+    assert memory_data["metadata"]["archived"] is True
+    manager._memory_instance.storage.update_memory.assert_called_once()
+    manager._memory_instance.update.assert_not_called()
+
+
+def test_cleanup_deletes_by_ebbinghaus_forget_threshold():
+    memory_data = _memory_with_reviewed_retention(123, "user-1", 50)
+    memory_data["retention_score"] = 1.0
+    manager = _build_multi_user_manager(memory_data)
+
+    result = manager.cleanup_forgotten_memories()
+
+    assert result["deleted_memories"] == 1
+    assert result["archived_memories"] == 0
+    assert result["cleaned_memory_ids"] == [123]
+    manager._memory_instance.delete.assert_called_once()
+
+
+def test_decay_syncs_metadata_intelligence_snapshot():
+    memory_data = _memory_with_reviewed_retention(123, "user-1", 24)
+    manager = _build_multi_agent_manager(memory_data)
+
+    manager.update_memory_decay()
+
+    metadata = memory_data["metadata"]
+    intelligence = metadata["intelligence"]
+    assert metadata["retention_score"] == pytest.approx(memory_data["retention_score"])
+    assert intelligence["current_retention"] == pytest.approx(
+        memory_data["retention_score"]
+    )
+    assert "last_reviewed" in intelligence
+    manager._memory_instance.storage.update_memory.assert_called_once()
+    manager._memory_instance.update.assert_not_called()
+
+
+def test_decay_uses_intelligence_access_count_when_cache_has_default_zero():
+    memory_data = _memory_with_reviewed_retention(123, "user-1", 24)
+    memory_data["metadata"]["intelligence"]["access_count"] = 10
+    memory_data["access_count"] = 0
+    manager = _build_multi_agent_manager(memory_data)
+    expected_memory = dict(memory_data)
+    expected_memory["access_count"] = 10
+    expected = manager.intelligent_manager.ebbinghaus_algorithm.calculate_current_retention(
+        expected_memory
+    )
+
+    manager.update_memory_decay()
+
+    assert memory_data["retention_score"] == pytest.approx(expected)
+    assert memory_data["metadata"]["intelligence"]["access_count"] == 10
+
+
+def test_decay_counts_due_access_reinforcement():
+    memory_data = _memory_with_reviewed_retention(123, "user-1", 24)
+    next_review = get_current_datetime() - timedelta(hours=1)
+    memory_data["metadata"]["intelligence"]["next_review"] = next_review.isoformat()
+    memory_data["last_accessed"] = get_current_datetime().isoformat()
+    _set_review_schedule(memory_data, -2, 24)
+    manager = _build_multi_agent_manager(memory_data)
+    decayed_score = manager.intelligent_manager.ebbinghaus_algorithm.calculate_current_retention(
+        memory_data
+    )
+
+    result = manager.update_memory_decay()
+
+    intelligence = memory_data["metadata"]["intelligence"]
+    assert result["reinforced_memories"] == 1
+    assert intelligence["review_count"] == 1
+    assert intelligence["next_review"] == intelligence["review_schedule"][1]
+    assert memory_data["retention_score"] > decayed_score
+    assert intelligence["current_retention"] == pytest.approx(
+        memory_data["retention_score"]
+    )
+
+
+def test_persist_retention_metadata_uses_storage_update_without_plugin_reprocess():
+    memory_instance = SimpleNamespace(
+        storage=MagicMock(),
+        update=MagicMock(),
+    )
+    metadata = {
+        "retention_score": 0.4,
+        "intelligence": {"current_retention": 0.4},
+    }
+    memory_data = {
+        "id": 123,
+        "content": "hello",
+        "agent_id": "agent-1",
+        "user_id": "user-1",
+        "metadata": metadata,
+    }
+
+    persist_agent_retention_metadata(memory_instance, memory_data)
+
+    memory_instance.storage.update_memory.assert_called_once_with(
+        123,
+        {"metadata": metadata, "updated_at": ANY},
+        "user-1",
+        "agent-1",
+    )
+    memory_instance.update.assert_not_called()
+
+
+def test_decay_preserves_legacy_retention_score_without_intelligence():
+    memory_data = {
+        "id": 123,
+        "content": "legacy",
+        "agent_id": "agent-1",
+        "user_id": "user-1",
+        "scope": MemoryScope.PRIVATE,
+        "memory_type": MemoryType.WORKING,
+        "metadata": {},
+        "retention_score": 0.05,
+    }
+    manager = _build_multi_user_manager(memory_data)
+
+    result = manager.cleanup_forgotten_memories()
+
+    assert result["cleaned_memory_ids"] == [123]
+
+
+def test_multi_agent_load_restores_effective_retention_from_intelligence():
+    algorithm = EbbinghausAlgorithm({"decay_rate": 1.5, "initial_retention": 1.0})
+    last_reviewed = get_current_datetime() - timedelta(hours=24)
+    manager = MultiAgentMemoryManager.__new__(MultiAgentMemoryManager)
+    manager.scope_memories = {
+        scope: {memory_type: {} for memory_type in MemoryType}
+        for scope in MemoryScope
+    }
+    manager.intelligent_manager = SimpleNamespace(ebbinghaus_algorithm=algorithm)
+    manager.scope_controller = MagicMock()
+    manager.scope_controller.scope_storage = {
+        scope: {memory_type: {} for memory_type in MemoryType}
+        for scope in MemoryScope
+    }
+    manager.scope_controller.check_scope_access.return_value = True
+    manager.permission_controller = MagicMock()
+    manager.permission_controller.memory_permissions = {}
+    manager.permission_controller.check_permission.return_value = True
+    manager.multi_agent_config = SimpleNamespace(
+        default_permissions={"owner": ["read"]}
+    )
+    manager._memory_instance = MagicMock()
+    manager._memory_instance.get_all.return_value = {
+        "results": [
+            {
+                "id": 123,
+                "memory": "persisted",
+                "agent_id": "agent-1",
+                "user_id": "user-1",
+                "metadata": {
+                    "scope": "private",
+                    "memory_type": "working",
+                    "intelligence": {
+                        "memory_type": "working",
+                        "current_retention": 0.8,
+                        "initial_retention": 0.8,
+                        "decay_rate": 1.5,
+                        "last_reviewed": last_reviewed.isoformat(),
+                        "importance_score": 0.73,
+                    },
+                },
+            }
+        ]
+    }
+    expected = algorithm.calculate_current_retention(
+        manager._memory_instance.get_all.return_value["results"][0]
+    )
+
+    result = manager.get_memories("agent-1")
+
+    assert result[0]["retention_score"] == pytest.approx(expected)
+    assert result[0]["retention_score"] < 0.8
+    assert result[0]["metadata"]["intelligence"]["current_retention"] == pytest.approx(
+        expected
+    )
+    assert result[0]["importance_level"] == pytest.approx(0.73)
+    assert manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING][
+        123
+    ]["retention_score"] == pytest.approx(expected)
+
+
+def test_multi_agent_load_refreshes_existing_cache_entry_from_database():
+    algorithm = EbbinghausAlgorithm({"decay_rate": 1.5, "initial_retention": 1.0})
+    last_reviewed = get_current_datetime() - timedelta(hours=24)
+    manager = MultiAgentMemoryManager.__new__(MultiAgentMemoryManager)
+    manager.scope_memories = {
+        scope: {memory_type: {} for memory_type in MemoryType}
+        for scope in MemoryScope
+    }
+    stale_cache = {
+        "id": 123,
+        "content": "stale",
+        "agent_id": "agent-1",
+        "user_id": "user-1",
+        "scope": MemoryScope.PRIVATE,
+        "memory_type": MemoryType.WORKING,
+        "metadata": {},
+        "retention_score": 1.0,
+    }
+    manager.scope_memories[MemoryScope.PRIVATE][MemoryType.SHORT_TERM]["123"] = (
+        stale_cache
+    )
+    manager.intelligent_manager = SimpleNamespace(ebbinghaus_algorithm=algorithm)
+    manager.scope_controller = MagicMock()
+    manager.scope_controller.scope_storage = {
+        scope: {memory_type: {} for memory_type in MemoryType}
+        for scope in MemoryScope
+    }
+    manager.scope_controller.check_scope_access.return_value = True
+    manager.permission_controller = MagicMock()
+    manager.permission_controller.memory_permissions = {}
+    manager.permission_controller.check_permission.return_value = True
+    manager.multi_agent_config = SimpleNamespace(
+        default_permissions={"owner": ["read"]}
+    )
+    manager._memory_instance = MagicMock()
+    manager._memory_instance.get_all.return_value = {
+        "results": [
+            {
+                "id": 123,
+                "memory": "fresh",
+                "agent_id": "agent-1",
+                "user_id": "user-1",
+                "metadata": {
+                    "scope": "private",
+                    "memory_type": "working",
+                    "intelligence": {
+                        "memory_type": "working",
+                        "current_retention": 0.8,
+                        "initial_retention": 0.8,
+                        "decay_rate": 1.5,
+                        "last_reviewed": last_reviewed.isoformat(),
+                    },
+                },
+            }
+        ]
+    }
+    expected = algorithm.calculate_current_retention(
+        manager._memory_instance.get_all.return_value["results"][0]
+    )
+
+    manager.get_memories("agent-1")
+
+    refreshed = manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING][123]
+    assert refreshed["content"] == "fresh"
+    assert refreshed["retention_score"] == pytest.approx(expected)
+    assert manager.scope_memories[MemoryScope.PRIVATE][MemoryType.SHORT_TERM] == {}
+
+
+def test_multi_agent_load_uses_normalized_id_for_scope_access():
+    algorithm = EbbinghausAlgorithm({"decay_rate": 1.5, "initial_retention": 1.0})
+    manager = MultiAgentMemoryManager.__new__(MultiAgentMemoryManager)
+    manager.scope_memories = {
+        scope: {memory_type: {} for memory_type in MemoryType}
+        for scope in MemoryScope
+    }
+    manager.scope_controller = MagicMock()
+    manager.scope_controller.scope_storage = {
+        scope: {memory_type: {} for memory_type in MemoryType}
+        for scope in MemoryScope
+    }
+
+    def _check_scope_access(_agent_id, memory_id):
+        return memory_id in manager.scope_controller.scope_storage[
+            MemoryScope.PRIVATE
+        ][MemoryType.WORKING]
+
+    manager.scope_controller.check_scope_access.side_effect = _check_scope_access
+    manager.permission_controller = MagicMock()
+    manager.permission_controller.memory_permissions = {}
+    manager.permission_controller.check_permission.return_value = True
+    manager.multi_agent_config = SimpleNamespace(
+        default_permissions={"owner": ["read"]}
+    )
+    manager.intelligent_manager = SimpleNamespace(ebbinghaus_algorithm=algorithm)
+    manager._memory_instance = MagicMock()
+    manager._memory_instance.get_all.return_value = {
+        "results": [
+            {
+                "id": "123",
+                "memory": "persisted",
+                "agent_id": "agent-1",
+                "user_id": "user-1",
+                "metadata": {"scope": "private", "memory_type": "working"},
+            }
+        ]
+    }
+
+    result = manager.get_memories("agent-1")
+
+    assert result[0]["id"] == "123"
+    assert 123 in manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING]
+
+
+def test_multi_user_load_restores_effective_retention_from_intelligence():
+    algorithm = EbbinghausAlgorithm({"decay_rate": 1.5, "initial_retention": 1.0})
+    last_reviewed = get_current_datetime() - timedelta(hours=24)
+    manager = MultiUserMemoryManager.__new__(MultiUserMemoryManager)
+    manager.user_memories = {}
+    manager.shared_memories = {}
+    manager.intelligent_manager = SimpleNamespace(ebbinghaus_algorithm=algorithm)
+    manager._extract_user_id = MagicMock(return_value="user-1")
+    manager._memory_instance = MagicMock()
+    manager._memory_instance.get_all.return_value = {
+        "results": [
+            {
+                "id": 123,
+                "memory": "persisted",
+                "agent_id": "agent-1",
+                "user_id": "user-1",
+                "metadata": {
+                    "scope": "private",
+                    "memory_type": "working",
+                    "intelligence": {
+                        "memory_type": "working",
+                        "current_retention": 0.8,
+                        "initial_retention": 0.8,
+                        "decay_rate": 1.5,
+                        "last_reviewed": last_reviewed.isoformat(),
+                    },
+                },
+            }
+        ]
+    }
+    expected = algorithm.calculate_current_retention(
+        manager._memory_instance.get_all.return_value["results"][0]
+    )
+
+    result = manager.get_memories("user-1")
+
+    assert result[0]["retention_score"] == pytest.approx(expected)
+    assert manager.user_memories["user-1"][MemoryType.WORKING][123][
+        "retention_score"
+    ] == pytest.approx(expected)
+
+
+def test_multi_user_load_refreshes_existing_cache_key_variants():
+    algorithm = EbbinghausAlgorithm({"decay_rate": 1.5, "initial_retention": 1.0})
+    last_reviewed = get_current_datetime() - timedelta(hours=24)
+    stale_cache = {
+        "id": 123,
+        "content": "stale",
+        "agent_id": "agent-1",
+        "user_id": "user-1",
+        "memory_type": MemoryType.SHORT_TERM,
+        "metadata": {},
+        "retention_score": 1.0,
+    }
+    manager = MultiUserMemoryManager.__new__(MultiUserMemoryManager)
+    manager.user_memories = {
+        "user-1": {memory_type: {} for memory_type in MemoryType}
+    }
+    manager.user_memories["user-1"][MemoryType.SHORT_TERM]["123"] = stale_cache
+    manager.shared_memories = {}
+    manager.intelligent_manager = SimpleNamespace(ebbinghaus_algorithm=algorithm)
+    manager._extract_user_id = MagicMock(return_value="user-1")
+    manager._memory_instance = MagicMock()
+    manager._memory_instance.get_all.return_value = {
+        "results": [
+            {
+                "id": 123,
+                "memory": "fresh",
+                "agent_id": "agent-1",
+                "user_id": "user-1",
+                "metadata": {
+                    "scope": "private",
+                    "memory_type": "working",
+                    "intelligence": {
+                        "memory_type": "working",
+                        "current_retention": 0.8,
+                        "initial_retention": 0.8,
+                        "decay_rate": 1.5,
+                        "last_reviewed": last_reviewed.isoformat(),
+                    },
+                },
+            }
+        ]
+    }
+    expected = algorithm.calculate_current_retention(
+        manager._memory_instance.get_all.return_value["results"][0]
+    )
+
+    manager.get_memories("user-1")
+
+    refreshed = manager.user_memories["user-1"][MemoryType.WORKING][123]
+    assert refreshed["content"] == "fresh"
+    assert refreshed["retention_score"] == pytest.approx(expected)
+    assert manager.user_memories["user-1"][MemoryType.SHORT_TERM] == {}
+
+
+def test_cleanup_removes_duplicate_cache_entries_for_deleted_memory():
+    memory_data = {
+        "id": 123,
+        "content": "duplicate",
+        "agent_id": "agent-1",
+        "user_id": "user-1",
+        "scope": MemoryScope.PRIVATE,
+        "memory_type": MemoryType.WORKING,
+        "metadata": {},
+        "retention_score": 0.05,
+    }
+    manager = _build_multi_agent_manager(memory_data)
+    manager.scope_memories[MemoryScope.PRIVATE][MemoryType.SHORT_TERM]["123"] = (
+        dict(memory_data)
+    )
+
+    result = manager.cleanup_forgotten_memories()
+
+    assert result["cleaned_memory_ids"] == [123]
+    manager._memory_instance.delete.assert_called_once()
+    assert manager.scope_memories[MemoryScope.PRIVATE][MemoryType.WORKING] == {}
+    assert manager.scope_memories[MemoryScope.PRIVATE][MemoryType.SHORT_TERM] == {}

--- a/tests/unit/agent/test_memory_id_normalize.py
+++ b/tests/unit/agent/test_memory_id_normalize.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from powermem.agent.utils.memory_id import memory_key_variants, normalize_memory_id
+from powermem.agent.utils.memory_id import (
+    memory_cache_key,
+    memory_cache_key_variants,
+    memory_key_variants,
+    normalize_memory_id,
+)
 
 
 def test_normalize_memory_id_accepts_int_and_string():
@@ -13,6 +18,16 @@ def test_normalize_memory_id_accepts_int_and_string():
 
 def test_memory_key_variants_include_int_and_str():
     assert memory_key_variants(123) == [123, "123"]
+
+
+def test_memory_cache_key_variants_keep_legacy_string_id():
+    assert memory_cache_key("memory-1") == "memory-1"
+    assert memory_cache_key_variants("memory-1") == ["memory-1"]
+
+
+def test_memory_cache_key_variants_include_int_and_str_for_snowflake_id():
+    assert memory_cache_key("123") == 123
+    assert memory_cache_key_variants("123") == [123, "123"]
 
 
 def test_normalize_memory_id_rejects_empty_string():


### PR DESCRIPTION
## Summary

- Replace the hard-coded linear decay in `MultiAgentMemoryManager.update_memory_decay()` and `MultiUserMemoryManager.update_memory_decay()` with `EbbinghausAlgorithm.calculate_current_retention()`, keeping Agent cache `retention_score` in sync with `metadata.intelligence`.
- Introduce shared helpers in `src/powermem/agent/utils/retention.py` for retention calculation, cache/metadata synchronization, cleanup classification, and persistence.
- Update `cleanup_forgotten_memories()` in both managers to use Ebbinghaus `should_forget()` / `should_archive()` instead of fixed linear thresholds on stale cache scores.
- Persist decay/archive metadata through `storage.update_memory()` so scheduled decay passes do not re-trigger the intelligence plugin.
- Preserve legacy string memory IDs when loading memories from storage into Agent caches, while retaining normalized int/string cache variants for modern Snowflake IDs.

## Test plan

- [x] `python -m pytest tests/unit/test_issue_925_agent_memory_share.py::test_multi_agent_loads_legacy_agent_scope_as_agent_group -q`
- [x] `python -m pytest tests/unit/agent/test_memory_id_normalize.py -q`
- [x] `python -m pytest tests/unit/agent/test_agent_retention_decay.py -q`

Fixes #1149
