### PR TITLE
docs: clarify PowerMem upgrade and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # PowerContext
 
-PowerContext gives agents durable, project-scoped context. A later session can recover a decision, outcome, current
-state, or next step without relying on chat history. PowerContext includes a local Server, SQLite storage, an
-async Python client, a Core SDK, a CLI, and a Codex plugin.
+PowerContext is PowerMem 2.0, the upgraded version of [PowerMem](https://www.powermem.ai/). It gives agents durable,
+project-scoped context. A later session can recover a decision, outcome, current state, or next step without relying
+on chat history. PowerContext includes a local Server, SQLite storage, an async Python client, a Core SDK, a CLI, and
+a Codex plugin.
 
 PowerContext can be installed directly from its Git URL. Users need read access to that URL, but they do not need to
 clone the repository or run commands from its working tree.
@@ -63,6 +64,18 @@ uv add "powercontext[client] @ git+https://github.com/oceanbase/powercontext.git
 
 Available extras are `builtin`, `client`, `server`, and `cli`. The CLI always includes Server-backed content commands;
 installing the `server` role also makes local Server process management available.
+
+## Benchmarks
+
+### [LOCOMO](https://github.com/snap-research/locomo)
+
+| Metric | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | Full-context baseline | PowerContext vs baseline |
+| --- | ---: | ---: | ---: | ---: |
+| Accuracy | **90.78%** (1,398/1,540) | 87.79% | 52.9% | **+60.7%** |
+| Search p95 latency | **1.38 s** | 1.44 s | 17.12 s | **-92.0%** |
+| Answer tokens / question | **~1.65 k** | ~0.9 k | 26 k | **-89.8%** |
+
+The PowerContext results come from a full 1,540-question run across all 10 LOCOMO conversations.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ installing the `server` role also makes local Server process management availabl
 
 ### [LOCOMO](https://github.com/snap-research/locomo)
 
-| Metric | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | Full-context baseline | PowerContext vs baseline |
-| --- | ---: | ---: | ---: | ---: |
-| Accuracy | **90.78%** (1,398/1,540) | 87.79% | 52.9% | **+60.7%** |
-| Search p95 latency | **1.38 s** | 1.44 s | 17.12 s | **-92.0%** |
-| Answer tokens / question | **~1.65 k** | ~0.9 k | 26 k | **-89.8%** |
+| Metric | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | Full-context baseline |
+| --- | ---: | ---: | ---: |
+| Accuracy | **90.78%** (1,398/1,540) | 87.79% | 52.9% |
+| Search p95 latency | **1.38 s** | 1.44 s | 17.12 s |
+| Answer tokens / question | **~1.65 k** | ~0.9 k | 26 k |
 
 The PowerContext results come from a full 1,540-question run across all 10 LOCOMO conversations.
 


### PR DESCRIPTION
# Which issue or RFC does this PR close?

No linked issue or RFC.

# Rationale for this change

The README should make the relationship between PowerContext and PowerMem immediately clear and surface the latest LOCOMO comparison for prospective users.

# What changes are included in this PR?

- Identify PowerContext as PowerMem 2.0, the upgraded version of PowerMem.
- Link readers to the PowerMem website.
- Add a LOCOMO benchmark table comparing accuracy, search p95 latency, and answer-token usage with PowerMem and a full-context baseline.

# Are there any user-facing changes?

Yes. The project positioning and benchmark results are now visible in the README. There are no runtime, API, storage, or compatibility changes.

# How was this change tested?

- `uv run prek run --files README.md`
- `make check`
- `make docs-test`

# AI usage statement

OpenAI Codex was used to edit the README and prepare this pull request.
