### PR TITLE
fix(web): stabilize dashboard and handoff state

### DIFF
--- a/src/powercontext/server/static/auth.js
+++ b/src/powercontext/server/static/auth.js
@@ -1,5 +1,9 @@
 const tokenKey = "powercontext.server.token";
 
+function setSessionState(state) {
+  document.documentElement.dataset.serverSession = state;
+}
+
 export function readServerToken() {
   try {
     return sessionStorage.getItem(tokenKey);
@@ -9,6 +13,7 @@ export function readServerToken() {
 }
 
 export function storeServerToken(token) {
+  setSessionState("active");
   try {
     sessionStorage.setItem(tokenKey, token);
   } catch (error) {
@@ -17,6 +22,7 @@ export function storeServerToken(token) {
 }
 
 export function clearServerToken() {
+  setSessionState("missing");
   try {
     sessionStorage.removeItem(tokenKey);
   } catch (error) {

--- a/src/powercontext/server/static/dashboard.js
+++ b/src/powercontext/server/static/dashboard.js
@@ -5,10 +5,9 @@ import {
   fetchWithBearer,
   readServerToken,
   storeServerToken
-} from "./auth.js";
+} from "./auth.js?v=session-shell";
+import {createPageUi, createRequestGate} from "./page-ui.js?v=request-gate";
 
-const themeKey = "powercontext.dashboard.theme";
-const localeKey = "powercontext.dashboard.locale";
 const translations = {
   en: {
     pageTitle: "PowerContext Dashboard",
@@ -61,6 +60,7 @@ const translations = {
     authRejected: "The Server rejected this token.",
     requestFailed: "The Dashboard request failed with HTTP {status}.",
     serverUnavailable: "The Server is unavailable.",
+    retry: "Retry",
     noScopes: "No Dashboard scopes are configured.",
     scopeUnavailable: "The selected scope is not available."
   },
@@ -115,6 +115,7 @@ const translations = {
     authRejected: "Server \u62d2\u7edd\u4e86\u8be5 Token\u3002",
     requestFailed: "Dashboard \u8bf7\u6c42\u5931\u8d25\uff08HTTP {status}\uff09\u3002",
     serverUnavailable: "Server \u65e0\u6cd5\u8bbf\u95ee\u3002",
+    retry: "\u91cd\u8bd5",
     noScopes: "\u672a\u914d\u7f6e Dashboard \u4f5c\u7528\u57df\u3002",
     scopeUnavailable: "\u9009\u4e2d\u7684\u4f5c\u7528\u57df\u4e0d\u53ef\u7528\u3002"
   }
@@ -123,29 +124,34 @@ const authShell = document.getElementById("auth-shell");
 const authForm = document.getElementById("auth-form");
 const authError = document.getElementById("auth-error");
 const tokenInput = document.getElementById("token");
+const pageStatus = document.getElementById("page-status");
+const pageStatusMessage = document.getElementById("page-status-message");
+const pageStatusRetry = document.getElementById("page-status-retry");
 const dashboard = document.getElementById("dashboard");
 const signOut = document.getElementById("sign-out");
-const themeToggle = document.getElementById("theme-toggle");
-const languageToggle = document.getElementById("language-toggle");
 const scopeSelect = document.getElementById("scope-select");
 const svgNamespace = "http://www.w3.org/2000/svg";
-let currentLocale = document.documentElement.lang === "zh" ? "zh" : "en";
 let currentView = null;
 let currentScopes = [];
 let currentAuthError = null;
-
-themeToggle.addEventListener("click", () => {
-  const currentTheme = document.documentElement.dataset.theme;
-  const nextTheme = currentTheme === "dark" ? "light" : "dark";
-  applyTheme(nextTheme);
+let currentPageStatus = null;
+let currentScopeId = "";
+const ui = createPageUi(translations, () => {
+  renderAuthError();
+  renderPageStatus();
+  if (currentView !== null) {
+    renderDashboard(currentView);
+  }
 });
-
-languageToggle.addEventListener("click", () => {
-  applyLocale(currentLocale === "en" ? "zh" : "en");
-});
+const {formatDateTime, formatNumber, translate} = ui;
+const dashboardRequests = createRequestGate();
 
 scopeSelect.addEventListener("change", async () => {
   await loadStatistics(readServerToken(), scopeSelect.value);
+});
+
+pageStatusRetry.addEventListener("click", async () => {
+  await authenticate(readServerToken(), currentScopeId);
 });
 
 authForm.addEventListener("submit", async (event) => {
@@ -160,127 +166,139 @@ signOut.addEventListener("click", () => {
   showLogin();
 });
 
-function applyTheme(theme, persist = true) {
-  document.documentElement.dataset.theme = theme;
-  if (persist) {
-    try {
-      localStorage.setItem(themeKey, theme);
-    } catch (error) {
-      // The selected theme still applies to the current page.
-    }
-  }
-  updateControlLabels();
-}
-
-function applyLocale(locale, persist = true) {
-  currentLocale = locale;
-  document.documentElement.lang = locale;
-  if (persist) {
-    try {
-      localStorage.setItem(localeKey, locale);
-    } catch (error) {
-      // The selected locale still applies to the current page.
-    }
-  }
-  document.title = translate("pageTitle");
-  document.querySelectorAll("[data-i18n]").forEach((element) => {
-    element.textContent = translate(element.dataset.i18n);
-  });
-  updateControlLabels();
-  renderAuthError();
-  if (currentView !== null) {
-    renderDashboard(currentView);
-  }
-}
-
-function updateControlLabels() {
-  const nextTheme = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
-  themeToggle.setAttribute("aria-label", translate(nextTheme === "dark" ? "switchDark" : "switchLight"));
-  themeToggle.setAttribute("title", translate(nextTheme === "dark" ? "switchDark" : "switchLight"));
-  languageToggle.textContent = currentLocale === "en" ? translate("languageChinese") : "EN";
-  languageToggle.setAttribute("aria-label", translate(currentLocale === "en" ? "switchChinese" : "switchEnglish"));
-}
-
 async function authenticate(token, scopeId = "") {
   if (!token) {
     showLogin();
     return;
   }
 
+  storeServerToken(token);
+  tokenInput.value = "";
+  currentAuthError = null;
+  const request = dashboardRequests.start();
   scopeSelect.disabled = true;
   try {
     const response = await fetchWithBearer("/dashboard/scopes", token);
+    if (!request.isCurrent()) {
+      return;
+    }
     if (response.status === 401) {
       clearServerToken();
       showLogin("authRejected");
       return;
     }
     if (!response.ok) {
-      showLogin("requestFailed", {status: response.status});
+      showPageStatus("requestFailed", {status: response.status}, true);
       return;
     }
     currentScopes = await response.json();
-    if (currentScopes.length === 0) {
-      showLogin("noScopes");
+    if (!request.isCurrent()) {
       return;
     }
-    storeServerToken(token);
-    tokenInput.value = "";
-    currentAuthError = null;
+    if (currentScopes.length === 0) {
+      showPageStatus("noScopes", {}, true);
+      return;
+    }
     const selectedScopeId = currentScopes.some((scope) => scope.scope_id === scopeId)
       ? scopeId
       : currentScopes[0].scope_id;
-    await loadStatistics(token, selectedScopeId);
+    currentScopeId = selectedScopeId;
+    await loadStatistics(token, selectedScopeId, request);
   } catch (error) {
-    showLogin("serverUnavailable");
+    if (request.isCurrent()) {
+      showPageStatus("serverUnavailable", {}, true);
+    }
   } finally {
-    scopeSelect.disabled = false;
+    if (request.isCurrent()) {
+      scopeSelect.disabled = false;
+    }
   }
 }
 
-async function loadStatistics(token, scopeId) {
+async function loadStatistics(token, scopeId, request = null) {
   if (!token) {
     showLogin();
     return;
   }
 
+  const activeRequest = request || dashboardRequests.start();
+  currentScopeId = scopeId;
   scopeSelect.disabled = true;
   try {
     const url = new URL("/v1/stats", window.location.origin);
     url.searchParams.set("scope_id", scopeId);
     url.searchParams.set("period", "30d");
     const response = await fetchWithBearer(url, token);
+    if (!activeRequest.isCurrent()) {
+      return;
+    }
     if (response.status === 401) {
       clearServerToken();
       showLogin("authRejected");
       return;
     }
     if (!response.ok) {
-      showLogin("requestFailed", {status: response.status});
+      showPageStatus("requestFailed", {status: response.status}, true);
       return;
     }
     const statistics = await response.json();
+    if (!activeRequest.isCurrent()) {
+      return;
+    }
     const selectedScope = currentScopes.find((scope) => scope.scope_id === statistics.scope_id);
     if (!selectedScope) {
-      showLogin("scopeUnavailable");
+      showPageStatus("scopeUnavailable", {}, true);
       return;
     }
     renderDashboard({scopes: currentScopes, selectedScope, statistics});
   } catch (error) {
-    showLogin("serverUnavailable");
+    if (activeRequest.isCurrent()) {
+      showPageStatus("serverUnavailable", {}, true);
+    }
   } finally {
-    scopeSelect.disabled = false;
+    if (activeRequest.isCurrent()) {
+      scopeSelect.disabled = false;
+    }
   }
 }
 
 function showLogin(messageKey = "", values = {}) {
+  dashboardRequests.cancel();
+  scopeSelect.disabled = false;
   currentView = null;
+  currentScopes = [];
+  currentScopeId = "";
+  currentPageStatus = null;
   currentAuthError = messageKey ? {key: messageKey, values} : null;
   renderAuthError();
   authShell.hidden = false;
+  pageStatus.hidden = true;
   dashboard.hidden = true;
   signOut.hidden = true;
   tokenInput.focus();
+}
+
+function showPageStatus(messageKey, values = {}, retryable = false) {
+  currentView = null;
+  currentPageStatus = {key: messageKey, values, retryable};
+  renderPageStatus();
+  authShell.hidden = true;
+  pageStatus.hidden = false;
+  dashboard.hidden = true;
+  signOut.hidden = false;
+}
+
+function renderPageStatus() {
+  if (currentPageStatus === null) {
+    pageStatusMessage.textContent = "";
+    pageStatusRetry.hidden = true;
+    return;
+  }
+  pageStatusMessage.textContent = translate(
+    currentPageStatus.key,
+    currentPageStatus.values
+  );
+  pageStatusRetry.hidden = !currentPageStatus.retryable;
 }
 
 function renderAuthError() {
@@ -291,10 +309,12 @@ function renderAuthError() {
 
 function renderDashboard(view) {
   currentView = view;
+  currentPageStatus = null;
   const statistics = view.statistics;
   const inventory = statistics.inventory;
   const recall = statistics.recall;
   authShell.hidden = true;
+  pageStatus.hidden = true;
   dashboard.hidden = false;
   signOut.hidden = false;
 
@@ -546,13 +566,8 @@ function setText(id, value) {
   document.getElementById(id).textContent = value;
 }
 
-function translate(key, values = {}) {
-  const template = translations[currentLocale][key] || translations.en[key] || key;
-  return template.replace(/\{([a-zA-Z]+)\}/g, (match, name) => String(values[name] ?? match));
-}
-
 function formatFamily(value) {
-  if (translations[currentLocale][value] || translations.en[value]) {
+  if (translations[ui.locale()][value] || translations.en[value]) {
     return translate(value);
   }
   return value
@@ -561,35 +576,17 @@ function formatFamily(value) {
     .join(" ");
 }
 
-function localeTag() {
-  return currentLocale === "zh" ? "zh-CN" : "en";
-}
-
-function formatNumber(value) {
-  return new Intl.NumberFormat(localeTag()).format(value);
-}
-
 function formatCompact(value) {
-  return new Intl.NumberFormat(localeTag(), {notation: "compact", maximumFractionDigits: 1}).format(value);
+  return new Intl.NumberFormat(ui.localeTag(), {notation: "compact", maximumFractionDigits: 1}).format(value);
 }
 
 function formatDate(value) {
-  return new Intl.DateTimeFormat(localeTag(), {dateStyle: "medium", timeZone: "UTC"}).format(new Date(`${value}T00:00:00Z`));
+  return new Intl.DateTimeFormat(ui.localeTag(), {dateStyle: "medium", timeZone: "UTC"}).format(new Date(`${value}T00:00:00Z`));
 }
 
 function formatShortDate(value) {
-  return new Intl.DateTimeFormat(localeTag(), {month: "short", day: "numeric", timeZone: "UTC"}).format(new Date(`${value}T00:00:00Z`));
+  return new Intl.DateTimeFormat(ui.localeTag(), {month: "short", day: "numeric", timeZone: "UTC"}).format(new Date(`${value}T00:00:00Z`));
 }
 
-function formatDateTime(value) {
-  return new Intl.DateTimeFormat(localeTag(), {dateStyle: "medium", timeStyle: "short"}).format(new Date(value));
-}
-
-const initialTheme = document.documentElement.dataset.theme === "dark"
-  ? "dark"
-  : (document.documentElement.dataset.theme === "light"
-    ? "light"
-    : (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"));
-applyLocale(currentLocale, false);
-applyTheme(initialTheme, false);
+ui.initialize();
 authenticate(readServerToken());

--- a/src/powercontext/server/static/handoff-report.js
+++ b/src/powercontext/server/static/handoff-report.js
@@ -5,11 +5,10 @@ import {
   fetchWithBearer,
   readServerToken,
   storeServerToken
-} from "./auth.js";
+} from "./auth.js?v=session-shell";
 import {formatDateRange, resolvePeriodSelection, validateDateRange} from "./handoff-period.js";
+import {createPageUi, createRequestGate} from "./page-ui.js?v=request-gate";
 
-const themeKey = "powercontext.dashboard.theme";
-const localeKey = "powercontext.dashboard.locale";
 const selectedProjectKey = "powercontext.handoff-report.project";
 const translations = {
   en: {
@@ -74,7 +73,7 @@ const translations = {
     switchEnglish: "Switch to English",
     languageChinese: "中文",
     updated: "Updated {value}",
-    projectTab: "{title} ({projectId})",
+    projectOption: "{title} ({projectId})",
     coverageCaptured: "Captured Activity is included through cursor {cursor}. Counts describe observed events, not completion percentage.",
     coverageNotConfigured: "Activity adapters are not configured. Missing Activity must not be read as no work occurring.",
     coverageUnavailable: "Activity coverage is unavailable for this report.",
@@ -82,6 +81,7 @@ const translations = {
     authRejected: "The Server rejected this token.",
     requestFailed: "The Handoff Report request failed with HTTP {status}.",
     serverUnavailable: "The Server is unavailable.",
+    retry: "Retry",
     reportUnavailable: "The selected Project report is unavailable.",
     downloadFailed: "The Markdown download failed with HTTP {status}.",
     reported: "Reported",
@@ -156,7 +156,7 @@ const translations = {
     switchEnglish: "切换至英文",
     languageChinese: "中文",
     updated: "更新于 {value}",
-    projectTab: "{title}（{projectId}）",
+    projectOption: "{title}（{projectId}）",
     coverageCaptured: "已纳入游标 {cursor} 之前捕获的 Activity。数量表示已观察事件，不代表完成百分比。",
     coverageNotConfigured: "Activity Adapter 尚未配置；缺少 Activity 不能解释为没有发生工作。",
     coverageUnavailable: "当前报告无法取得 Activity 覆盖信息。",
@@ -164,6 +164,7 @@ const translations = {
     authRejected: "Server 拒绝了该 Token。",
     requestFailed: "Handoff Report 请求失败（HTTP {status}）。",
     serverUnavailable: "Server 无法访问。",
+    retry: "重试",
     reportUnavailable: "当前 Project 的交接报告不可用。",
     downloadFailed: "Markdown 下载失败（HTTP {status}）。",
     reported: "已汇报",
@@ -182,9 +183,12 @@ const authShell = document.getElementById("auth-shell");
 const authForm = document.getElementById("auth-form");
 const authError = document.getElementById("auth-error");
 const tokenInput = document.getElementById("token");
+const pageStatus = document.getElementById("page-status");
+const pageStatusMessage = document.getElementById("page-status-message");
+const pageStatusRetry = document.getElementById("page-status-retry");
 const reportShell = document.getElementById("handoff-report");
 const reportError = document.getElementById("report-error");
-const projectTabs = document.getElementById("project-tabs");
+const projectSelect = document.getElementById("project-select");
 const refreshButton = document.getElementById("refresh-report");
 const downloadButton = document.getElementById("download-report");
 const periodButtons = Array.from(document.querySelectorAll("[data-period-mode]"));
@@ -194,24 +198,28 @@ const periodEndInput = document.getElementById("period-end");
 const applyCustomPeriodButton = document.getElementById("apply-custom-period");
 const periodError = document.getElementById("period-error");
 const signOut = document.getElementById("sign-out");
-const themeToggle = document.getElementById("theme-toggle");
-const languageToggle = document.getElementById("language-toggle");
-let currentLocale = document.documentElement.lang === "zh" ? "zh" : "en";
 let currentProjects = [];
 let currentProject = null;
 let currentReport = null;
 let currentAuthError = null;
+let currentPageStatus = null;
 let currentPeriodMode = "day";
 let currentPeriodSelection = null;
 let appliedCustomRange = null;
-
-themeToggle.addEventListener("click", () => {
-  applyTheme(document.documentElement.dataset.theme === "dark" ? "light" : "dark");
+const ui = createPageUi(translations, () => {
+  renderAuthError();
+  renderPageStatus();
+  if (currentProject !== null) {
+    renderProjectOptions(currentProjects, currentProject.project_id);
+  }
+  if (currentReport !== null) {
+    renderReport(currentReport);
+  } else {
+    renderPeriodControls();
+  }
 });
-
-languageToggle.addEventListener("click", () => {
-  applyLocale(currentLocale === "en" ? "zh" : "en");
-});
+const {formatDateTime, formatNumber, translate} = ui;
+const reportRequests = createRequestGate();
 
 authForm.addEventListener("submit", async (event) => {
   event.preventDefault();
@@ -224,6 +232,15 @@ signOut.addEventListener("click", () => {
   showLogin();
 });
 
+pageStatusRetry.addEventListener("click", async () => {
+  const token = readServerToken();
+  if (currentProject === null) {
+    await authenticate(token);
+  } else {
+    await loadReport(token, currentProject.project_id);
+  }
+});
+
 refreshButton.addEventListener("click", async () => {
   if (currentProject !== null) {
     await loadReport(readServerToken(), currentProject.project_id);
@@ -232,6 +249,12 @@ refreshButton.addEventListener("click", async () => {
 
 downloadButton.addEventListener("click", async () => {
   await downloadMarkdown();
+});
+
+projectSelect.addEventListener("change", async () => {
+  if (projectSelect.value !== currentProject?.project_id) {
+    await loadReport(readServerToken(), projectSelect.value);
+  }
 });
 
 for (const button of periodButtons) {
@@ -263,81 +286,35 @@ customPeriodForm.addEventListener("submit", async (event) => {
 periodStartInput.addEventListener("change", updatePeriodInputBounds);
 periodEndInput.addEventListener("change", updatePeriodInputBounds);
 
-function applyTheme(theme, persist = true) {
-  document.documentElement.dataset.theme = theme;
-  if (persist) {
-    try {
-      localStorage.setItem(themeKey, theme);
-    } catch (error) {
-      // The selected theme still applies to the current page.
-    }
-  }
-  updateControlLabels();
-}
-
-function applyLocale(locale, persist = true) {
-  currentLocale = locale;
-  document.documentElement.lang = locale;
-  if (persist) {
-    try {
-      localStorage.setItem(localeKey, locale);
-    } catch (error) {
-      // The selected locale still applies to the current page.
-    }
-  }
-  document.title = translate("pageTitle");
-  document.querySelectorAll("[data-i18n]").forEach((element) => {
-    element.textContent = translate(element.dataset.i18n);
-  });
-  updateControlLabels();
-  renderAuthError();
-  if (currentProject !== null) {
-    renderProjects(currentProjects, currentProject.project_id);
-  }
-  if (currentReport !== null) {
-    renderReport(currentReport);
-  } else {
-    renderPeriodControls();
-  }
-}
-
-function updateControlLabels() {
-  const nextTheme = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
-  themeToggle.setAttribute("aria-label", translate(nextTheme === "dark" ? "switchDark" : "switchLight"));
-  themeToggle.setAttribute("title", translate(nextTheme === "dark" ? "switchDark" : "switchLight"));
-  languageToggle.textContent = currentLocale === "en" ? translate("languageChinese") : "EN";
-  languageToggle.setAttribute("aria-label", translate(currentLocale === "en" ? "switchChinese" : "switchEnglish"));
-}
-
 async function authenticate(token) {
   if (!token) {
     showLogin();
     return;
   }
-  setBusy(true);
+  storeServerToken(token);
+  tokenInput.value = "";
+  currentAuthError = null;
+  const request = beginReportRequest();
   try {
     currentProjects = await listProjects(token);
-    storeServerToken(token);
-    tokenInput.value = "";
-    currentAuthError = null;
-    authShell.hidden = true;
-    reportShell.hidden = false;
-    signOut.hidden = false;
+    if (!request.isCurrent()) {
+      return;
+    }
     if (currentProjects.length === 0) {
       currentProject = null;
       currentReport = null;
-      renderProjects([], "");
-      showReportError("noProjects");
-      clearReport();
+      showPageStatus("noProjects", {}, true);
       return;
     }
     const remembered = readSelectedProject();
     const selected = currentProjects.find((project) => project.project_id === remembered) || currentProjects[0];
-    await loadReport(token, selected.project_id);
+    await loadReportData(token, selected.project_id, request);
   } catch (error) {
-    handleRequestError(error);
+    if (request.isCurrent()) {
+      handleRequestError(error);
+    }
   } finally {
-    setBusy(false);
+    request.finish();
   }
 }
 
@@ -361,38 +338,59 @@ async function loadReport(token, projectId) {
     showLogin();
     return;
   }
-  setBusy(true);
+  const request = beginReportRequest();
   clearReportError();
   try {
-    const project = currentProjects.find((item) => item.project_id === projectId) || currentProject;
-    const periodSelection = resolveSelectedPeriod(project);
-    const response = await requestJson("/v1/handoff-reports/get", token, {
-      project_id: projectId,
-      locale: currentLocale === "zh" ? "zh-CN" : "en",
-      include_evidence_checks: false,
-      format: "json",
-      include_archived: false,
-      download: false,
-      period: periodSelection.period
-    });
-    if (response.report === null) {
-      throw new Error("reportUnavailable");
-    }
-    currentProject = currentProjects.find((project) => project.project_id === projectId) || response.report.project;
-    currentReport = response.report;
-    currentPeriodSelection = periodSelection;
-    rememberSelectedProject(projectId);
-    renderProjects(currentProjects, projectId);
-    renderReport(currentReport);
+    await loadReportData(token, projectId, request);
   } catch (error) {
-    if (error.message === "reportUnavailable") {
-      showReportError("reportUnavailable");
-    } else {
+    if (request.isCurrent()) {
+      if (currentProject !== null) {
+        renderProjectOptions(currentProjects, currentProject.project_id);
+      }
       handleRequestError(error);
     }
   } finally {
-    setBusy(false);
+    request.finish();
   }
+}
+
+async function loadReportData(token, projectId, request) {
+  const project = currentProjects.find((item) => item.project_id === projectId) || currentProject;
+  const periodSelection = resolveSelectedPeriod(project);
+  const response = await requestJson("/v1/handoff-reports/get", token, {
+    project_id: projectId,
+    locale: ui.locale() === "zh" ? "zh-CN" : "en",
+    include_evidence_checks: false,
+    format: "json",
+    include_archived: false,
+    download: false,
+    period: periodSelection.period
+  });
+  if (!request.isCurrent()) {
+    return;
+  }
+  if (response.report === null) {
+    throw new Error("reportUnavailable");
+  }
+  currentProject = currentProjects.find((item) => item.project_id === projectId) || response.report.project;
+  currentReport = response.report;
+  currentPeriodSelection = periodSelection;
+  rememberSelectedProject(projectId);
+  renderProjectOptions(currentProjects, projectId);
+  renderReport(currentReport);
+}
+
+function beginReportRequest() {
+  setBusy(true);
+  const request = reportRequests.start();
+  return {
+    finish() {
+      if (request.isCurrent()) {
+        setBusy(false);
+      }
+    },
+    isCurrent: request.isCurrent
+  };
 }
 
 async function requestJson(path, token, payload) {
@@ -420,28 +418,61 @@ function handleRequestError(error) {
     showLogin("authRejected");
     return;
   }
+  const key = error.message === "reportUnavailable" ? "reportUnavailable" : "serverUnavailable";
   if (typeof error.status === "number") {
-    showReportOrLoginError("requestFailed", {status: error.status});
+    showReportFailure("requestFailed", {status: error.status});
     return;
   }
-  showReportOrLoginError("serverUnavailable");
+  showReportFailure(key);
 }
 
-function showReportOrLoginError(key, values = {}) {
-  if (readServerToken()) {
-    showReportError(key, values);
-  } else {
-    showLogin(key, values);
+function showReportFailure(key, values = {}) {
+  if (currentReport === null) {
+    showPageStatus(key, values, true);
+    return;
   }
+  currentPageStatus = null;
+  pageStatus.hidden = true;
+  reportShell.hidden = false;
+  signOut.hidden = false;
+  showReportError(key, values);
 }
 
 function showLogin(messageKey = "", values = {}) {
+  reportRequests.cancel();
+  setBusy(false);
+  currentProjects = [];
+  currentProject = null;
+  currentReport = null;
+  currentPeriodSelection = null;
+  currentPageStatus = null;
   currentAuthError = messageKey ? {key: messageKey, values} : null;
   renderAuthError();
+  clearReport();
   authShell.hidden = false;
+  pageStatus.hidden = true;
   reportShell.hidden = true;
   signOut.hidden = true;
   tokenInput.focus();
+}
+
+function showPageStatus(messageKey, values = {}, retryable = false) {
+  currentPageStatus = {key: messageKey, values, retryable};
+  renderPageStatus();
+  authShell.hidden = true;
+  pageStatus.hidden = false;
+  reportShell.hidden = true;
+  signOut.hidden = false;
+}
+
+function renderPageStatus() {
+  if (currentPageStatus === null) {
+    pageStatusMessage.textContent = "";
+    pageStatusRetry.hidden = true;
+    return;
+  }
+  pageStatusMessage.textContent = translate(currentPageStatus.key, currentPageStatus.values);
+  pageStatusRetry.hidden = !currentPageStatus.retryable;
 }
 
 function renderAuthError() {
@@ -450,32 +481,25 @@ function renderAuthError() {
     : translate(currentAuthError.key, currentAuthError.values);
 }
 
-function renderProjects(projects, selectedProjectId) {
-  projectTabs.replaceChildren();
+function renderProjectOptions(projects, selectedProjectId) {
+  projectSelect.replaceChildren();
   for (const project of projects) {
-    const tab = document.createElement("button");
-    tab.type = "button";
-    tab.className = "project-tab";
-    tab.dataset.projectId = project.project_id;
-    tab.setAttribute("role", "tab");
-    tab.setAttribute("aria-selected", String(project.project_id === selectedProjectId));
-    tab.textContent = translate("projectTab", {title: project.title, projectId: project.project_id});
-    tab.addEventListener("click", async () => {
-      if (project.project_id !== currentProject?.project_id) {
-        await loadReport(readServerToken(), project.project_id);
-      }
-    });
-    projectTabs.appendChild(tab);
+    const option = document.createElement("option");
+    option.value = project.project_id;
+    option.selected = project.project_id === selectedProjectId;
+    option.textContent = translate("projectOption", {title: project.title, projectId: project.project_id});
+    projectSelect.appendChild(option);
   }
 }
 
 function renderReport(report) {
+  currentPageStatus = null;
   authShell.hidden = true;
+  pageStatus.hidden = true;
   reportShell.hidden = false;
   signOut.hidden = false;
   clearReportError();
   setText("project-name", report.project.title);
-  setText("project-identity", `${report.project.project_key} · ${report.project.project_id}`);
   setText("report-updated", translate("updated", {value: formatDateTime(report.generated_at)}));
   setText("continuable-count", formatNumber(report.summary.continuable_count));
   setText("blocked-count", formatNumber(report.summary.blocked_count));
@@ -497,7 +521,6 @@ function renderReport(report) {
 
 function clearReport() {
   setText("project-name", translate("handoffReportTitle"));
-  setText("project-identity", "");
   setText("report-updated", "");
   for (const id of [
     "continuable-count",
@@ -648,10 +671,7 @@ function statusBadge(status) {
 }
 
 function statusLabel(status) {
-  const key = status === "continuable" || status === "blocked" || status === "complete"
-    ? status
-    : status;
-  return translate(key);
+  return translate(status);
 }
 
 async function downloadMarkdown() {
@@ -669,7 +689,7 @@ async function downloadMarkdown() {
       headers: {"Content-Type": "application/json"},
       body: JSON.stringify({
         project_id: currentProject.project_id,
-        locale: currentLocale === "zh" ? "zh-CN" : "en",
+        locale: ui.locale() === "zh" ? "zh-CN" : "en",
         include_evidence_checks: true,
         format: "markdown",
         include_archived: false,
@@ -709,9 +729,7 @@ function setBusy(busy) {
   periodButtons.forEach((button) => {
     button.disabled = busy;
   });
-  projectTabs.querySelectorAll("button").forEach((button) => {
-    button.disabled = busy;
-  });
+  projectSelect.disabled = busy;
 }
 
 function resolveSelectedPeriod(project) {
@@ -748,7 +766,7 @@ function renderPeriodControls(report = null) {
   updatePeriodInputBounds();
   setText("period-summary-label", translate("periodSummary", {
     preset: translate(currentPeriodMode),
-    range: formatDateRange(selection.startDate, selection.endDate, localeTag()),
+    range: formatDateRange(selection.startDate, selection.endDate, ui.localeTag()),
     timezone: selection.period.timezone
   }));
   const comparison = report?.period_comparison;
@@ -808,32 +826,9 @@ function setText(id, value) {
   document.getElementById(id).textContent = value;
 }
 
-function translate(key, values = {}) {
-  const template = translations[currentLocale][key] || translations.en[key] || key;
-  return template.replace(/\{([a-zA-Z]+)\}/g, (match, name) => String(values[name] ?? match));
-}
-
-function localeTag() {
-  return currentLocale === "zh" ? "zh-CN" : "en";
-}
-
-function formatNumber(value) {
-  return new Intl.NumberFormat(localeTag()).format(value);
-}
-
 function formatSignedNumber(value) {
-  return new Intl.NumberFormat(localeTag(), {signDisplay: "always"}).format(value);
+  return new Intl.NumberFormat(ui.localeTag(), {signDisplay: "always"}).format(value);
 }
 
-function formatDateTime(value) {
-  return new Intl.DateTimeFormat(localeTag(), {dateStyle: "medium", timeStyle: "short"}).format(new Date(value));
-}
-
-const initialTheme = document.documentElement.dataset.theme === "dark"
-  ? "dark"
-  : (document.documentElement.dataset.theme === "light"
-    ? "light"
-    : (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"));
-applyLocale(currentLocale, false);
-applyTheme(initialTheme, false);
+ui.initialize();
 authenticate(readServerToken());

--- a/src/powercontext/server/static/page-ui.js
+++ b/src/powercontext/server/static/page-ui.js
@@ -1,0 +1,104 @@
+"use strict";
+
+const themeKey = "powercontext.dashboard.theme";
+const localeKey = "powercontext.dashboard.locale";
+
+export function createRequestGate() {
+  let requestSequence = 0;
+  return {
+    cancel() {
+      requestSequence += 1;
+    },
+    start() {
+      const sequence = ++requestSequence;
+      return {
+        isCurrent() {
+          return sequence === requestSequence;
+        }
+      };
+    }
+  };
+}
+
+export function createPageUi(translations, onLocaleChange = () => {}) {
+  const themeToggle = document.getElementById("theme-toggle");
+  const languageToggle = document.getElementById("language-toggle");
+  let currentLocale = document.documentElement.lang === "zh" ? "zh" : "en";
+
+  function translate(key, values = {}) {
+    const template = translations[currentLocale][key] || translations.en[key] || key;
+    return template.replace(/\{([a-zA-Z]+)\}/g, (match, name) => String(values[name] ?? match));
+  }
+
+  function locale() {
+    return currentLocale;
+  }
+
+  function localeTag() {
+    return currentLocale === "zh" ? "zh-CN" : "en";
+  }
+
+  function formatNumber(value) {
+    return new Intl.NumberFormat(localeTag()).format(value);
+  }
+
+  function formatDateTime(value) {
+    return new Intl.DateTimeFormat(localeTag(), {dateStyle: "medium", timeStyle: "short"}).format(new Date(value));
+  }
+
+  function updateControls() {
+    const nextTheme = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+    themeToggle.setAttribute("aria-label", translate(nextTheme === "dark" ? "switchDark" : "switchLight"));
+    themeToggle.setAttribute("title", translate(nextTheme === "dark" ? "switchDark" : "switchLight"));
+    languageToggle.textContent = currentLocale === "en" ? translate("languageChinese") : "EN";
+    languageToggle.setAttribute("aria-label", translate(currentLocale === "en" ? "switchChinese" : "switchEnglish"));
+  }
+
+  function applyTheme(theme, persist = true) {
+    document.documentElement.dataset.theme = theme;
+    if (persist) {
+      try {
+        localStorage.setItem(themeKey, theme);
+      } catch (error) {
+        // The selected theme still applies to the current page.
+      }
+    }
+    updateControls();
+  }
+
+  function applyLocale(nextLocale, persist = true) {
+    currentLocale = nextLocale;
+    document.documentElement.lang = nextLocale;
+    if (persist) {
+      try {
+        localStorage.setItem(localeKey, nextLocale);
+      } catch (error) {
+        // The selected locale still applies to the current page.
+      }
+    }
+    document.title = translate("pageTitle");
+    document.querySelectorAll("[data-i18n]").forEach((element) => {
+      element.textContent = translate(element.dataset.i18n);
+    });
+    updateControls();
+    onLocaleChange();
+  }
+
+  function initialize() {
+    themeToggle.addEventListener("click", () => {
+      applyTheme(document.documentElement.dataset.theme === "dark" ? "light" : "dark");
+    });
+    languageToggle.addEventListener("click", () => {
+      applyLocale(currentLocale === "en" ? "zh" : "en");
+    });
+    const initialTheme = document.documentElement.dataset.theme === "dark"
+      ? "dark"
+      : (document.documentElement.dataset.theme === "light"
+        ? "light"
+        : (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"));
+    applyLocale(currentLocale, false);
+    applyTheme(initialTheme, false);
+  }
+
+  return {formatDateTime, formatNumber, initialize, locale, localeTag, translate};
+}

--- a/src/powercontext/server/static/site.css
+++ b/src/powercontext/server/static/site.css
@@ -323,18 +323,26 @@ button {
   justify-self: end;
 }
 
-.auth-shell {
+:root[data-server-session="active"] .auth-shell,
+:root[data-server-session="missing"] .server-content {
+  display: none;
+}
+
+.auth-shell,
+.status-shell {
   min-height: calc(100vh - 280px);
   display: grid;
   place-items: center;
 }
 
-.auth-panel {
+.auth-panel,
+.status-panel {
   width: min(460px, 100%);
   padding: 30px 0 34px;
 }
 
 .auth-panel h1,
+.status-panel h1,
 .hero h1 {
   margin: 0;
   color: var(--pc-ink);
@@ -342,11 +350,13 @@ button {
   letter-spacing: -0.02em;
 }
 
-.auth-panel h1 {
+.auth-panel h1,
+.status-panel h1 {
   font-size: 24px;
 }
 
-.auth-panel > p {
+.auth-panel > p,
+.status-panel > p {
   margin: 9px 0 24px;
   color: var(--pc-muted);
 }

--- a/src/powercontext/server/static/site.css
+++ b/src/powercontext/server/static/site.css
@@ -748,11 +748,14 @@ button {
   margin-bottom: 24px;
 }
 
-.project-identity {
-  margin: 6px 0 0;
-  color: var(--pc-muted);
-  font: 12px/1.5 var(--pc-font-code);
-  overflow-wrap: anywhere;
+.report-hero-controls {
+  display: grid;
+  justify-items: end;
+  gap: 10px;
+}
+
+.report-project-picker {
+  min-width: min(360px, 70vw);
 }
 
 .report-actions {
@@ -772,57 +775,6 @@ button {
   background: var(--pc-surface);
   color: var(--pc-ink);
   padding: 0 14px;
-}
-
-.project-tabs-shell {
-  margin-bottom: 30px;
-  border-bottom: 1px solid var(--pc-rule-strong);
-}
-
-.project-tabs-shell > .field-label {
-  margin-bottom: 4px;
-  color: var(--pc-muted);
-  font-size: 12px;
-}
-
-.project-tabs {
-  display: flex;
-  gap: 4px;
-  overflow-x: auto;
-}
-
-.project-tab {
-  position: relative;
-  flex: 0 0 auto;
-  max-width: min(360px, 70vw);
-  border: 0;
-  background: transparent;
-  color: var(--pc-muted);
-  padding: 10px 12px 12px;
-  font-size: 13px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.project-tab:hover {
-  background: var(--pc-nav-hover);
-  color: var(--pc-ink);
-}
-
-.project-tab[aria-selected="true"] {
-  color: var(--pc-accent);
-  font-weight: 650;
-}
-
-.project-tab[aria-selected="true"]::after {
-  position: absolute;
-  right: 10px;
-  bottom: 0;
-  left: 10px;
-  height: 3px;
-  background: var(--pc-accent);
-  content: "";
 }
 
 .report-toolbar {
@@ -1339,6 +1291,16 @@ button {
 
   .report-actions .hero-meta {
     text-align: left;
+  }
+
+  .report-hero-controls {
+    width: 100%;
+    justify-items: start;
+  }
+
+  .report-project-picker {
+    width: 100%;
+    min-width: 0;
   }
 
   .header-tools {

--- a/src/powercontext/server/templates/base.html
+++ b/src/powercontext/server/templates/base.html
@@ -1,10 +1,17 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-server-session="missing">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}PowerContext{% endblock %}</title>
   <script>
+    try {
+      document.documentElement.dataset.serverSession = sessionStorage.getItem("powercontext.server.token")
+        ? "active"
+        : "missing";
+    } catch (error) {
+      document.documentElement.dataset.serverSession = "missing";
+    }
     try {
       const savedTheme = localStorage.getItem("powercontext.dashboard.theme");
       const initialTheme = savedTheme === "light" || savedTheme === "dark"
@@ -19,7 +26,7 @@
       // Theme persistence is optional when browser storage is unavailable.
     }
   </script>
-  <link rel="stylesheet" href="{{ url_for('web_static', path='/site.css') }}">
+  <link rel="stylesheet" href="{{ url_for('web_static', path='/site.css') }}?v=handoff-baseline">
   {% block head %}{% endblock %}
 </head>
 <body>

--- a/src/powercontext/server/templates/components/status.html
+++ b/src/powercontext/server/templates/components/status.html
@@ -1,0 +1,7 @@
+<section class="status-shell" id="page-status" hidden>
+  <div class="status-panel" role="status" aria-live="polite">
+    <h1 data-i18n="{{ status_title_key }}">{{ status_title }}</h1>
+    <p id="page-status-message"></p>
+    <button class="primary-button" id="page-status-retry" type="button" data-i18n="retry" hidden>Retry</button>
+  </div>
+</section>

--- a/src/powercontext/server/templates/pages/dashboard.html
+++ b/src/powercontext/server/templates/pages/dashboard.html
@@ -5,7 +5,11 @@
 {% block content %}
 {% include "components/login.html" %}
 
-<section id="dashboard" hidden>
+{% set status_title_key = "dashboardTitle" %}
+{% set status_title = "Dashboard" %}
+{% include "components/status.html" %}
+
+<section class="server-content" id="dashboard">
   <div class="hero">
     <div>
       <p class="page-kind" data-i18n="dashboardTitle">Dashboard</p>
@@ -74,5 +78,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script type="module" src="{{ url_for('web_static', path='/dashboard.js') }}"></script>
+<script type="module" src="{{ url_for('web_static', path='/dashboard.js') }}?v=state-races"></script>
 {% endblock %}

--- a/src/powercontext/server/templates/pages/handoff_report.html
+++ b/src/powercontext/server/templates/pages/handoff_report.html
@@ -5,23 +5,27 @@
 {% block content %}
 {% include "components/login.html" %}
 
-<section id="handoff-report" hidden>
+{% set status_title_key = "handoffReportTitle" %}
+{% set status_title = "Handoff Report" %}
+{% include "components/status.html" %}
+
+<section class="server-content" id="handoff-report">
   <div class="hero report-hero">
     <div>
       <p class="page-kind" data-i18n="handoffReportTitle">Handoff Report</p>
       <h1 id="project-name"></h1>
-      <p class="project-identity" id="project-identity"></p>
     </div>
-    <div class="report-actions">
-      <button class="secondary-button page-button" id="refresh-report" type="button" data-i18n="refresh">Refresh</button>
-      <button class="primary-button" id="download-report" type="button" data-i18n="downloadMarkdown">Download Markdown</button>
-      <div class="hero-meta"><span id="report-updated"></span></div>
+    <div class="report-hero-controls">
+      <div class="scope-picker report-project-picker">
+        <label for="project-select" data-i18n="projects">Projects</label>
+        <select id="project-select"></select>
+      </div>
+      <div class="report-actions">
+        <button class="secondary-button page-button" id="refresh-report" type="button" data-i18n="refresh">Refresh</button>
+        <button class="primary-button" id="download-report" type="button" data-i18n="downloadMarkdown">Download Markdown</button>
+        <div class="hero-meta"><span id="report-updated"></span></div>
+      </div>
     </div>
-  </div>
-
-  <div class="project-tabs-shell" aria-labelledby="project-tabs-label">
-    <div class="field-label" id="project-tabs-label" data-i18n="projects">Projects</div>
-    <div class="project-tabs" id="project-tabs" role="tablist"></div>
   </div>
 
   <section class="report-toolbar" aria-labelledby="period-filter-label">
@@ -141,5 +145,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script type="module" src="{{ url_for('web_static', path='/handoff-report.js') }}"></script>
+<script type="module" src="{{ url_for('web_static', path='/handoff-report.js') }}?v=state-races"></script>
 {% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -59,6 +59,13 @@ def test_dashboard_is_the_authenticated_server_ui_entry(tmp_path) -> None:
     assert removed_dashboard_alias.status_code == 404
     assert missing_scopes.status_code == 401
     assert scopes.status_code == 200
+    assert 'data-server-session="missing"' in home.text
+    assert 'id="auth-shell"' in home.text
+    assert 'id="auth-shell" hidden' not in home.text
+    assert 'id="page-status" hidden' in home.text
+    assert 'class="server-content" id="dashboard"' in home.text
+    assert 'id="dashboard" hidden' not in home.text
+    assert "dashboard.js?v=state-races" in home.text
     assert scopes.json() == [
         {"scope_id": "person:psiace", "display_name": "PsiACE"},
         {"scope_id": "project:powercontext", "display_name": "PowerContext"},

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -88,11 +88,22 @@ def test_handoff_report_page_is_available_only_when_both_features_are_enabled(tm
 
     assert disabled_page.status_code == 404
     assert enabled_page.status_code == 200
+    assert 'data-server-session="missing"' in enabled_page.text
+    assert 'id="auth-shell"' in enabled_page.text
+    assert 'id="auth-shell" hidden' not in enabled_page.text
+    assert 'id="page-status" hidden' in enabled_page.text
+    assert 'class="server-content" id="handoff-report"' in enabled_page.text
+    assert 'id="handoff-report" hidden' not in enabled_page.text
     assert 'data-period-mode="day"' in enabled_page.text
     assert 'data-period-mode="week"' in enabled_page.text
     assert 'data-period-mode="month"' in enabled_page.text
     assert 'id="period-start" type="date"' in enabled_page.text
     assert 'id="period-end" type="date"' in enabled_page.text
+    assert 'id="project-select"' in enabled_page.text
+    assert 'id="project-tabs"' not in enabled_page.text
+    assert '<section class="report-overview"' in enabled_page.text
+    assert '<dl class="report-overview"' not in enabled_page.text
+    assert "handoff-report.js?v=state-races" in enabled_page.text
     assert protected_projects.status_code == 401
 
 


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A

# Rationale for this change

Dashboard and Handoff could briefly show empty or stale states during authentication and navigation.

# What changes are included in this PR?

- Share page UI state and request gating.
- Prevent stale Dashboard requests from restoring signed-out views.
- Add a Handoff Project selector and restore the previous selection when loading fails.
- Preserve the existing Handoff Report layout and Dashboard scope-ID behavior.

# Are there any user-facing changes?

Navigation no longer flashes login/loading content. Handoff Projects use a selector. No API, schema, or migration changes.

# How was this change tested?

- `make check`
- `make test` — 433 passed, 7 skipped
- JavaScript ES module syntax checks
- Delayed sign-out and failed Project-switch reproductions

# AI usage statement

Implemented and reviewed with OpenAI Codex.