### PR TITLE
test: trigger VLDB LangChain CI smoke run

### DIFF
--- a/packages/powermem-langchain/CI_SMOKE.md
+++ b/packages/powermem-langchain/CI_SMOKE.md
@@ -1,0 +1,6 @@
+This file is used by a draft pull request to exercise the VLDB 2026
+LangChain package workflow against the `vldb_2026` branch.
+
+It intentionally does not implement or change the PowerMem LangChain
+middleware. The file can be removed after the CI and scoring workflow are
+verified.


### PR DESCRIPTION
This draft PR is a smoke check for the VLDB 2026 LangChain CI workflow.

It intentionally adds only a marker file under `packages/powermem-langchain/` so the `pull_request` path filter for `vldb_2026` is exercised without implementing or changing the middleware.

Expected validation: the VLDB 2026 LangChain package workflow should run against the `vldb_2026` base branch and produce the contract score artifacts/comment path for inspection.
