### PR TITLE
feat(rerank): add NVIDIA NIM provider

### DIFF
--- a/src/powermem/integrations/rerank/config/providers.py
+++ b/src/powermem/integrations/rerank/config/providers.py
@@ -118,10 +118,46 @@ class ZaiRerankConfig(BaseRerankConfig):
 
 class GenericRerankConfig(BaseRerankConfig):
     """Configuration for generic rerank service"""
-    
+
     _provider_name = "generic"
     _class_path = "powermem.integrations.rerank.generic.GenericRerank"
-    
+
     model_config = settings_config("RERANKER_", extra="forbid", env_file=None)
-    
+
     # Generic uses base class default configuration
+
+
+class NimRerankConfig(BaseRerankConfig):
+    """Configuration for NVIDIA NIM (NeMo Retriever Reranking) `/v1/ranking` service"""
+
+    _provider_name = "nim"
+    _class_path = "powermem.integrations.rerank.nim.NimRerank"
+
+    model_config = settings_config("RERANKER_", extra="forbid", env_file=None)
+
+    api_key: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "api_key",
+            "RERANKER_API_KEY",
+            "NIM_API_KEY",
+            "NGC_API_KEY",
+        ),
+        description="NGC / NIM API key for the NIM rerank service"
+    )
+
+    model: Optional[str] = Field(
+        default="baai/bge-reranker-v2-m3",
+        description="NIM rerank model name"
+    )
+
+    api_base_url: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "api_base_url",
+            "RERANKER_API_BASE_URL",
+            "NIM_RERANK_BASE_URL",
+            "NIM_BASE_URL",
+        ),
+        description="Base URL for the NIM rerank service, e.g. http://host:8002/v1"
+    )

--- a/src/powermem/integrations/rerank/factory.py
+++ b/src/powermem/integrations/rerank/factory.py
@@ -14,6 +14,7 @@ from powermem.integrations.rerank.config.providers import (
     JinaRerankConfig,
     ZaiRerankConfig,
     GenericRerankConfig,
+    NimRerankConfig,
 )
 
 

--- a/src/powermem/integrations/rerank/nim.py
+++ b/src/powermem/integrations/rerank/nim.py
@@ -1,0 +1,166 @@
+"""
+NVIDIA NIM Rerank implementation
+
+Targets the NVIDIA NIM / NeMo Retriever Reranking `/v1/ranking` endpoint
+(e.g. baai/bge-reranker-v2-m3). Unlike the unified/Cohere-style rerank API,
+NIM wraps the query and each passage in objects and returns a flat
+`rankings` array scored by the cross-encoder.
+
+Request:
+    POST {api_base_url}/ranking
+    {
+        "model": "baai/bge-reranker-v2-m3",
+        "query": {"text": "..."},
+        "passages": [{"text": "..."}, ...]
+    }
+
+Response:
+    {
+        "rankings": [
+            {"index": 0, "logit": -9.09},
+            {"index": 1, "logit": -11.02}
+        ],
+        "usage": {"prompt_tokens": 31, "total_tokens": 31}
+    }
+
+Note: do NOT send `return_text` — the NIM /v1/ranking endpoint rejects unknown
+fields with a validation error. Scores come back as `logit` (no `score` field);
+the parser falls back to `logit` when `score` is absent.
+"""
+from typing import List, Optional, Tuple
+
+try:
+    import httpx
+except ImportError:
+    httpx = None
+
+from powermem.integrations.rerank.base import RerankBase
+from powermem.integrations.rerank.config.base import BaseRerankConfig
+
+
+def _ranking_url(api_base_url: str) -> str:
+    """Normalize the configured base URL to the NIM `/v1/ranking` endpoint.
+
+    Accepts any of: `http://h:8002`, `http://h:8002/v1`,
+    `http://h:8002/v1/ranking` (idempotent).
+    """
+    url = (api_base_url or "").rstrip("/")
+    if url.endswith("/ranking"):
+        return url
+    if url.endswith("/v1"):
+        return url + "/ranking"
+    return url + "/v1/ranking"
+
+
+class NimRerank(RerankBase):
+    """Rerank via the NVIDIA NIM `/v1/ranking` endpoint.
+
+    Args:
+        config (Optional[BaseRerankConfig]):
+            - api_base_url: NIM rerank base URL, e.g. http://host:8002/v1 (required)
+            - model: NIM model name, e.g. baai/bge-reranker-v2-m3 (required)
+            - api_key: Optional NGC / NIM API key (sent as Bearer)
+    """
+
+    def __init__(self, config: Optional[BaseRerankConfig] = None):
+        super().__init__(config)
+
+        if httpx is None:
+            raise ImportError(
+                "httpx is not installed. Please install it with: pip install httpx"
+            )
+
+        if not self.config.api_base_url:
+            raise ValueError(
+                "api_base_url is required. Set RERANKER_API_BASE_URL / NIM_RERANK_BASE_URL "
+                "or pass api_base_url in config."
+            )
+        if not self.config.model:
+            raise ValueError(
+                "model is required. Set RERANK_MODEL or pass model name in config."
+            )
+
+        self.api_base_url = self.config.api_base_url
+        self.api_key = self.config.api_key
+        self.http_client = self.config.http_client
+
+    def rerank(
+        self,
+        query: str,
+        documents: List[str],
+        top_n: Optional[int] = None,
+        instruct: Optional[str] = None,
+    ) -> List[Tuple[int, float]]:
+        """Rerank documents via the NIM `/v1/ranking` endpoint.
+
+        Returns: list of (document_index, score) sorted by score desc, sliced to top_n.
+        """
+        if not query or not query.strip():
+            raise ValueError("Query cannot be empty")
+        if not documents:
+            raise ValueError("Documents list cannot be empty")
+
+        query = query.strip()
+        effective_top_n = top_n if top_n is not None else len(documents)
+
+        payload = {
+            "model": self.config.model,
+            "query": {"text": query},
+            "passages": [{"text": d} for d in documents],
+        }
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        url = _ranking_url(self.api_base_url)
+
+        try:
+            if self.http_client:
+                response = self.http_client.post(url, json=payload, headers=headers)
+                response.raise_for_status()
+                result = response.json()
+            else:
+                with httpx.Client(timeout=30.0) as client:
+                    response = client.post(url, json=payload, headers=headers)
+                    response.raise_for_status()
+                    result = response.json()
+        except httpx.HTTPStatusError as e:
+            error_msg = f"HTTP error {e.response.status_code}"
+            try:
+                detail = e.response.json()
+                error_msg += f": {detail.get('detail') or detail.get('error') or detail}"
+            except (ValueError, KeyError):
+                error_msg += f": {e.response.text}"
+            raise Exception(f"NIM rerank failed: {error_msg}")
+        except Exception as e:
+            raise Exception(f"NIM rerank failed: {e}")
+
+        rankings = result.get("rankings")
+        if not rankings:
+            raise Exception(f"Unexpected response format from NIM Rerank API: {result}")
+
+        scored = []
+        for item in rankings:
+            idx = item.get("index")
+            if idx is None:
+                continue
+            score = item.get("score")
+            if score is None:
+                score = item.get("logit", 0.0)
+            scored.append((int(idx), float(score)))
+
+        scored.sort(key=lambda x: x[1], reverse=True)
+        return scored[:effective_top_n]
+
+    def rerank_with_texts(
+        self,
+        query: str,
+        documents: List[str],
+        top_n: Optional[int] = None,
+        instruct: Optional[str] = None,
+    ) -> List[Tuple[str, float]]:
+        """Rerank and return (document_text, score) sorted by score desc."""
+        return [
+            (documents[idx], score)
+            for idx, score in self.rerank(query, documents, top_n, instruct)
+        ]

--- a/tests/unit/test_nim_rerank.py
+++ b/tests/unit/test_nim_rerank.py
@@ -1,0 +1,135 @@
+"""Unit tests for the NVIDIA NIM rerank provider.
+
+The NIM `/v1/ranking` endpoint is exercised via an injected mock http_client
+(no live GPU/NIM container required).
+"""
+from unittest.mock import Mock
+
+import pytest
+
+from powermem.integrations.rerank.config.base import BaseRerankConfig
+from powermem.integrations.rerank.config.providers import NimRerankConfig
+from powermem.integrations.rerank.factory import RerankFactory
+from powermem.integrations.rerank.nim import NimRerank, _ranking_url
+
+
+def _mock_client(response_json):
+    """Build a mock httpx-like client whose .post() returns response_json."""
+    resp = Mock()
+    resp.json.return_value = response_json
+    resp.raise_for_status.return_value = None
+    client = Mock()
+    client.post.return_value = resp
+    return client, resp
+
+
+def _make_rerank(client, **overrides):
+    cfg = NimRerankConfig(
+        api_base_url="http://nim:8002/v1",
+        model="baai/bge-reranker-v2-m3",
+        api_key="nvapi-test",
+        http_client=client,
+        **overrides,
+    )
+    return NimRerank(cfg)
+
+
+def test_rankings_parsed_and_sorted_desc():
+    client, _ = _mock_client({
+        "rankings": [
+            {"index": 0, "score": 0.03, "logit": -3.5},
+            {"index": 1, "score": 0.98, "logit": 4.1},
+        ]
+    })
+    r = _make_rerank(client)
+    assert r.rerank("q", ["doc0", "doc1"]) == [(1, 0.98), (0, 0.03)]
+
+
+def test_request_payload_matches_nim_shape():
+    client, _ = _mock_client({"rankings": [{"index": 0, "score": 0.5}]})
+    r = _make_rerank(client)
+    r.rerank("query", ["a", "b"])
+
+    url = client.post.call_args.args[0]
+    payload = client.post.call_args.kwargs["json"]
+    headers = client.post.call_args.kwargs["headers"]
+
+    assert url == "http://nim:8002/v1/ranking"
+    assert payload["model"] == "baai/bge-reranker-v2-m3"
+    assert payload["query"] == {"text": "query"}
+    assert payload["passages"] == [{"text": "a"}, {"text": "b"}]
+    assert "return_text" not in payload  # real NIM rejects unknown fields
+    assert headers["Authorization"] == "Bearer nvapi-test"
+
+
+def test_top_n_slicing():
+    client, _ = _mock_client({
+        "rankings": [
+            {"index": 0, "score": 0.9},
+            {"index": 1, "score": 0.8},
+            {"index": 2, "score": 0.7},
+        ]
+    })
+    r = _make_rerank(client)
+    assert r.rerank("q", ["a", "b", "c"], top_n=2) == [(0, 0.9), (1, 0.8)]
+
+
+def test_logit_fallback_when_score_missing():
+    client, _ = _mock_client({
+        "rankings": [
+            {"index": 0, "logit": -2.0},
+            {"index": 1, "logit": 3.0},
+        ]
+    })
+    r = _make_rerank(client)
+    assert r.rerank("q", ["a", "b"]) == [(1, 3.0), (0, -2.0)]
+
+
+@pytest.mark.parametrize(
+    "base,expected",
+    [
+        ("http://h:8002", "http://h:8002/v1/ranking"),
+        ("http://h:8002/v1", "http://h:8002/v1/ranking"),
+        ("http://h:8002/v1/", "http://h:8002/v1/ranking"),
+        ("http://h:8002/v1/ranking", "http://h:8002/v1/ranking"),
+    ],
+)
+def test_ranking_url_normalization(base, expected):
+    assert _ranking_url(base) == expected
+
+
+def test_factory_creates_nim_provider():
+    client, _ = _mock_client({"rankings": [{"index": 0, "score": 0.1}]})
+    reranker = RerankFactory.create(
+        "nim",
+        {
+            "api_base_url": "http://nim:8002/v1",
+            "model": "baai/bge-reranker-v2-m3",
+            "http_client": client,
+        },
+    )
+    assert isinstance(reranker, NimRerank)
+    assert "nim" in BaseRerankConfig._registry
+
+
+def test_empty_inputs_raise():
+    client, _ = _mock_client({"rankings": []})
+    r = _make_rerank(client)
+    with pytest.raises(ValueError):
+        r.rerank("", ["a"])
+    with pytest.raises(ValueError):
+        r.rerank("q", [])
+
+
+def test_missing_base_url_or_model_raises():
+    with pytest.raises(ValueError):
+        NimRerank(NimRerankConfig(model="x"))  # no api_base_url
+    with pytest.raises(ValueError):
+        NimRerank(NimRerankConfig(api_base_url="http://h:8002/v1", model=""))
+
+
+def test_unexpected_response_raises():
+    client, _ = _mock_client({"not_rankings": []})
+    r = _make_rerank(client)
+    with pytest.raises(Exception):
+        r.rerank("q", ["a"])


### PR DESCRIPTION
Add NimRerank for the NVIDIA NIM / NeMo Retriever Reranking /v1/ranking endpoint (e.g. baai/bge-reranker-v2-m3). Translates the standard rerank() call into NIM's shape (query/passage objects) and parses rankings[].index with logit fallback, sorted desc and sliced to top_n.

- nim.py: NimRerank + _ranking_url normalizer (accepts bare host, .../v1, or full .../v1/ranking); http_client injectable for tests
- config/providers.py: NimRerankConfig (provider "nim") with env aliases RERANKER_API_KEY/NIM_API_KEY/NGC_API_KEY and RERANKER_API_BASE_URL/NIM_RERANK_BASE_URL/NIM_BASE_URL
- factory.py: import NimRerankConfig to trigger registration
- tests/unit/test_nim_rerank.py: 12 unit tests (request shape, response parsing, sorting, top_n, logit fallback, URL normalization, factory wiring, error cases)

Verified against a live NIM bge-reranker-v2-m3 container.

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
