### PR TITLE
fix(powercontext): use --frozen for Codex plugin uv commands

### DIFF
--- a/integrations/codex/plugins/powercontext/hooks/hooks.json
+++ b/integrations/codex/plugins/powercontext/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --locked --quiet --project \"${PLUGIN_ROOT}\" python \"${PLUGIN_ROOT}/hooks/recall.py\"",
+            "command": "uv run --frozen --quiet --project \"${PLUGIN_ROOT}\" python \"${PLUGIN_ROOT}/hooks/recall.py\"",
             "timeout": 10,
             "statusMessage": "Syncing PowerContext"
           }

--- a/integrations/codex/plugins/powercontext/skills/project-context/SKILL.md
+++ b/integrations/codex/plugins/powercontext/skills/project-context/SKILL.md
@@ -18,7 +18,7 @@ to duplicate the current prompt.
 Before the first memory tool call, run:
 
 ```bash
-uv run --locked --quiet --project "$PLUGIN_ROOT" python "$PLUGIN_ROOT/scripts/project_scope.py" --cwd "$PWD"
+uv run --frozen --quiet --project "$PLUGIN_ROOT" python "$PLUGIN_ROOT/scripts/project_scope.py" --cwd "$PWD"
 ```
 
 Reuse that exact `scope_id` for the task.


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1210.

# Rationale for this change

The PowerContext Codex plugin runs project-local helper scripts with `uv run --locked`.

When a user's global uv configuration uses a custom package index while the bundled `uv.lock` records PyPI, uv considers the lockfile outdated and exits. This breaks both the `UserPromptSubmit` hook and the `project-context` skill.

Using `--frozen` allows the plugin to trust its bundled lockfile without checking or modifying it.

# What changes are included in this PR?

- Replace `--locked` with `--frozen` in the `UserPromptSubmit` hook command.
- Replace `--locked` with `--frozen` in the `project-context` skill command.
- No dependency versions, public APIs, or persisted formats are changed.

# Are there any user-facing changes?

Yes. The Codex plugin can now run when users configure a custom uv package index without requiring them to regenerate the plugin's lockfile.

There are no breaking changes.

# How was this change tested?

- Reproduced the lockfile error with `--locked` while using the Tsinghua PyPI mirror.
- Verified that the same plugin command succeeds with `--frozen`.
- Validated `hooks/hooks.json` with `python3 -m json.tool`.
- Ran `git diff --check upstream/master...HEAD`.

# AI usage statement

OpenAI Codex (GPT-5.6) was used to inspect the affected plugin paths, reproduce the uv index and lockfile behavior, and draft the change and PR description. The final diff and validation results were reviewed by the contributor.