### PR TITLE
docs: add Docker deployment guidance for powermem-server

### DIFF
--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -17,7 +17,8 @@ This guide provides instructions for building and running PowerMem Server using 
 ## Prerequisites
 
 - Docker 20.10 or later
-- Docker Compose 2.0 or later (optional, for docker-compose setup)
+- Docker Compose 2.0 or later (optional, for Compose setup)
+- A project-root `.env` file. Start with `cp .env.example .env`, then set the LLM provider, model, API key, and base URL required by your provider.
 
 ## Quick Start
 
@@ -43,23 +44,24 @@ The server will be available at `http://localhost:8848`.
 
 ### Using Docker Compose
 
-The `docker/docker-compose.yml` file is pre-configured to:
-- Automatically load environment variables from `.env` file
-- Mount the `.env` file as a read-only volume at `/app/.env`
-- Enable both SDK and Server to use the same configuration
+The `docker/docker-compose.yml` file is the recommended local stack when you want PowerMem Server and a bundled seekdb database to start together. It is pre-configured to:
+- Load environment variables from the project-root `.env` file
+- Mount the project-root `.env` file as a read-only volume at `/app/.env`
+- Reuse the same LLM, embedding, server, and other application settings as the local SDK
+- Connect `powermem-server` to the `seekdb` service on the internal Compose network
 
 ```bash
-# Start the server (from project root)
-docker-compose -f docker/docker-compose.yml up -d
+# Start PowerMem Server and seekdb (from project root)
+docker compose -f docker/docker-compose.yml up -d --build
 
 # View logs
-docker-compose -f docker/docker-compose.yml logs -f
+docker compose -f docker/docker-compose.yml logs -f
 
 # Stop the server
-docker-compose -f docker/docker-compose.yml down
+docker compose -f docker/docker-compose.yml down
 ```
 
-**Note**: The Docker Compose setup automatically handles the shared `.env` file configuration, so both your local SDK and the containerized Server will use the same configuration values.
+**Note**: The Docker Compose setup automatically handles the shared `.env` file configuration for application settings, but intentionally overrides `DATABASE_PROVIDER` and `OCEANBASE_*` so the server uses the bundled seekdb container. If your `.env` points to an existing database service, use the single-container deployment or a custom Compose override instead.
 
 ## Building the Docker Image
 
@@ -242,7 +244,7 @@ docker run -d \
   oceanbase/powermem-server:latest
 ```
 
-**Note**: With Docker Compose, the `.env` file is automatically mounted and loaded. See the `docker/docker-compose.yml` file for details.
+**Note**: With Docker Compose, the project-root `.env` file is automatically mounted and loaded. See the `docker/docker-compose.yml` file for details.
 
 
 ## Environment Variables
@@ -309,10 +311,10 @@ For complete SDK configuration options, refer to the [Configuration Guide](../do
 
 ## Docker Compose
 
-A `docker/docker-compose.yml` file is provided for easier deployment:
+A `docker/docker-compose.yml` file is provided for easier deployment. The excerpt below shows the PowerMem Server service; the checked-in Compose file also includes a `seekdb` service that stores data in the `powermem_seekdb_data` Docker volume and is wired to the server through `OCEANBASE_HOST=seekdb`.
 
 ```yaml
-version: '3.8'
+name: powermem
 
 services:
   powermem-server:
@@ -332,8 +334,9 @@ services:
       - POWERMEM_SERVER_CORS_ENABLED=${POWERMEM_SERVER_CORS_ENABLED:-true}
       - POWERMEM_DATABASE_URL=${POWERMEM_DATABASE_URL:-}
     env_file:
-      - .env
+      - ../.env
     volumes:
+      - ../.env:/app/.env:ro
       - ./logs:/app/logs
     restart: unless-stopped
     healthcheck:
@@ -348,16 +351,16 @@ services:
 
 ```bash
 # Start services (from project root)
-docker-compose -f docker/docker-compose.yml up -d
+docker compose -f docker/docker-compose.yml up -d --build
 
 # View logs
-docker-compose -f docker/docker-compose.yml logs -f powermem-server
+docker compose -f docker/docker-compose.yml logs -f powermem-server
 
 # Stop services
-docker-compose -f docker/docker-compose.yml down
+docker compose -f docker/docker-compose.yml down
 
 # Rebuild and restart
-docker-compose -f docker/docker-compose.yml up -d --build
+docker compose -f docker/docker-compose.yml up -d --build
 ```
 
 ## Production Deployment
@@ -391,8 +394,6 @@ docker inspect --format='{{.State.Health.Status}}' powermem-server
 ### Production Docker Compose Example
 
 ```yaml
-version: '3.8'
-
 services:
   powermem-server:
     build:
@@ -547,4 +548,3 @@ docker run -d \
 ```
 
 **Note**: When using `--env-file`, the Server will read from environment variables, but the SDK running locally will still read from the `.env` file. This is fine as long as both have the same values.
-

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -18,7 +18,7 @@ This guide provides instructions for building and running PowerMem Server using 
 
 - Docker 20.10 or later
 - Docker Compose 2.0 or later (optional, for Compose setup)
-- A project-root `.env` file. Start with `cp .env.example .env`, then set the LLM provider, model, API key, and base URL required by your provider.
+- A project-root `.env` file for single-container deployment. Start with `cp .env.example .env`, then set the LLM provider, model, API key, and base URL required by your provider. For Docker Compose, copy the same settings to `docker/.env`.
 
 ## Quick Start
 
@@ -44,10 +44,16 @@ The server will be available at `http://localhost:8848`.
 
 ### Using Docker Compose
 
-The `docker/docker-compose.yml` file is the recommended local stack when you want PowerMem Server and a bundled seekdb database to start together. It is pre-configured to:
-- Load environment variables from the project-root `.env` file
-- Mount the project-root `.env` file as a read-only volume at `/app/.env`
-- Reuse the same LLM, embedding, server, and other application settings as the local SDK
+The `docker/docker-compose.yml` file is the recommended local stack when you want PowerMem Server and a bundled seekdb database to start together. Prepare `docker/.env` before starting the stack:
+
+```bash
+cp .env.example docker/.env
+# Edit docker/.env with your LLM provider, model, API key, and base URL.
+```
+
+It is pre-configured to:
+- Load environment variables from `docker/.env`
+- Reuse the same LLM, embedding, server, and other application settings through container environment variables
 - Connect `powermem-server` to the `seekdb` service on the internal Compose network
 
 ```bash
@@ -61,7 +67,7 @@ docker compose -f docker/docker-compose.yml logs -f
 docker compose -f docker/docker-compose.yml down
 ```
 
-**Note**: The Docker Compose setup automatically handles the shared `.env` file configuration for application settings, but intentionally overrides `DATABASE_PROVIDER` and `OCEANBASE_*` so the server uses the bundled seekdb container. If your `.env` points to an existing database service, use the single-container deployment or a custom Compose override instead.
+**Note**: The Docker Compose setup intentionally overrides `DATABASE_PROVIDER` and `OCEANBASE_*` so the server uses the bundled seekdb container. If your `.env` points to an existing database service, use the single-container deployment or a custom Compose override instead.
 
 ## Building the Docker Image
 
@@ -244,7 +250,7 @@ docker run -d \
   oceanbase/powermem-server:latest
 ```
 
-**Note**: With Docker Compose, the project-root `.env` file is automatically mounted and loaded. See the `docker/docker-compose.yml` file for details.
+**Note**: With Docker Compose, `docker/.env` is loaded through `env_file`. See the `docker/docker-compose.yml` file for details.
 
 
 ## Environment Variables
@@ -311,10 +317,10 @@ For complete SDK configuration options, refer to the [Configuration Guide](../do
 
 ## Docker Compose
 
-A `docker/docker-compose.yml` file is provided for easier deployment. The excerpt below shows the PowerMem Server service; the checked-in Compose file also includes a `seekdb` service that stores data in the `powermem_seekdb_data` Docker volume and is wired to the server through `OCEANBASE_HOST=seekdb`.
+A `docker/docker-compose.yml` file is provided for easier deployment. The excerpt below shows the PowerMem Server service; the checked-in Compose file also includes a `seekdb` service that stores data in the `docker_seekdb_data` Docker volume and is wired to the server through `OCEANBASE_HOST=seekdb`.
 
 ```yaml
-name: powermem
+version: '3.8'
 
 services:
   powermem-server:
@@ -334,9 +340,8 @@ services:
       - POWERMEM_SERVER_CORS_ENABLED=${POWERMEM_SERVER_CORS_ENABLED:-true}
       - POWERMEM_DATABASE_URL=${POWERMEM_DATABASE_URL:-}
     env_file:
-      - ../.env
+      - .env
     volumes:
-      - ../.env:/app/.env:ro
       - ./logs:/app/logs
     restart: unless-stopped
     healthcheck:

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,6 +12,13 @@ This directory contains all Docker-related files for PowerMem Server.
 
 ## Quick Start
 
+Prepare a local configuration file first:
+
+```bash
+cp .env.example .env
+# Edit .env and set the LLM provider, model, API key, and base URL you use.
+```
+
 ### Build Docker Image
 
 From the project root directory:
@@ -26,15 +33,24 @@ From the project root directory:
 
 ```bash
 # Without password (default)
-docker-compose -f docker/docker-compose.yml up -d
+docker compose -f docker/docker-compose.yml up -d --build
 
 # With password (set via command line)
-SEEKDB_ROOT_PASSWORD=your_password docker-compose -f docker/docker-compose.yml up -d
+SEEKDB_ROOT_PASSWORD=your_password docker compose -f docker/docker-compose.yml up -d --build
 
 # Alternatively, export the variable first
 export SEEKDB_ROOT_PASSWORD=your_password
-docker-compose -f docker/docker-compose.yml up -d
+docker compose -f docker/docker-compose.yml up -d --build
+
+# Verify the API server
+curl http://localhost:8848/api/v1/system/health
+
+# View logs and stop the stack
+docker compose -f docker/docker-compose.yml logs -f powermem-server
+docker compose -f docker/docker-compose.yml down
 ```
+
+Compose uses the project-root `.env` for LLM, embedding, server, and other application settings. It intentionally sets `DATABASE_PROVIDER` and `OCEANBASE_*` to the bundled seekdb container; use single-container deployment or a custom Compose override when connecting to an existing database service.
 
 ### Run with Docker
 
@@ -59,7 +75,7 @@ docker run -d \
 ### seekdb Database
 - MySQL Port: 2881
 - seekdb Web Dashboard: 2886
-- Data persistence: Docker volume `seekdb_data`
+- Data persistence: Docker volume `powermem_seekdb_data`
 - Default database: `powermem`
 - Password: Controlled by `SEEKDB_ROOT_PASSWORD` environment variable
   - Not set (default): No password
@@ -109,10 +125,10 @@ For detailed documentation, see [DOCKER.md](./DOCKER.md).
 
 - All Docker commands should be run from the **project root directory**, not from the `docker/` directory
 - The build context is the project root, so paths in Dockerfile are relative to the project root
-- The `.env` file should be in the project root directory and will be mounted into the container
-- seekdb data is persisted in a Docker volume named `seekdb_data`
+- The `.env` file should be in the project root directory; Docker Compose reads it and mounts it into the PowerMem container at `/app/.env`
+- seekdb data is persisted in a Docker volume named `powermem_seekdb_data`
 - On macOS with Docker version > 4.9.0, there are known issues with seekdb. Consider using an older Docker version if needed.
 - **Password Management**: 
   - Default: No password (`SEEKDB_ROOT_PASSWORD` not set)
-  - To set a password: Use command line: `SEEKDB_ROOT_PASSWORD=your_password docker-compose -f docker/docker-compose.yml up -d`
+  - To set a password: Use command line: `SEEKDB_ROOT_PASSWORD=your_password docker compose -f docker/docker-compose.yml up -d --build`
   - Password change: Stop services, set new password via command line, restart services

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,8 @@
 
 This directory contains all Docker-related files for PowerMem Server.
 
+中文快速部署说明见 [README_CN.md](./README_CN.md).
+
 ## Files
 
 - `Dockerfile` - Multi-stage Docker build file for PowerMem Server
@@ -12,11 +14,11 @@ This directory contains all Docker-related files for PowerMem Server.
 
 ## Quick Start
 
-Prepare a local configuration file first:
+Prepare the Compose configuration file first:
 
 ```bash
-cp .env.example .env
-# Edit .env and set the LLM provider, model, API key, and base URL you use.
+cp .env.example docker/.env
+# Edit docker/.env and set the LLM provider, model, API key, and base URL you use.
 ```
 
 ### Build Docker Image
@@ -50,7 +52,7 @@ docker compose -f docker/docker-compose.yml logs -f powermem-server
 docker compose -f docker/docker-compose.yml down
 ```
 
-Compose uses the project-root `.env` for LLM, embedding, server, and other application settings. It intentionally sets `DATABASE_PROVIDER` and `OCEANBASE_*` to the bundled seekdb container; use single-container deployment or a custom Compose override when connecting to an existing database service.
+Compose loads `docker/.env` through `env_file` for LLM, embedding, server, and other application settings. It intentionally sets `DATABASE_PROVIDER` and `OCEANBASE_*` to the bundled seekdb container; use single-container deployment or a custom Compose override when connecting to an existing database service.
 
 ### Run with Docker
 
@@ -70,12 +72,12 @@ docker run -d \
 ### PowerMem Server
 - Port: 8848
 - Health check: `http://localhost:8848/api/v1/system/health`
-- Database: Connected to seekdb without password
+- Database: Connected to bundled seekdb; password is controlled by `SEEKDB_ROOT_PASSWORD`
 
 ### seekdb Database
 - MySQL Port: 2881
 - seekdb Web Dashboard: 2886
-- Data persistence: Docker volume `powermem_seekdb_data`
+- Data persistence: Docker volume `docker_seekdb_data`
 - Default database: `powermem`
 - Password: Controlled by `SEEKDB_ROOT_PASSWORD` environment variable
   - Not set (default): No password
@@ -125,8 +127,8 @@ For detailed documentation, see [DOCKER.md](./DOCKER.md).
 
 - All Docker commands should be run from the **project root directory**, not from the `docker/` directory
 - The build context is the project root, so paths in Dockerfile are relative to the project root
-- The `.env` file should be in the project root directory; Docker Compose reads it and mounts it into the PowerMem container at `/app/.env`
-- seekdb data is persisted in a Docker volume named `powermem_seekdb_data`
+- The Compose `.env` file should be copied to `docker/.env`; Docker Compose loads it through `env_file`
+- seekdb data is persisted in a Docker volume named `docker_seekdb_data`
 - On macOS with Docker version > 4.9.0, there are known issues with seekdb. Consider using an older Docker version if needed.
 - **Password Management**: 
   - Default: No password (`SEEKDB_ROOT_PASSWORD` not set)

--- a/docker/README_CN.md
+++ b/docker/README_CN.md
@@ -1,0 +1,128 @@
+# Docker 目录说明
+
+本目录包含 PowerMem Server 的 Docker 相关文件，可用于构建镜像、启动 `powermem-server`，或通过 Docker Compose 同时启动 `powermem-server` 与内置 `seekdb`。
+
+英文说明见 [README.md](./README.md)，更完整的英文 Docker 部署指南见 [DOCKER.md](./DOCKER.md)。
+
+## 文件说明
+
+- `Dockerfile`：PowerMem Server 的多阶段 Docker 构建文件。
+- `docker-compose.yml`：带 `seekdb` 的 Docker Compose 配置。
+- `docker-entrypoint.sh`：容器入口脚本。
+- `.dockerignore`：Docker 构建时排除的文件。
+- `DOCKER.md`：更完整的 Docker 部署说明。
+
+## 快速开始
+
+所有命令都在项目根目录执行。
+
+### 1. 准备配置文件
+
+```bash
+cp .env.example docker/.env
+# 编辑 docker/.env，设置使用的 LLM provider、model、API key 和 base URL。
+```
+
+### 2. 使用 Docker Compose 启动 PowerMem Server 和 seekdb（推荐）
+
+```bash
+# 不设置 seekdb root 密码（默认）
+docker compose -f docker/docker-compose.yml up -d --build
+
+# 通过命令行设置 seekdb root 密码
+SEEKDB_ROOT_PASSWORD=your_password docker compose -f docker/docker-compose.yml up -d --build
+
+# 或先导出环境变量
+export SEEKDB_ROOT_PASSWORD=your_password
+docker compose -f docker/docker-compose.yml up -d --build
+```
+
+Compose 会通过 `env_file` 读取 `docker/.env`，用于 LLM、embedding、Server 等应用配置；Compose 会有意覆盖 `DATABASE_PROVIDER` 和 `OCEANBASE_*`，让 `powermem-server` 连接内置 `seekdb` 容器。如果需要连接已有数据库服务，请使用单容器部署或自定义 Compose override。
+
+### 3. 验证服务
+
+```bash
+curl http://localhost:8848/api/v1/system/health
+```
+
+常用入口：
+
+- PowerMem Server API：`http://localhost:8848`
+- 健康检查：`http://localhost:8848/api/v1/system/health`
+- seekdb MySQL 端口：`localhost:2881`
+- seekdb Web Dashboard：`http://localhost:2886`
+
+### 4. 查看日志和停止服务
+
+```bash
+docker compose -f docker/docker-compose.yml logs -f powermem-server
+docker compose -f docker/docker-compose.yml down
+```
+
+`seekdb` 数据会保存在 Docker volume `docker_seekdb_data` 中。若要同时删除数据卷，请谨慎执行：
+
+```bash
+docker compose -f docker/docker-compose.yml down -v
+```
+
+## 单容器部署
+
+如果 `.env` 已配置外部数据库，或者不希望启动内置 `seekdb`，可以只运行 `powermem-server` 容器。
+
+```bash
+docker build -t oceanbase/powermem-server:latest -f docker/Dockerfile .
+
+docker run -d \
+  --name powermem-server \
+  -p 8848:8848 \
+  -v $(pwd)/.env:/app/.env:ro \
+  --env-file .env \
+  oceanbase/powermem-server:latest
+```
+
+## seekdb 连接方式
+
+### 默认无密码
+
+```bash
+mysql -h localhost -P 2881 -u root
+```
+
+### 设置了 `SEEKDB_ROOT_PASSWORD`
+
+```bash
+mysql -h localhost -P 2881 -u root -p
+# 根据提示输入密码
+```
+
+seekdb Web Dashboard：
+
+- 地址：`http://localhost:2886`
+- 用户名：`root`
+- 密码：与 `SEEKDB_ROOT_PASSWORD` 相同；默认未设置。
+
+## 默认配置
+
+PowerMem Server：
+
+- Host：`0.0.0.0`
+- Port：`8848`
+- Workers：`4`
+- Authentication：默认关闭
+- CORS：默认允许所有来源
+
+seekdb：
+
+- 数据库：`powermem`
+- CPU：4 核
+- 内存：4 GB
+- 数据持久化：Docker volume `docker_seekdb_data`
+- 密码：由 `SEEKDB_ROOT_PASSWORD` 控制；默认未设置
+
+## 注意事项
+
+- Docker 命令应在项目根目录执行，不要在 `docker/` 目录内执行。
+- Docker 构建上下文是项目根目录，因此 Dockerfile 中的路径按项目根目录解析。
+- Compose 使用的 `.env` 应复制到 `docker/.env`，并通过 `env_file` 注入容器环境变量。
+- 如果修改 `SEEKDB_ROOT_PASSWORD`，建议停止服务后用新密码重新启动。
+- macOS 上 Docker 版本高于 4.9.0 时，`seekdb` 可能存在兼容性问题；如遇到问题，可考虑使用较低版本 Docker。

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+name: powermem
 
 networks:
   powermem-network:
@@ -37,8 +37,9 @@ services:
       - OCEANBASE_DATABASE=powermem
       - OCEANBASE_COLLECTION=memories
     env_file:
-      - .env
+      - ../.env
     volumes:
+      - ../.env:/app/.env:ro
       - ./logs:/app/logs
     restart: unless-stopped
     healthcheck:
@@ -94,4 +95,3 @@ services:
 
 volumes:
   seekdb_data:
-

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-name: powermem
+version: '3.8'
 
 networks:
   powermem-network:
@@ -37,9 +37,8 @@ services:
       - OCEANBASE_DATABASE=powermem
       - OCEANBASE_COLLECTION=memories
     env_file:
-      - ../.env
+      - .env
     volumes:
-      - ../.env:/app/.env:ro
       - ./logs:/app/logs
     restart: unless-stopped
     healthcheck:
@@ -95,3 +94,4 @@ services:
 
 volumes:
   seekdb_data:
+

--- a/docs/api/0005-api_server.md
+++ b/docs/api/0005-api_server.md
@@ -23,18 +23,10 @@ The PowerMem HTTP API Server is built with FastAPI and provides:
 pip install powermem
 powermem-server --host 0.0.0.0 --port 8848
 
-# Method 2: Using Docker
-# Build and run with Docker
-docker build -t oceanbase/powermem-server:latest -f docker/Dockerfile .
-docker run -d \
-  --name powermem-server \
-  -p 8848:8848 \
-  -v $(pwd)/.env:/app/.env:ro \
-  --env-file .env \
-  oceanbase/powermem-server:latest
-
-# Or use Docker Compose (recommended)
-docker-compose -f docker/docker-compose.yml up -d
+# Method 2: Using Docker Compose (recommended)
+cp .env.example .env
+# Edit .env and set your LLM provider/key before starting the server.
+docker compose -f docker/docker-compose.yml up -d --build
 
 # Method 3: From source code, use Makefile
 git clone git@github.com:oceanbase/powermem.git
@@ -58,6 +50,74 @@ make server-stop
 make server-restart
 
 ```
+
+### Deploy with Docker
+
+Use Docker when you want a reusable `powermem-server` HTTP API without installing Python dependencies on the host. Run the following commands from the project root directory.
+
+#### 1. Prepare configuration
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set at least the LLM provider, model, API key, and base URL required by your provider. The Compose file reads this root `.env` file and mounts it into the server container at `/app/.env` for application settings. It intentionally overrides `DATABASE_PROVIDER` and `OCEANBASE_*` so the server uses the bundled seekdb container.
+
+#### 2. Start PowerMem Server with seekdb
+
+The recommended local deployment starts both `powermem-server` and a `seekdb` container:
+
+```bash
+docker compose -f docker/docker-compose.yml up -d --build
+```
+
+If your `.env` points to an existing database service, use the [single-container deployment](#single-container-deployment) or a custom Compose override instead.
+
+To protect the bundled seekdb instance with a root password, pass `SEEKDB_ROOT_PASSWORD` when starting the stack:
+
+```bash
+SEEKDB_ROOT_PASSWORD=change-me docker compose -f docker/docker-compose.yml up -d --build
+```
+
+The stack exposes:
+
+| Service | URL / port | Notes |
+| --- | --- | --- |
+| PowerMem API | `http://localhost:8848` | REST API and Dashboard |
+| Health check | `http://localhost:8848/api/v1/system/health` | Public endpoint |
+| Dashboard | `http://localhost:8848/dashboard/` | Memory inspection and monitoring |
+| seekdb MySQL | `localhost:2881` | Root password is `SEEKDB_ROOT_PASSWORD` if set |
+| seekdb console | `http://localhost:2886` | seekdb web dashboard |
+
+#### 3. Verify, inspect, and stop
+
+```bash
+curl http://localhost:8848/api/v1/system/health
+docker compose -f docker/docker-compose.yml logs -f powermem-server
+docker compose -f docker/docker-compose.yml down
+```
+
+Add `-v` to `down` only when you also want to delete the persisted `powermem_seekdb_data` Docker volume:
+
+```bash
+docker compose -f docker/docker-compose.yml down -v
+```
+
+#### Single-container deployment
+
+If your `.env` points to an existing database service, or if you intentionally want the server container to manage its own local storage, build and run only the server image:
+
+```bash
+docker build -t oceanbase/powermem-server:latest -f docker/Dockerfile .
+docker run -d \
+  --name powermem-server \
+  -p 8848:8848 \
+  -v "$(pwd)/.env:/app/.env:ro" \
+  --env-file .env \
+  oceanbase/powermem-server:latest
+```
+
+For complete image build options, mirror settings, and production notes, see the [Docker deployment guide](https://github.com/oceanbase/powermem/blob/main/docker/DOCKER.md).
 
 ### Dashboard browser behavior
 

--- a/docs/api/0005-api_server.md
+++ b/docs/api/0005-api_server.md
@@ -24,8 +24,8 @@ pip install powermem
 powermem-server --host 0.0.0.0 --port 8848
 
 # Method 2: Using Docker Compose (recommended)
-cp .env.example .env
-# Edit .env and set your LLM provider/key before starting the server.
+cp .env.example docker/.env
+# Edit docker/.env and set your LLM provider/key before starting the server.
 docker compose -f docker/docker-compose.yml up -d --build
 
 # Method 3: From source code, use Makefile
@@ -59,9 +59,10 @@ Use Docker when you want a reusable `powermem-server` HTTP API without installin
 
 ```bash
 cp .env.example .env
+cp .env.example docker/.env
 ```
 
-Edit `.env` and set at least the LLM provider, model, API key, and base URL required by your provider. The Compose file reads this root `.env` file and mounts it into the server container at `/app/.env` for application settings. It intentionally overrides `DATABASE_PROVIDER` and `OCEANBASE_*` so the server uses the bundled seekdb container.
+Edit `docker/.env` and set at least the LLM provider, model, API key, and base URL required by your provider. The Compose file loads `docker/.env` through `env_file` for application settings. It intentionally overrides `DATABASE_PROVIDER` and `OCEANBASE_*` so the server uses the bundled seekdb container. Keep the project-root `.env` when you also run the SDK or single-container deployment locally.
 
 #### 2. Start PowerMem Server with seekdb
 
@@ -97,7 +98,7 @@ docker compose -f docker/docker-compose.yml logs -f powermem-server
 docker compose -f docker/docker-compose.yml down
 ```
 
-Add `-v` to `down` only when you also want to delete the persisted `powermem_seekdb_data` Docker volume:
+Add `-v` to `down` only when you also want to delete the persisted `docker_seekdb_data` Docker volume:
 
 ```bash
 docker compose -f docker/docker-compose.yml down -v
@@ -105,7 +106,7 @@ docker compose -f docker/docker-compose.yml down -v
 
 #### Single-container deployment
 
-If your `.env` points to an existing database service, or if you intentionally want the server container to manage its own local storage, build and run only the server image:
+If your `.env` points to an existing database service and you do not want to start the bundled seekdb container, build and run only the server image:
 
 ```bash
 docker build -t oceanbase/powermem-server:latest -f docker/Dockerfile .

--- a/docs/website/i18n/zh/docusaurus-plugin-content-docs/current/api/0005-api_server.md
+++ b/docs/website/i18n/zh/docusaurus-plugin-content-docs/current/api/0005-api_server.md
@@ -23,8 +23,8 @@ pip install powermem
 powermem-server --host 0.0.0.0 --port 8848
 
 # 方法 2：使用 Docker Compose（推荐）
-cp .env.example .env
-# 启动服务前，先编辑 .env 并配置 LLM provider/key。
+cp .env.example docker/.env
+# 启动服务前，先编辑 docker/.env 并配置 LLM provider/key。
 docker compose -f docker/docker-compose.yml up -d --build
 
 # 方法 3：从源码使用 Makefile
@@ -57,9 +57,10 @@ make server-restart
 
 ```bash
 cp .env.example .env
+cp .env.example docker/.env
 ```
 
-编辑 `.env`，至少配置所选 LLM provider 需要的模型、API key 和 base URL。Compose 文件会读取项目根目录的 `.env`，并将它只读挂载到服务容器的 `/app/.env`，用于加载应用侧配置。它会有意覆盖 `DATABASE_PROVIDER` 和 `OCEANBASE_*`，让 Server 使用内置的 seekdb 容器。
+编辑 `docker/.env`，至少配置所选 LLM provider 需要的模型、API key 和 base URL。Compose 文件会通过 `env_file` 读取 `docker/.env`，用于加载应用侧配置。它会有意覆盖 `DATABASE_PROVIDER` 和 `OCEANBASE_*`，让 Server 使用内置的 seekdb 容器。如果还需要在本地运行 SDK 或单容器部署，可以继续保留项目根目录的 `.env`。
 
 #### 2. 启动 PowerMem Server 与 seekdb {#start-powermem-server-with-seekdb}
 
@@ -95,7 +96,7 @@ docker compose -f docker/docker-compose.yml logs -f powermem-server
 docker compose -f docker/docker-compose.yml down
 ```
 
-只有在同时想删除持久化的 `powermem_seekdb_data` Docker volume 时，才为 `down` 添加 `-v`：
+只有在同时想删除持久化的 `docker_seekdb_data` Docker volume 时，才为 `down` 添加 `-v`：
 
 ```bash
 docker compose -f docker/docker-compose.yml down -v
@@ -103,7 +104,7 @@ docker compose -f docker/docker-compose.yml down -v
 
 #### 单容器部署 {#single-container-deployment}
 
-如果 `.env` 已经指向现有数据库服务，或者明确希望 Server 容器自己管理本地存储，也可以只构建并运行 Server 镜像：
+如果 `.env` 已经指向现有数据库服务，并且不希望启动内置 `seekdb` 容器，也可以只构建并运行 Server 镜像：
 
 ```bash
 docker build -t oceanbase/powermem-server:latest -f docker/Dockerfile .
@@ -115,7 +116,7 @@ docker run -d \
   oceanbase/powermem-server:latest
 ```
 
-完整镜像构建参数、镜像源配置和生产环境注意事项见 [Docker 部署说明](https://github.com/oceanbase/powermem/blob/main/docker/DOCKER.md)。
+中文快速部署说明见 [Docker 目录中文说明](https://github.com/oceanbase/powermem/blob/main/docker/README_CN.md)，完整镜像构建参数、镜像源配置和生产环境注意事项见 [Docker 部署说明](https://github.com/oceanbase/powermem/blob/main/docker/DOCKER.md)。
 
 ### Dashboard 浏览器行为 {#dashboard-browser-behavior}
 

--- a/docs/website/i18n/zh/docusaurus-plugin-content-docs/current/api/0005-api_server.md
+++ b/docs/website/i18n/zh/docusaurus-plugin-content-docs/current/api/0005-api_server.md
@@ -22,18 +22,10 @@ PowerMem HTTP API 服务器基于 FastAPI 构建，提供以下功能：
 pip install powermem
 powermem-server --host 0.0.0.0 --port 8848
 
-# 方法 2：使用 Docker
-# 使用 Docker 构建并运行
-docker build -t oceanbase/powermem-server:latest -f docker/Dockerfile .
-docker run -d \
-  --name powermem-server \
-  -p 8848:8848 \
-  -v $(pwd)/.env:/app/.env:ro \
-  --env-file .env \
-  oceanbase/powermem-server:latest
-
-# 或使用 Docker Compose（推荐）
-docker-compose -f docker/docker-compose.yml up -d
+# 方法 2：使用 Docker Compose（推荐）
+cp .env.example .env
+# 启动服务前，先编辑 .env 并配置 LLM provider/key。
+docker compose -f docker/docker-compose.yml up -d --build
 
 # 方法 3：从源码使用 Makefile
 git clone git@github.com:oceanbase/powermem.git
@@ -57,6 +49,74 @@ make server-stop
 make server-restart
 
 ```
+### 使用 Docker 部署 {#deploy-with-docker}
+
+如果希望复用 `powermem-server` HTTP API，但不想在宿主机上安装 Python 依赖，可以使用 Docker。以下命令都在项目根目录执行。
+
+#### 1. 准备配置 {#prepare-configuration}
+
+```bash
+cp .env.example .env
+```
+
+编辑 `.env`，至少配置所选 LLM provider 需要的模型、API key 和 base URL。Compose 文件会读取项目根目录的 `.env`，并将它只读挂载到服务容器的 `/app/.env`，用于加载应用侧配置。它会有意覆盖 `DATABASE_PROVIDER` 和 `OCEANBASE_*`，让 Server 使用内置的 seekdb 容器。
+
+#### 2. 启动 PowerMem Server 与 seekdb {#start-powermem-server-with-seekdb}
+
+推荐的本地部署方式会同时启动 `powermem-server` 和 `seekdb`：
+
+```bash
+docker compose -f docker/docker-compose.yml up -d --build
+```
+
+如果 `.env` 已经指向现有数据库服务，请使用[单容器部署](#single-container-deployment)或自定义 Compose override。
+
+如果需要为内置的 seekdb 设置 root 密码，启动时传入 `SEEKDB_ROOT_PASSWORD`：
+
+```bash
+SEEKDB_ROOT_PASSWORD=change-me docker compose -f docker/docker-compose.yml up -d --build
+```
+
+该部署会暴露以下入口：
+
+| 服务 | 地址 / 端口 | 说明 |
+| --- | --- | --- |
+| PowerMem API | `http://localhost:8848` | REST API 与 Dashboard |
+| 健康检查 | `http://localhost:8848/api/v1/system/health` | 公开端点 |
+| Dashboard | `http://localhost:8848/dashboard/` | 记忆检查与监控 |
+| seekdb MySQL | `localhost:2881` | 如设置了 `SEEKDB_ROOT_PASSWORD`，则 root 使用该密码 |
+| seekdb 控制台 | `http://localhost:2886` | seekdb Web Dashboard |
+
+#### 3. 验证、查看日志与停止 {#verify-inspect-and-stop}
+
+```bash
+curl http://localhost:8848/api/v1/system/health
+docker compose -f docker/docker-compose.yml logs -f powermem-server
+docker compose -f docker/docker-compose.yml down
+```
+
+只有在同时想删除持久化的 `powermem_seekdb_data` Docker volume 时，才为 `down` 添加 `-v`：
+
+```bash
+docker compose -f docker/docker-compose.yml down -v
+```
+
+#### 单容器部署 {#single-container-deployment}
+
+如果 `.env` 已经指向现有数据库服务，或者明确希望 Server 容器自己管理本地存储，也可以只构建并运行 Server 镜像：
+
+```bash
+docker build -t oceanbase/powermem-server:latest -f docker/Dockerfile .
+docker run -d \
+  --name powermem-server \
+  -p 8848:8848 \
+  -v "$(pwd)/.env:/app/.env:ro" \
+  --env-file .env \
+  oceanbase/powermem-server:latest
+```
+
+完整镜像构建参数、镜像源配置和生产环境注意事项见 [Docker 部署说明](https://github.com/oceanbase/powermem/blob/main/docker/DOCKER.md)。
+
 ### Dashboard 浏览器行为 {#dashboard-browser-behavior}
 
 当 `powermem-server` 从交互式本地终端启动且已构建的 Dashboard 资源可用时，它会等待 `/dashboard/` 可访问，并在默认浏览器中打开该页面。


### PR DESCRIPTION
## Summary

- Add a step-by-step Docker deployment guide for `powermem-server` to the API Server docs and Chinese docs.
- Add a Chinese Docker quickstart in `docker/README_CN.md` and link it from the Docker README and Chinese API docs.
- Clarify the recommended Compose stack: `powermem-server` plus bundled `seekdb`, using the existing `docker/.env` workflow.
- Update Docker README/DOCKER docs to use Docker Compose v2 commands, explain the existing `docker/.env` Compose workflow, and clarify when to use single-container deployment.

## Validation

- `git diff --check`
- `SEEKDB_ROOT_PASSWORD=change-me docker compose -f docker/docker-compose.yml config`
- `SEEKDB_ROOT_PASSWORD=change-me docker compose --dry-run -f docker/docker-compose.yml up -d --build`
- `bash scripts/sync-website-docs.sh`
- In `docs/website`: `npm ci` and `npm run build`
- Two independent final reviews confirmed the PR diff does not include `docker/docker-compose.yml`.

## Notes

- The full container start was not run to avoid mutating pre-existing local Docker state that uses the same fixed container name.
