### PR TITLE
fix(ci): validate VLDB comment target

### DIFF
--- a/.github/workflows/vldb-comment.yml
+++ b/.github/workflows/vldb-comment.yml
@@ -49,17 +49,8 @@ jobs:
 
           PR_NUMBER="$PR_NUMBER_FROM_EVENT"
           if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            PR_NUMBER_PATH="$ARTIFACT_DIR/pr_number"
-            if [[ ! -f "$PR_NUMBER_PATH" ]]; then
-              echo "::warning::PR number missing from workflow_run event and artifact, skip PR comment"
-              exit 0
-            fi
-            PR_NUMBER="$(tr -d '[:space:]' < "$PR_NUMBER_PATH")"
-            echo "workflow_run event did not include PR number, using artifact PR number: $PR_NUMBER"
-          fi
-          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "invalid PR number: $PR_NUMBER"
-            exit 1
+            echo "::warning::PR number missing from workflow_run event, skip PR comment"
+            exit 0
           fi
 
           MARKER="<!-- powermem-vldb-langchain-contract-score -->"
@@ -95,13 +86,13 @@ jobs:
 
           pr_head_repo = (pr.get("head", {}).get("repo") or {}).get("full_name") or ""
           pr_head_sha = pr.get("head", {}).get("sha") or ""
-          if workflow_head_repo and pr_head_repo and workflow_head_repo != pr_head_repo:
+          if workflow_head_repo != pr_head_repo:
               raise SystemExit(
                   f"PR head repo mismatch: workflow_run={workflow_head_repo}, pr={pr_head_repo}"
               )
-          if workflow_head_sha and pr_head_sha and workflow_head_sha != pr_head_sha:
-              print(
-                  f"::warning::PR head sha differs from workflow_run head_sha: "
+          if workflow_head_sha != pr_head_sha:
+              raise SystemExit(
+                  f"PR head sha mismatch: "
                   f"workflow_run={workflow_head_sha}, pr={pr_head_sha}"
               )
           PY

--- a/tests/unit/test_vldb_comment_ci.py
+++ b/tests/unit/test_vldb_comment_ci.py
@@ -1,0 +1,98 @@
+import json
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "vldb-comment.yml"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _target_validation_script() -> str:
+    match = re.search(
+        r'python3 - "\$PR_JSON" "\$WORKFLOW_HEAD_REPO" "\$WORKFLOW_HEAD_SHA" <<\'PY\'\n'
+        r"(?P<script>.*?)\n          PY",
+        _workflow_text(),
+        flags=re.DOTALL,
+    )
+    assert match is not None
+    return textwrap.dedent(match.group("script"))
+
+
+def _run_target_validation(
+    tmp_path: Path,
+    *,
+    workflow_repo: str,
+    workflow_sha: str,
+    pr_repo: str,
+    pr_sha: str,
+) -> subprocess.CompletedProcess[str]:
+    pr_path = tmp_path / "pr.json"
+    pr_path.write_text(
+        json.dumps({"head": {"repo": {"full_name": pr_repo}, "sha": pr_sha}}),
+        encoding="utf-8",
+    )
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _target_validation_script(),
+            str(pr_path),
+            workflow_repo,
+            workflow_sha,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_vldb_comment_skips_when_event_has_no_pr_number() -> None:
+    workflow = _workflow_text()
+
+    assert "PR_NUMBER_PATH" not in workflow
+    assert "using artifact PR number" not in workflow
+    assert "PR number missing from workflow_run event, skip PR comment" in workflow
+
+
+def test_vldb_comment_accepts_exact_pr_head(tmp_path: Path) -> None:
+    result = _run_target_validation(
+        tmp_path,
+        workflow_repo="oceanbase/powermem",
+        workflow_sha="abc123",
+        pr_repo="oceanbase/powermem",
+        pr_sha="abc123",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_vldb_comment_rejects_pr_head_sha_mismatch(tmp_path: Path) -> None:
+    result = _run_target_validation(
+        tmp_path,
+        workflow_repo="oceanbase/powermem",
+        workflow_sha="workflow-sha",
+        pr_repo="oceanbase/powermem",
+        pr_sha="different-pr-sha",
+    )
+
+    assert result.returncode != 0
+    assert "PR head sha mismatch" in result.stderr
+
+
+def test_vldb_comment_rejects_pr_head_repo_mismatch(tmp_path: Path) -> None:
+    result = _run_target_validation(
+        tmp_path,
+        workflow_repo="contributor/fork",
+        workflow_sha="abc123",
+        pr_repo="other/fork",
+        pr_sha="abc123",
+    )
+
+    assert result.returncode != 0
+    assert "PR head repo mismatch" in result.stderr


### PR DESCRIPTION
## Summary
- fail closed when the `workflow_run` event does not provide a PR number instead of trusting the downloaded artifact
- require the selected PR head repository and SHA to exactly match the completed workflow run before writing comments
- add focused unit coverage for missing event targets and head repository/SHA validation

## Test plan
- [x] `uv run --no-sync python -m pytest tests/unit/test_vldb_comment_ci.py -q`
- [x] `git diff --check origin/main...HEAD`

Closes #1156

Made with [Cursor](https://cursor.com)