### PR TITLE
docs: point Git install references to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Prerequisites:
 Install the tool and configure the Codex plugin:
 
 ```bash
-uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@main"
-powercontext setup codex --source oceanbase/powercontext --ref main
+uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+powercontext setup codex --source oceanbase/powercontext --ref master
 ```
 
 You do not need to create or manage a repository checkout. Start the local service in a terminal:
@@ -58,7 +58,7 @@ surfaces. Installation, configuration, and troubleshooting live under [`docs/en/
 Add only the role the project imports:
 
 ```bash
-uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@main"
+uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
 Available extras are `builtin`, `client`, `server`, and `cli`. The CLI always includes Server-backed content commands;

--- a/docs/en/changelog/index.md
+++ b/docs/en/changelog/index.md
@@ -19,6 +19,6 @@ hide:
   <div class="pc-release__body">
     <h2>No tagged release yet.</h2>
     <p>The repository does not have a version tag, so there is no release entry to publish.</p>
-    <p><a href="https://github.com/oceanbase/powercontext/commits/main">Commit history</a> · <a href="https://github.com/oceanbase/powercontext/releases">GitHub Releases</a></p>
+    <p><a href="https://github.com/oceanbase/powercontext/commits/master">Commit history</a> · <a href="https://github.com/oceanbase/powercontext/releases">GitHub Releases</a></p>
   </div>
 </section>

--- a/docs/en/docs/how-to/configure-codex.md
+++ b/docs/en/docs/how-to/configure-codex.md
@@ -10,7 +10,7 @@ description: Install the PowerContext Codex plugin and control its local behavio
 Run:
 
 ```bash
-powercontext setup codex --source oceanbase/powercontext --ref main
+powercontext setup codex --source oceanbase/powercontext --ref master
 ```
 
 The command adds the repository as a Codex marketplace, installs the PowerContext plugin, and creates the user data

--- a/docs/en/docs/how-to/install-and-run.md
+++ b/docs/en/docs/how-to/install-and-run.md
@@ -10,14 +10,14 @@ description: Install PowerContext from Git and run the local Server.
 Install `uv`, then install PowerContext directly from a Git ref:
 
 ```bash
-uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@main"
+uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
 This works on macOS and Linux and does not require a user-managed repository checkout. Git uses its normal credential
 configuration, including credential helpers and SSH settings. For an SSH-based install, replace the HTTPS URL with the
 Git URL approved for your environment.
 
-To install a tested branch or tag, replace `main` after the final `@`. Use the same ref when configuring integrations:
+To install a tested branch or tag, replace `master` after the final `@`. Use the same ref when configuring integrations:
 
 ```bash
 powercontext setup codex --source oceanbase/powercontext --ref <ref>
@@ -66,7 +66,7 @@ directory unless `POWERCONTEXT_HOME` or the database URL changes.
 An application that imports the async Client SDK should add it to that application's environment:
 
 ```bash
-uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@main"
+uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
 Use `builtin` for in-process Python composition, `server` for the service, `client` for the Python SDK, or `cli` for

--- a/docs/en/docs/tutorials/codex-quickstart.md
+++ b/docs/en/docs/tutorials/codex-quickstart.md
@@ -18,8 +18,8 @@ repository with the credentials already configured on your machine.
 Run these commands from any directory:
 
 ```bash
-uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@main"
-powercontext setup codex --source oceanbase/powercontext --ref main
+uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+powercontext setup codex --source oceanbase/powercontext --ref master
 ```
 
 The first command installs an isolated application. The second installs the Codex plugin and prepares PowerContext's

--- a/docs/zh/changelog/index.md
+++ b/docs/zh/changelog/index.md
@@ -19,6 +19,6 @@ hide:
   <div class="pc-release__body">
     <h2>尚无正式版本。</h2>
     <p>当前仓库还没有版本标签，因此没有可发布的 release 条目。</p>
-    <p><a href="https://github.com/oceanbase/powercontext/commits/main">提交历史</a> · <a href="https://github.com/oceanbase/powercontext/releases">GitHub Releases</a></p>
+    <p><a href="https://github.com/oceanbase/powercontext/commits/master">提交历史</a> · <a href="https://github.com/oceanbase/powercontext/releases">GitHub Releases</a></p>
   </div>
 </section>

--- a/docs/zh/docs/how-to/configure-codex.md
+++ b/docs/zh/docs/how-to/configure-codex.md
@@ -10,7 +10,7 @@ description: 安装 PowerContext Codex 插件并控制其本地行为。
 执行：
 
 ```bash
-powercontext setup codex --source oceanbase/powercontext --ref main
+powercontext setup codex --source oceanbase/powercontext --ref master
 ```
 
 该命令会把仓库添加为 Codex marketplace，安装 PowerContext 插件，并创建用户数据目录。重复执行是安全的。

--- a/docs/zh/docs/how-to/install-and-run.md
+++ b/docs/zh/docs/how-to/install-and-run.md
@@ -10,13 +10,13 @@ description: 从 Git 安装 PowerContext，并运行本地 Server。
 先安装 `uv`，再从指定 Git ref 直接安装 PowerContext：
 
 ```bash
-uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@main"
+uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
 该方式支持 macOS 和 Linux，不需要用户自行管理仓库工作副本。Git 会沿用本机的凭据配置，包括 credential
 helper 和 SSH 设置。如需使用 SSH，请把 HTTPS URL 换成当前环境允许的 Git URL。
 
-安装指定分支或 tag 时，替换最后一个 `@` 后的 `main`。配置集成时应使用同一个 ref：
+安装指定分支或 tag 时，替换最后一个 `@` 后的 `master`。配置集成时应使用同一个 ref：
 
 ```bash
 powercontext setup codex --source oceanbase/powercontext --ref <ref>
@@ -64,7 +64,7 @@ powercontext setup codex --source oceanbase/powercontext --ref <ref>
 如果应用需要导入异步 Client SDK，应把它加入该应用自己的环境：
 
 ```bash
-uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@main"
+uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git@master"
 ```
 
 进程内 Python 组合使用 `builtin`，服务使用 `server`，Python SDK 使用 `client`，基于 Server 的命令行使用

--- a/docs/zh/docs/tutorials/codex-quickstart.md
+++ b/docs/zh/docs/tutorials/codex-quickstart.md
@@ -17,8 +17,8 @@ description: 安装 PowerContext，并在多个 Codex 会话之间传递项目�
 在任意目录执行：
 
 ```bash
-uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@main"
-powercontext setup codex --source oceanbase/powercontext --ref main
+uv tool install "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+powercontext setup codex --source oceanbase/powercontext --ref master
 ```
 
 第一条命令安装隔离的应用环境；第二条命令安装 Codex 插件，并准备 PowerContext 用户数据目录。

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -5,7 +5,7 @@
 Install the PowerContext tool first, then configure the plugin:
 
 ```bash
-powercontext setup codex --source oceanbase/powercontext --ref main
+powercontext setup codex --source oceanbase/powercontext --ref master
 powercontext server run
 ```
 

--- a/integrations/codex/plugins/powercontext/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/powercontext/.codex-plugin/plugin.json
@@ -29,7 +29,7 @@
       "Write",
       "Handoff"
     ],
-    "websiteURL": "https://github.com/oceanbase/powercontext/tree/main/docs/en/docs",
+    "websiteURL": "https://github.com/oceanbase/powercontext/tree/master/docs/en/docs",
     "defaultPrompt": [
       "Restore relevant project memory for this task.",
       "Prepare an inspectable Handoff for another task.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ setup = "powercontext.cli.system:setup_app"
 [project.urls]
 Homepage = "https://github.com/oceanbase/powercontext"
 Repository = "https://github.com/oceanbase/powercontext"
-Documentation = "https://github.com/oceanbase/powercontext/tree/main/docs/en/docs"
+Documentation = "https://github.com/oceanbase/powercontext/tree/master/docs/en/docs"
 
 [dependency-groups]
 dev = [

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -19,7 +19,7 @@ from powercontext.paths import powercontext_data_dir
 
 HELP_OPTION_NAMES = ("-h", "--help")
 DEFAULT_MARKETPLACE_SOURCE = "oceanbase/powercontext"
-DEFAULT_MARKETPLACE_REF = "main"
+DEFAULT_MARKETPLACE_REF = "master"
 PLUGIN_NAME = "powercontext"
 
 setup_app = typer.Typer(

--- a/zensical.toml
+++ b/zensical.toml
@@ -4,7 +4,7 @@ repo_url = "https://github.com/oceanbase/powercontext"
 site_url = "https://oceanbase.github.io/powercontext"
 site_description = "PowerContext turns human-agent work into handoff-ready context."
 site_author = "PowerContext Team"
-edit_uri = "edit/main/docs/"
+edit_uri = "edit/master/docs/"
 repo_name = "oceanbase/powercontext"
 copyright = 'Maintained by <a href="https://oceanbase.com">OceanBase</a>.'
 


### PR DESCRIPTION
Closes #1205

## Rationale

The repository's `main` branch still contains legacy PowerMem (package metadata: `powermem`), while current PowerContext development is on `master`. The documented Git install ref therefore cannot install the requested `powercontext` package.

## Changes

- Point all documented PowerContext Git-install and Codex-plugin refs from `main` to `master`.
- Update the package documentation URL to the `master` branch.
- Keep English and Chinese instructions aligned.

## User-facing impact

Following the documented command now resolves PowerContext instead of the legacy PowerMem branch.

## Validation

- In an isolated `uv tool` environment, the original `@main` command resolved `9d1b484` and failed with `Package metadata name 'powermem' does not match given name 'powercontext'`.
- The corrected `@master` command resolved `c870f81`, installed `powercontext==0.0.1`, and its CLI ran successfully. The isolated test installation and cache were removed afterward.
- `git diff --check` passed.
- `uv run zensical build -s` was attempted but timed out during first-run environment preparation after 244 seconds, without a build diagnostic.