### PR TITLE
fix(docs): remove undefined homepage icon class

### DIFF
--- a/docs/website/src/components/Features/index.tsx
+++ b/docs/website/src/components/Features/index.tsx
@@ -100,7 +100,7 @@ export default function Features() {
                 key={feature.key}
                 className={styles.card}
               >
-                <div className={`${styles.icon} ${styles[`icon-${feature.key}`]}`}>
+                <div className={styles.icon}>
                   <Icon className={styles.iconSvg} />
                 </div>
                 <Heading as="h3" className={styles.cardTitle}>


### PR DESCRIPTION
Close #1178

## Summary
- Remove the stale dynamic CSS Module lookup from homepage feature icon wrappers.
- Prevent the `undefined` CSS class token described in #1178 from being emitted in the homepage markup.

## Test plan
- [x] `npm run typecheck`
- [x] Synced source docs and ran `npm run build` in a clean worktree.
- [x] Confirmed the generated homepage HTML contains no `undefined` token.