### PR TITLE
improve(doctor): split integration checks and improve runtime readiness

### DIFF
--- a/.github/workflows/e2e-harness.yml
+++ b/.github/workflows/e2e-harness.yml
@@ -61,6 +61,10 @@ jobs:
           EVIDENCE_PATH: ${{ github.workspace }}/.powercontext-e2e/${{ matrix.database }}/acceptance
         run: |
           test -d "${EVIDENCE_PATH}"
+          if ! find "${EVIDENCE_PATH}" -type f -print -quit | grep -q .; then
+            echo "No replay evidence was produced." >&2
+            exit 1
+          fi
           docker run --rm \
             --volume "${EVIDENCE_PATH}:/evidence:ro" \
             "${TRUFFLEHOG_IMAGE}" \
@@ -74,7 +78,7 @@ jobs:
 
       - name: Report suppressed replay evidence
         if: always() && steps.evidence_scan.outcome != 'success'
-        run: echo "::warning::Replay evidence was not published because secret scanning did not complete cleanly."
+        run: echo "::warning::Replay evidence was missing or secret scanning did not complete cleanly."
 
       - name: Upload replay evidence
         if: always() && steps.evidence_scan.outcome == 'success'

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ You do not need to create or manage a repository checkout. Start the local servi
 powercontext server run
 ```
 
-In another terminal, verify the package, plugin, Server, and database:
+In another terminal, verify the package and Server dependencies, then the optional Codex integration:
 
 ```bash
 powercontext doctor
+powercontext doctor codex
 ```
 
 Start a new Codex session after installation. Open `/hooks` once and approve the PowerContext hook if Codex asks for

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ powercontext doctor
 powercontext doctor codex
 ```
 
+Runtime or database failures make the Server not ready. A configured inference failure is reported as degraded
+without removing the Server from traffic; the separate Codex command does not affect Server health.
+
 Start a new Codex session after installation. Open `/hooks` once and approve the PowerContext hook if Codex asks for
 trust. The default database is persistent and requires no configuration.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,9 @@ docker run --rm \
 ```
 
 The image listens on `0.0.0.0:8000`, stores its default data under `/data`, and exposes a Docker health check backed
-by `GET /health/ready`. Configure another database or inference provider with the same
+by `GET /health/ready`. Readiness verifies the database and each configured inference provider. Provider checks make
+one minimal real request at startup and refresh at most once every 300 seconds; they use the same credentials as the
+Runtime and never expose them in the response. Configure another database or inference provider with the same
 `POWERCONTEXT_SERVER_*` environment variables used by a regular Server installation.
 
 The `Build Docker image` GitHub workflow builds downloadable Linux amd64 and arm64 image archives for pull requests,

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,10 +17,13 @@ docker run --rm \
 ```
 
 The image listens on `0.0.0.0:8000`, stores its default data under `/data`, and exposes a Docker health check backed
-by `GET /health/ready`. Readiness verifies the database and each configured inference provider. Provider checks make
-one minimal real request at startup and refresh at most once every 300 seconds; they use the same credentials as the
-Runtime and never expose them in the response. Configure another database or inference provider with the same
-`POWERCONTEXT_SERVER_*` environment variables used by a regular Server installation.
+by `GET /health/ready`. Runtime or database failures return `not_ready` with HTTP 503. A configured inference failure
+returns `degraded` with HTTP 200, so database-backed operations remain in traffic while the response exposes the
+affected capability. Provider checks make one minimal real request at startup. `ready` and `misconfigured` results
+are cached for 300 seconds; `timeout` and `unavailable` results are retried after 30 seconds, and concurrent health
+requests share one refresh. Checks use the Runtime's credentials and never expose them in the response. Configure
+another database or inference provider with the same `POWERCONTEXT_SERVER_*` environment variables used by a regular
+Server installation.
 
 The `Build Docker image` GitHub workflow builds downloadable Linux amd64 and arm64 image archives for pull requests,
 changes merged to `main`, and manual runs. Publishing a GitHub Release pushes a multi-platform image to Docker Hub.

--- a/docs/en/docs/how-to/install-and-run.md
+++ b/docs/en/docs/how-to/install-and-run.md
@@ -48,8 +48,10 @@ powercontext capabilities
 ```
 
 `doctor` checks the installed package, Server liveness, and Server readiness without requiring Codex. Server
-readiness covers the database and each configured inference provider. `doctor codex` separately checks the optional
-Codex CLI and PowerContext plugin. The content commands exercise the public HTTP SDK path.
+readiness covers the database and each configured inference provider. Runtime or database failures return
+`not_ready`; an inference failure returns `degraded` without removing database-backed operations from traffic.
+`doctor codex` separately checks the optional Codex CLI and PowerContext plugin. The content commands exercise the
+public HTTP SDK path.
 
 ## Update or replace an installation
 

--- a/docs/en/docs/how-to/install-and-run.md
+++ b/docs/en/docs/how-to/install-and-run.md
@@ -42,12 +42,14 @@ With no environment variables, the Server:
 
 ```bash
 powercontext doctor
+powercontext doctor codex
 powercontext ready
 powercontext capabilities
 ```
 
-`doctor` checks the installed package, Codex plugin, and Server readiness. The content commands exercise the public
-HTTP SDK path.
+`doctor` checks the installed package, Server liveness, and Server readiness without requiring Codex. Server
+readiness covers the database and each configured inference provider. `doctor codex` separately checks the optional
+Codex CLI and PowerContext plugin. The content commands exercise the public HTTP SDK path.
 
 ## Update or replace an installation
 

--- a/docs/en/docs/how-to/troubleshoot.md
+++ b/docs/en/docs/how-to/troubleshoot.md
@@ -11,8 +11,9 @@ Start with:
 powercontext doctor
 ```
 
-The command checks the package, Server liveness, and Server readiness. It exits with status 1 if any check fails. Add
-`--json` for automation. Check the optional Codex integration separately:
+The command checks the package, Server liveness, and Server readiness. It exits with status 1 unless every check is
+`ok`; a `degraded` readiness result is usable but is not a complete diagnostic success. Add `--json` for automation;
+the top-level result and every check include `ok` and `status`. Check the optional Codex integration separately:
 
 ```bash
 powercontext doctor codex
@@ -76,9 +77,9 @@ powercontext --server-url http://127.0.0.1:9000 ready
 ```
 
 The bundled Codex plugin uses port 8000 by default. A liveness failure means the process cannot answer health
-requests, so readiness is not checked. A readiness failure means the process is alive but at least one Runtime
-dependency is unavailable, timed out, or misconfigured. Human and JSON output retain the Server's individual check
-statuses.
+requests, so readiness is not checked. `not_ready` with HTTP 503 means the Runtime or database cannot accept work.
+`degraded` with HTTP 200 means a configured inference capability failed while database-backed operations remain
+available. Human and JSON output retain the Server's individual check statuses.
 
 ## The Server cannot open its database
 
@@ -102,8 +103,10 @@ credentials and endpoints that can be validated only by sending a request, inclu
 provider's API prefix. Stable statuses are `ready`, `unavailable`, `timeout`, and `misconfigured`; responses never
 include credentials, provider response bodies, or configured URLs.
 
-Provider results, including failures, are cached for 300 seconds and concurrent health requests share one refresh.
-Restart the Server to check a corrected configuration immediately, or wait for the cached result to expire.
+An inference failure makes overall readiness `degraded` with HTTP 200 instead of removing the whole Server from
+traffic. `ready` and `misconfigured` results are cached for 300 seconds; temporary `timeout` and `unavailable` results
+are retried after 30 seconds. Concurrent health requests share one refresh. Restart the Server to apply corrected
+static configuration immediately, or wait for the cached result to expire.
 
 ## Memory writes work but captured prompts do not become Memory
 

--- a/docs/en/docs/how-to/troubleshoot.md
+++ b/docs/en/docs/how-to/troubleshoot.md
@@ -11,7 +11,12 @@ Start with:
 powercontext doctor
 ```
 
-The command exits with status 1 if any check fails. Add `--json` for automation.
+The command checks the package, Server liveness, and Server readiness. It exits with status 1 if any check fails. Add
+`--json` for automation. Check the optional Codex integration separately:
+
+```bash
+powercontext doctor codex
+```
 
 ## Installation cannot read the Git URL
 
@@ -39,6 +44,12 @@ plugin when Codex CLI is unavailable.
 
 ## The plugin is missing or stale
 
+Confirm the integration failure without involving the Server:
+
+```bash
+powercontext doctor codex
+```
+
 Reinstall it from the same ref as the tool:
 
 ```bash
@@ -64,7 +75,10 @@ powercontext doctor --server-url http://127.0.0.1:9000
 powercontext --server-url http://127.0.0.1:9000 ready
 ```
 
-The bundled Codex plugin uses port 8000 by default.
+The bundled Codex plugin uses port 8000 by default. A liveness failure means the process cannot answer health
+requests, so readiness is not checked. A readiness failure means the process is alive but at least one Runtime
+dependency is unavailable, timed out, or misconfigured. Human and JSON output retain the Server's individual check
+statuses.
 
 ## The Server cannot open its database
 
@@ -80,6 +94,16 @@ powercontext server run
 
 Use the same environment variable whenever you start or diagnose that instance. PowerContext creates missing parent
 directories for a file-backed SQLite database.
+
+## An inference readiness check fails
+
+When generation or embedding is configured, Server readiness makes one minimal real provider request. This catches
+credentials and endpoints that can be validated only by sending a request, including a base URL that is missing the
+provider's API prefix. Stable statuses are `ready`, `unavailable`, `timeout`, and `misconfigured`; responses never
+include credentials, provider response bodies, or configured URLs.
+
+Provider results, including failures, are cached for 300 seconds and concurrent health requests share one refresh.
+Restart the Server to check a corrected configuration immediately, or wait for the cached result to expire.
 
 ## Memory writes work but captured prompts do not become Memory
 

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -27,6 +27,7 @@ starts or embeds the Server.
 ```text
 powercontext setup codex
 powercontext doctor
+powercontext doctor codex
 powercontext server run
 powercontext ready
 powercontext capabilities
@@ -54,6 +55,9 @@ powercontext external-skill import --scope-id project:example --fingerprint SHA2
 
 All content commands call the configured Server. The optional `server` role adds `powercontext server run`; it does
 not create a second content profile inside the CLI.
+
+`powercontext doctor` checks the package and Server without requiring an integration. `powercontext doctor codex`
+checks the Codex CLI and PowerContext plugin explicitly.
 
 Generation and revision commands accept repeatable `--source-ref TYPE/ID` and
 `--artifact-ref FAMILY/ID@REVISION` options instead of serialized request files. `--target FAMILY/ID@REVISION`

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -189,6 +189,9 @@ The Server publishes its OpenAPI document at `/openapi.json`, readiness at `/hea
 `/v1/capabilities`, and Streamable HTTP MCP at `/mcp` by default. HTTP is the complete application contract. MCP is a
 curated agent-facing projection of Memory and Candidate Review operations. The five Candidate Review operations use the
 same validation, `expected_version` concurrency checks, and approval transaction over HTTP and MCP.
+Readiness is `ready` with HTTP 200 when all checks pass, `degraded` with HTTP 200 when only configured inference checks
+fail, and `not_ready` with HTTP 503 when the Runtime or database fails. Individual checks use `ready`, `unavailable`,
+`timeout`, or `misconfigured`.
 Experience and Skill generation, exact reads, external Registry operations, and low-level proposal operations remain
 HTTP-only.
 `POST /v1/context/prepare` and the matching Python Client method expose final ephemeral `PreparedContext` over HTTP;

--- a/docs/en/docs/reference/interfaces.md
+++ b/docs/en/docs/reference/interfaces.md
@@ -190,8 +190,8 @@ The Server publishes its OpenAPI document at `/openapi.json`, readiness at `/hea
 curated agent-facing projection of Memory and Candidate Review operations. The five Candidate Review operations use the
 same validation, `expected_version` concurrency checks, and approval transaction over HTTP and MCP.
 Readiness is `ready` with HTTP 200 when all checks pass, `degraded` with HTTP 200 when only configured inference checks
-fail, and `not_ready` with HTTP 503 when the Runtime or database fails. Individual checks use `ready`, `unavailable`,
-`timeout`, or `misconfigured`.
+fail, and `not_ready` with HTTP 503 when the Runtime or database fails. Dependency checks use `ready`, `unavailable`,
+`timeout`, or `misconfigured`; an intentionally unbound Runtime reports `not_ready` for the `runtime` check.
 Experience and Skill generation, exact reads, external Registry operations, and low-level proposal operations remain
 HTTP-only.
 `POST /v1/context/prepare` and the matching Python Client method expose final ephemeral `PreparedContext` over HTTP;

--- a/docs/en/docs/tutorials/codex-quickstart.md
+++ b/docs/en/docs/tutorials/codex-quickstart.md
@@ -79,3 +79,5 @@ active list.
 Stop the Server with `Ctrl-C`, then give Codex an ordinary task. PowerContext may report that Memory is unavailable,
 but it must not block the task. `powercontext doctor` now exits with a liveness failure, skips readiness, and still
 reports the installed package. `powercontext doctor codex` continues to report the Codex integration independently.
+If only a configured inference provider fails, the Server remains in traffic and reports readiness as `degraded`;
+`doctor` surfaces that non-OK status without reading provider credentials.

--- a/docs/en/docs/tutorials/codex-quickstart.md
+++ b/docs/en/docs/tutorials/codex-quickstart.md
@@ -39,9 +39,11 @@ Check the whole installation from another terminal:
 
 ```bash
 powercontext doctor
+powercontext doctor codex
 ```
 
-Every line should report `ok`.
+Every line from both commands should report `ok`. The first command checks the package and Server dependencies; the
+second checks the optional Codex integration.
 
 ## 3. Save a handoff
 
@@ -75,5 +77,5 @@ active list.
 ## 5. Check graceful degradation
 
 Stop the Server with `Ctrl-C`, then give Codex an ordinary task. PowerContext may report that Memory is unavailable,
-but it must not block the task. `powercontext doctor` now exits with a failure for the Server check while continuing to
-report the installed package, plugin, and database.
+but it must not block the task. `powercontext doctor` now exits with a liveness failure, skips readiness, and still
+reports the installed package. `powercontext doctor codex` continues to report the Codex integration independently.

--- a/docs/zh/docs/how-to/install-and-run.md
+++ b/docs/zh/docs/how-to/install-and-run.md
@@ -41,11 +41,14 @@ powercontext server run
 
 ```bash
 powercontext doctor
+powercontext doctor codex
 powercontext ready
 powercontext capabilities
 ```
 
-`doctor` 检查已安装的包、Codex 插件和 Server 就绪状态。内容命令会经过公开 HTTP SDK 路径。
+`doctor` 检查已安装的包、Server 存活状态和 Server 就绪状态，不要求安装 Codex。Server 就绪检查涵盖数据库和
+每个已配置的推理服务；`doctor codex` 单独检查可选的 Codex CLI 与 PowerContext 插件。内容命令会经过公开
+HTTP SDK 路径。
 
 ## 更新或替换安装
 

--- a/docs/zh/docs/how-to/install-and-run.md
+++ b/docs/zh/docs/how-to/install-and-run.md
@@ -47,8 +47,9 @@ powercontext capabilities
 ```
 
 `doctor` 检查已安装的包、Server 存活状态和 Server 就绪状态，不要求安装 Codex。Server 就绪检查涵盖数据库和
-每个已配置的推理服务；`doctor codex` 单独检查可选的 Codex CLI 与 PowerContext 插件。内容命令会经过公开
-HTTP SDK 路径。
+每个已配置的推理服务。Runtime 或数据库故障返回 `not_ready`；推理服务故障返回 `degraded`，不会使数据库
+操作退出流量。`doctor codex` 单独检查可选的 Codex CLI 与 PowerContext 插件。内容命令会经过公开 HTTP SDK
+路径。
 
 ## 更新或替换安装
 

--- a/docs/zh/docs/how-to/troubleshoot.md
+++ b/docs/zh/docs/how-to/troubleshoot.md
@@ -11,7 +11,12 @@ description: 诊断 PowerContext 安装、Server、数据库和 Codex 插件问�
 powercontext doctor
 ```
 
-任一检查失败时，命令会以状态码 1 退出。自动化场景可添加 `--json`。
+该命令检查安装包、Server liveness 和 Server readiness；任一检查失败时会以状态码 1 退出。自动化场景可添加
+`--json`。可单独检查可选的 Codex 集成：
+
+```bash
+powercontext doctor codex
+```
 
 ## 安装时无法读取 Git 地址
 
@@ -39,6 +44,12 @@ command -v codex
 
 ## 插件缺失或版本不一致
 
+先在不涉及 Server 的情况下确认集成故障：
+
+```bash
+powercontext doctor codex
+```
+
 使用与工具一致的 ref 重新安装：
 
 ```bash
@@ -63,7 +74,9 @@ powercontext doctor --server-url http://127.0.0.1:9000
 powercontext --server-url http://127.0.0.1:9000 ready
 ```
 
-随附的 Codex 插件默认使用 8000 端口。
+随附的 Codex 插件默认使用 8000 端口。liveness 失败表示进程无法响应健康请求，此时不会继续检查
+readiness；readiness 失败表示进程仍存活，但至少一个 Runtime 依赖不可用、超时或配置错误。Human 与 JSON
+输出都会保留 Server 返回的各项检查状态。
 
 ## Server 无法打开数据库
 
@@ -79,6 +92,15 @@ powercontext server run
 
 每次启动或诊断该实例时都应使用同一个环境变量。对于文件型 SQLite 数据库，PowerContext 会创建缺失的父
 目录。
+
+## 推理服务 readiness 检查失败
+
+配置 generation 或 embedding 后，Server readiness 会向 provider 发起一次最小化真实请求。这样可以发现只有
+实际请求时才能确认的凭据或 endpoint 问题，包括 base URL 遗漏 provider API 前缀。稳定状态包括 `ready`、
+`unavailable`、`timeout` 和 `misconfigured`；响应不会包含凭据、provider 响应正文或已配置 URL。
+
+Provider 的成功和失败结果都会缓存 300 秒，并发健康请求共用同一次刷新。修改配置后如需立即检查，请重启
+Server；否则等待缓存过期。
 
 ## Memory 可以显式写入，但采集的提示词没有生成 Memory
 

--- a/docs/zh/docs/how-to/troubleshoot.md
+++ b/docs/zh/docs/how-to/troubleshoot.md
@@ -11,8 +11,9 @@ description: 诊断 PowerContext 安装、Server、数据库和 Codex 插件问�
 powercontext doctor
 ```
 
-该命令检查安装包、Server liveness 和 Server readiness；任一检查失败时会以状态码 1 退出。自动化场景可添加
-`--json`。可单独检查可选的 Codex 集成：
+该命令检查安装包、Server liveness 和 Server readiness；只有所有检查均为 `ok` 时才以状态码 0 退出。
+`degraded` 表示仍可使用，但不算完整诊断成功。自动化场景可添加 `--json`，顶层结果和每个检查都会包含
+`ok` 与 `status`。可单独检查可选的 Codex 集成：
 
 ```bash
 powercontext doctor codex
@@ -75,8 +76,8 @@ powercontext --server-url http://127.0.0.1:9000 ready
 ```
 
 随附的 Codex 插件默认使用 8000 端口。liveness 失败表示进程无法响应健康请求，此时不会继续检查
-readiness；readiness 失败表示进程仍存活，但至少一个 Runtime 依赖不可用、超时或配置错误。Human 与 JSON
-输出都会保留 Server 返回的各项检查状态。
+readiness。HTTP 503 的 `not_ready` 表示 Runtime 或数据库无法接受工作；HTTP 200 的 `degraded` 表示已配置的
+推理能力异常，但数据库操作仍然可用。Human 与 JSON 输出都会保留 Server 返回的各项检查状态。
 
 ## Server 无法打开数据库
 
@@ -99,8 +100,9 @@ powercontext server run
 实际请求时才能确认的凭据或 endpoint 问题，包括 base URL 遗漏 provider API 前缀。稳定状态包括 `ready`、
 `unavailable`、`timeout` 和 `misconfigured`；响应不会包含凭据、provider 响应正文或已配置 URL。
 
-Provider 的成功和失败结果都会缓存 300 秒，并发健康请求共用同一次刷新。修改配置后如需立即检查，请重启
-Server；否则等待缓存过期。
+推理检查失败时，overall readiness 为 HTTP 200 的 `degraded`，不会使整个 Server 退出流量。`ready` 和
+`misconfigured` 会缓存 300 秒；临时的 `timeout` 和 `unavailable` 会在 30 秒后重试。并发健康请求共用同一次
+刷新。修改静态配置后如需立即检查，请重启 Server；否则等待缓存过期。
 
 ## Memory 可以显式写入，但采集的提示词没有生成 Memory
 

--- a/docs/zh/docs/reference/interfaces.md
+++ b/docs/zh/docs/reference/interfaces.md
@@ -183,6 +183,9 @@ Server 在 `/openapi.json` 提供 OpenAPI 文档，在 `/health/ready` 提供就
 Memory 与 Candidate Review operation 子集。五个 Candidate Review operation 通过 HTTP 和 MCP 使用相同的
 validation、`expected_version` 并发校验和 approval transaction。Experience/Skill generation、exact read、
 external Registry operation 和低阶 proposal operation 仍只通过 HTTP 提供。
+所有检查通过时 readiness 为 HTTP 200 的 `ready`；只有已配置的推理检查失败时为 HTTP 200 的 `degraded`；
+Runtime 或数据库失败时为 HTTP 503 的 `not_ready`。单项检查使用 `ready`、`unavailable`、`timeout` 或
+`misconfigured`。
 `POST /v1/context/prepare` 及对应的 Python Client method 通过 HTTP 提供最终的临时 `PreparedContext`；
 Runtime 召回 active Memory 与 approved Experience head，统一负责选择和总输出预算；该 operation 不会投影为
 MCP tool。public schema 仍是 `powercontext.prepared-context.v1`，Experience item 在 prepared content 内携带精确

--- a/docs/zh/docs/reference/interfaces.md
+++ b/docs/zh/docs/reference/interfaces.md
@@ -26,6 +26,7 @@ project-context skill 指导 Codex 何时检索、记忆、修订或停用 Memor
 ```text
 powercontext setup codex
 powercontext doctor
+powercontext doctor codex
 powercontext server run
 powercontext ready
 powercontext capabilities
@@ -53,6 +54,9 @@ powercontext external-skill import --scope-id project:example --fingerprint SHA2
 
 所有内容命令都调用已配置的 Server。可选的 `server` role 会增加 `powercontext server run`，但不会在 CLI
 中创建第二套内容 profile。
+
+`powercontext doctor` 检查安装包和 Server，不要求任何集成；`powercontext doctor codex` 显式检查 Codex CLI
+和 PowerContext 插件。
 
 Generation 和 revision 命令通过可重复的 `--source-ref TYPE/ID` 与
 `--artifact-ref FAMILY/ID@REVISION` 接收精确引用，不再读取序列化请求文件。

--- a/docs/zh/docs/reference/interfaces.md
+++ b/docs/zh/docs/reference/interfaces.md
@@ -184,8 +184,8 @@ Memory 与 Candidate Review operation 子集。五个 Candidate Review operation
 validation、`expected_version` 并发校验和 approval transaction。Experience/Skill generation、exact read、
 external Registry operation 和低阶 proposal operation 仍只通过 HTTP 提供。
 所有检查通过时 readiness 为 HTTP 200 的 `ready`；只有已配置的推理检查失败时为 HTTP 200 的 `degraded`；
-Runtime 或数据库失败时为 HTTP 503 的 `not_ready`。单项检查使用 `ready`、`unavailable`、`timeout` 或
-`misconfigured`。
+Runtime 或数据库失败时为 HTTP 503 的 `not_ready`。依赖检查使用 `ready`、`unavailable`、`timeout` 或
+`misconfigured`；有意不绑定 Runtime 时，`runtime` 检查使用 `not_ready`。
 `POST /v1/context/prepare` 及对应的 Python Client method 通过 HTTP 提供最终的临时 `PreparedContext`；
 Runtime 召回 active Memory 与 approved Experience head，统一负责选择和总输出预算；该 operation 不会投影为
 MCP tool。public schema 仍是 `powercontext.prepared-context.v1`，Experience item 在 prepared content 内携带精确

--- a/docs/zh/docs/tutorials/codex-quickstart.md
+++ b/docs/zh/docs/tutorials/codex-quickstart.md
@@ -72,3 +72,5 @@ Codex 应使用 project-context skill，并在 Memory 写入成功后确认。�
 按 `Ctrl-C` 停止 Server，再让 Codex 执行一项普通任务。PowerContext 可以报告 Memory 不可用，但不能阻塞
 任务。此时 `powercontext doctor` 会报告 liveness 失败、跳过 readiness，同时仍能报告已安装的包；
 `powercontext doctor codex` 会继续独立报告 Codex 集成状态。
+如果只有已配置的推理服务失败，Server 会继续接收流量并把 readiness 报告为 `degraded`；`doctor` 会在不读取
+provider 凭据的前提下显示该非 `ok` 状态。

--- a/docs/zh/docs/tutorials/codex-quickstart.md
+++ b/docs/zh/docs/tutorials/codex-quickstart.md
@@ -37,9 +37,10 @@ powercontext server run
 
 ```bash
 powercontext doctor
+powercontext doctor codex
 ```
 
-每项都应显示 `ok`。
+两个命令的每项检查都应显示 `ok`。第一个命令检查安装包和 Server 依赖，第二个命令检查可选的 Codex 集成。
 
 ## 3. 保存交接信息
 
@@ -69,5 +70,5 @@ Codex 应使用 project-context skill，并在 Memory 写入成功后确认。�
 ## 5. 检查降级行为
 
 按 `Ctrl-C` 停止 Server，再让 Codex 执行一项普通任务。PowerContext 可以报告 Memory 不可用，但不能阻塞
-任务。此时 `powercontext doctor` 会因 Server 检查失败而返回非零状态，同时仍能报告已安装的包、插件和
-数据库。
+任务。此时 `powercontext doctor` 会报告 liveness 失败、跳过 readiness，同时仍能报告已安装的包；
+`powercontext doctor codex` 会继续独立报告 Codex 集成状态。

--- a/e2e/bub/compose.oceanbase.yaml
+++ b/e2e/bub/compose.oceanbase.yaml
@@ -2,10 +2,8 @@ services:
   oceanbase:
     image: ${POWERCONTEXT_E2E_OCEANBASE_IMAGE:-ghcr.io/oceanbase/oceanbase-ce:4.3.5.6-106000012026040916}
     environment:
-      MODE: MINI
+      MODE: slim
       OB_DATABASE: powercontext
-      OB_DATAFILE_SIZE: 2G
-      OB_LOG_DISK_SIZE: 4G
       OB_TENANT_PASSWORD: powercontext-e2e
     healthcheck:
       test:

--- a/e2e/bub/run.sh
+++ b/e2e/bub/run.sh
@@ -68,6 +68,43 @@ if [ -z "${GITHUB_SHA:-}" ]; then
     export GITHUB_SHA
 fi
 
+show_startup_diagnostics() {
+    echo "Compose startup failed; service state:" >&2
+    docker compose $compose_files ps --all >&2 || true
+    echo "Compose service logs (last 200 lines):" >&2
+    docker compose $compose_files logs --no-color --timestamps --tail 200 >&2 || true
+}
+
+start_services() {
+    attempt=1
+    max_attempts=1
+    if [ "$database" = oceanbase ]; then
+        max_attempts=2
+    fi
+
+    while :; do
+        if docker compose $compose_files up --detach --wait powercontext; then
+            return
+        else
+            status=$?
+        fi
+
+        show_startup_diagnostics
+        if [ "$attempt" -ge "$max_attempts" ]; then
+            return "$status"
+        fi
+
+        attempt=$((attempt + 1))
+        echo "Retrying OceanBase Compose startup (attempt $attempt of $max_attempts)." >&2
+        if docker compose $compose_files down --volumes --remove-orphans; then
+            continue
+        fi
+
+        echo "Compose reset failed; startup will not be retried." >&2
+        return "$status"
+    done
+}
+
 cleanup() {
     status=$?
     trap - EXIT INT TERM
@@ -89,7 +126,7 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 docker compose $compose_files build powercontext harness
-docker compose $compose_files up --detach --wait powercontext
+start_services
 
 if [ "$mode" = acceptance ]; then
     docker compose $compose_files run --rm harness \

--- a/e2e/bub/tests/test_run_script.py
+++ b/e2e/bub/tests/test_run_script.py
@@ -70,12 +70,57 @@ def test_cleanup_failure_makes_a_successful_run_fail(tmp_path: Path) -> None:
     assert "Compose cleanup failed with exit code 71" in result.stderr
 
 
+def test_startup_failure_reports_compose_diagnostics(tmp_path: Path) -> None:
+    result, _ = _run_with_fake_docker(
+        tmp_path,
+        failed_command="up",
+        exit_code=32,
+    )
+
+    assert result.returncode == 32
+    assert "Compose startup failed; service state:" in result.stderr
+    assert "fake compose state" in result.stderr
+    assert "fake compose logs" in result.stderr
+
+
+def test_oceanbase_startup_retries_once(tmp_path: Path) -> None:
+    result, state = _run_with_fake_docker(
+        tmp_path,
+        failed_command="up",
+        exit_code=32,
+        database="oceanbase",
+        startup_failures=1,
+    )
+
+    assert result.returncode == 0
+    assert list(state.iterdir()) == []
+    assert result.stderr.count("Compose startup failed; service state:") == 1
+    assert "Retrying OceanBase Compose startup (attempt 2 of 2)." in result.stderr
+
+
+def test_persistent_oceanbase_startup_failure_preserves_exit_code(tmp_path: Path) -> None:
+    result, state = _run_with_fake_docker(
+        tmp_path,
+        failed_command="up",
+        exit_code=32,
+        database="oceanbase",
+        startup_failures=2,
+    )
+
+    assert result.returncode == 32
+    assert list(state.iterdir()) == []
+    assert result.stderr.count("Compose startup failed; service state:") == 2
+    assert result.stderr.count("Retrying OceanBase Compose startup") == 1
+
+
 def _run_with_fake_docker(
     tmp_path: Path,
     *,
     failed_command: str,
     exit_code: int,
     cleanup_exit_code: int = 0,
+    database: str = "sqlite",
+    startup_failures: int = 1000,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -89,7 +134,7 @@ set -eu
 command=
 for argument in "$@"; do
     case "$argument" in
-        build | config | down | run | up)
+        build | config | down | logs | ps | run | up)
             command=$argument
             break
             ;;
@@ -97,11 +142,29 @@ for argument in "$@"; do
 done
 
 case "$command" in
-    build | run | up)
+    build | run)
         touch "$FAKE_DOCKER_STATE/container" "$FAKE_DOCKER_STATE/network" "$FAKE_DOCKER_STATE/volume"
         if [ "$FAKE_DOCKER_FAIL" = "$command" ]; then
             exit "$FAKE_DOCKER_EXIT"
         fi
+        ;;
+    up)
+        touch "$FAKE_DOCKER_STATE/container" "$FAKE_DOCKER_STATE/network" "$FAKE_DOCKER_STATE/volume"
+        count=0
+        if [ -f "$FAKE_DOCKER_UP_COUNT" ]; then
+            count=$(cat "$FAKE_DOCKER_UP_COUNT")
+        fi
+        count=$((count + 1))
+        echo "$count" > "$FAKE_DOCKER_UP_COUNT"
+        if [ "$FAKE_DOCKER_FAIL" = up ] && [ "$count" -le "$FAKE_DOCKER_STARTUP_FAILURES" ]; then
+            exit "$FAKE_DOCKER_EXIT"
+        fi
+        ;;
+    ps)
+        echo "fake compose state"
+        ;;
+    logs)
+        echo "fake compose logs"
         ;;
     down)
         rm -f "$FAKE_DOCKER_STATE"/*
@@ -118,9 +181,11 @@ esac
         "FAKE_DOCKER_EXIT": str(exit_code),
         "FAKE_DOCKER_FAIL": failed_command,
         "FAKE_DOCKER_STATE": str(state),
+        "FAKE_DOCKER_STARTUP_FAILURES": str(startup_failures),
+        "FAKE_DOCKER_UP_COUNT": str(tmp_path / "up-count"),
         "GITHUB_SHA": "test-revision",
         "PATH": f"{fake_bin}{os.pathsep}{environment['PATH']}",
-        "POWERCONTEXT_E2E_DATABASE": "sqlite",
+        "POWERCONTEXT_E2E_DATABASE": database,
         "POWERCONTEXT_E2E_OUTPUT": str(tmp_path / "evidence"),
     })
     result = subprocess.run(  # noqa: S603 - executes the repository script with an isolated fake Docker binary.

--- a/openapi/powercontext.yaml
+++ b/openapi/powercontext.yaml
@@ -31,7 +31,7 @@ paths:
       operationId: get_readiness
       responses:
         "200":
-          description: Required Server bindings are ready.
+          description: Required Server bindings are ready; optional capabilities may be degraded.
           headers:
             X-PowerContext-Request-ID:
               $ref: "#/components/headers/RequestId"
@@ -3751,7 +3751,7 @@ components:
             type: string
     ReadinessStatus:
       type: string
-      enum: [ready, not_ready]
+      enum: [ready, degraded, not_ready]
     RememberMemoryRequest:
       type: object
       additionalProperties: false

--- a/src/powercontext/builtin/inference/__init__.py
+++ b/src/powercontext/builtin/inference/__init__.py
@@ -5,6 +5,7 @@ Pydantic AI remains optional and is imported only from
 """
 
 from powercontext.builtin.inference.errors import (
+    InferenceConfigurationError,
     InferenceError,
     InferenceTimeoutError,
     InferenceUnavailableError,
@@ -24,6 +25,7 @@ __all__ = [
     "EmbeddingResult",
     "EmbeddingVector",
     "GenerationResult",
+    "InferenceConfigurationError",
     "InferenceError",
     "InferenceTimeoutError",
     "InferenceUnavailableError",

--- a/src/powercontext/builtin/inference/errors.py
+++ b/src/powercontext/builtin/inference/errors.py
@@ -9,6 +9,10 @@ class InferenceError(PowerContextError):
     """Base exception for stable PowerContext inference failures."""
 
 
+class InferenceConfigurationError(InferenceError, RuntimeError):
+    """Raised when a configured inference provider rejects a request."""
+
+
 class InferenceUnavailableError(InferenceError, RuntimeError):
     """Raised when a transient provider failure prevents inference."""
 

--- a/src/powercontext/builtin/inference/pydantic_ai.py
+++ b/src/powercontext/builtin/inference/pydantic_ai.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 from powercontext.builtin.artifacts.memory.canonical import canonical_embedding
 from powercontext.builtin.artifacts.memory.models import EmbeddingProfile
 from powercontext.builtin.inference.errors import (
+    InferenceConfigurationError,
     InferenceError,
     InferenceTimeoutError,
     InferenceUnavailableError,
@@ -23,7 +24,7 @@ from powercontext.builtin.inference.models import (
 )
 
 
-class PydanticAIConfigurationError(InferenceError, RuntimeError):
+class PydanticAIConfigurationError(InferenceConfigurationError):
     """Raised when the Pydantic AI adapter cannot be configured safely."""
 
     def __init__(self, code: str, detail: object | None = None) -> None:
@@ -59,7 +60,8 @@ try:
         UsageLimitExceeded,
         UserError,
     )
-    from pydantic_ai.models import Model
+    from pydantic_ai.messages import ModelRequest, UserPromptPart
+    from pydantic_ai.models import Model, ModelRequestParameters
     from pydantic_ai.settings import ModelSettings
     from pydantic_ai.usage import RunUsage, UsageLimits
     from pydantic_core import PydanticSerializationError
@@ -236,6 +238,36 @@ class PydanticAIEmbeddingModel:
         return tuple(vectors)
 
 
+async def probe_pydantic_ai_model(
+    model: Model,
+    /,
+    *,
+    timeout_seconds: float,
+) -> None:
+    """Send one minimal text request through an assembled generation model."""
+
+    if isinstance(model, str) or not isinstance(model, Model):
+        raise PydanticAIConfigurationError("model-instance")
+    try:
+        await asyncio.wait_for(
+            model.request(
+                [ModelRequest(parts=[UserPromptPart("Reply with one token.")])],
+                ModelSettings(max_tokens=1),
+                ModelRequestParameters(),
+            ),
+            timeout=timeout_seconds,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as error:
+        mapped = _map_error(error, operation="generate", timeout_seconds=timeout_seconds)
+        if mapped is None:
+            raise
+        if mapped is error:
+            raise
+        raise mapped from error
+
+
 def _generation_usage(value: RunUsage) -> InferenceUsage:
     return InferenceUsage(
         requests=value.requests,
@@ -274,4 +306,5 @@ __all__ = [
     "PydanticAIConfigurationError",
     "PydanticAIEmbeddingModel",
     "PydanticAIStructuredGenerator",
+    "probe_pydantic_ai_model",
 ]

--- a/src/powercontext/builtin/persistence/database.py
+++ b/src/powercontext/builtin/persistence/database.py
@@ -69,6 +69,12 @@ class AsyncDatabase:
 
         return self.transaction() if bound is None else nullcontext(bound)
 
+    async def ping(self) -> None:
+        """Verify that the configured database can execute a trivial query."""
+
+        async with self.transaction() as connection:
+            await connection.exec_driver_sql("SELECT 1")
+
     async def close(self) -> None:
         """Drain active transactions, then dispose only an owned engine."""
 

--- a/src/powercontext/builtin/runtime/__init__.py
+++ b/src/powercontext/builtin/runtime/__init__.py
@@ -106,6 +106,11 @@ from powercontext.builtin.runtime.models import (
     SourceReceipt,
 )
 from powercontext.builtin.runtime.protocols import PowerContextProvider
+from powercontext.builtin.runtime.readiness import (
+    ReadinessCheckStatus,
+    RuntimeReadiness,
+    RuntimeReadinessChecks,
+)
 from powercontext.builtin.statistics import (
     ArtifactInventoryStatistics,
     CandidateFamilyCount,
@@ -211,6 +216,7 @@ __all__ = [
     "PreparedHandoff",
     "ProposeExperienceRequest",
     "ProposeSkillRequest",
+    "ReadinessCheckStatus",
     "RecallTokenDay",
     "RecallTokenMeasurement",
     "RecallTokenStatistics",
@@ -227,6 +233,8 @@ __all__ = [
     "ReviseMemoryEntryRequest",
     "RuntimeCapabilities",
     "RuntimeConfig",
+    "RuntimeReadiness",
+    "RuntimeReadinessChecks",
     "ScheduledExperienceProcessor",
     "ScheduledSourceProcessor",
     "ScopedExperienceApplication",

--- a/src/powercontext/builtin/runtime/__init__.py
+++ b/src/powercontext/builtin/runtime/__init__.py
@@ -108,8 +108,10 @@ from powercontext.builtin.runtime.models import (
 from powercontext.builtin.runtime.protocols import PowerContextProvider
 from powercontext.builtin.runtime.readiness import (
     ReadinessCheckStatus,
+    ReadinessProbeDefinition,
     RuntimeReadiness,
     RuntimeReadinessChecks,
+    RuntimeReadinessStatus,
 )
 from powercontext.builtin.statistics import (
     ArtifactInventoryStatistics,
@@ -217,6 +219,7 @@ __all__ = [
     "ProposeExperienceRequest",
     "ProposeSkillRequest",
     "ReadinessCheckStatus",
+    "ReadinessProbeDefinition",
     "RecallTokenDay",
     "RecallTokenMeasurement",
     "RecallTokenStatistics",
@@ -235,6 +238,7 @@ __all__ = [
     "RuntimeConfig",
     "RuntimeReadiness",
     "RuntimeReadinessChecks",
+    "RuntimeReadinessStatus",
     "ScheduledExperienceProcessor",
     "ScheduledSourceProcessor",
     "ScopedExperienceApplication",

--- a/src/powercontext/builtin/runtime/application.py
+++ b/src/powercontext/builtin/runtime/application.py
@@ -90,6 +90,11 @@ from powercontext.builtin.runtime.models import (
 )
 from powercontext.builtin.runtime.prepared_context import PreparedContextBuild, PreparedContextBuilder
 from powercontext.builtin.runtime.protocols import BuiltinTriggers, PowerContextProvider
+from powercontext.builtin.runtime.readiness import (
+    ReadinessCheckStatus,
+    RuntimeReadiness,
+    RuntimeReadinessChecks,
+)
 from powercontext.builtin.runtime.statistics import RelationalScopedStatistics
 from powercontext.builtin.sources import ContentCapture, ExternalSkillImportMode, SourceCursor, validate_scope_id
 from powercontext.builtin.statistics import (
@@ -907,6 +912,7 @@ class BuiltinRuntime:
         external_skill_importer: ExternalSkillImporter | None = None,
         statistics_service: StatisticsServiceFactory | None = None,
         recall_token_estimator: RecallTokenEstimator | None = None,
+        readiness: RuntimeReadinessChecks | None = None,
         clock: Clock | None = None,
     ) -> None:
         if source_window_limit < 1:
@@ -921,6 +927,7 @@ class BuiltinRuntime:
         self._external_skill_importer = external_skill_importer
         self._statistics_service = statistics_service
         self._recall_token_estimator = recall_token_estimator
+        self._readiness = RuntimeReadinessChecks() if readiness is None else readiness
         self._clock = _utc_now if clock is None else clock
         self.source_window_limit = source_window_limit
         self._locks: dict[str, asyncio.Lock] = {}
@@ -956,6 +963,15 @@ class BuiltinRuntime:
     async def capabilities(self) -> RuntimeCapabilities:
         async with self._operation():
             return self._capabilities
+
+    async def readiness(self) -> RuntimeReadiness:
+        """Check whether the Runtime and its assembled dependencies can accept work."""
+
+        async with self._operation():
+            dependencies = await self._readiness.run()
+        return RuntimeReadiness(
+            checks={"runtime": ReadinessCheckStatus.READY, **dependencies.checks},
+        )
 
     def start_scheduler(
         self,

--- a/src/powercontext/builtin/runtime/application.py
+++ b/src/powercontext/builtin/runtime/application.py
@@ -970,6 +970,7 @@ class BuiltinRuntime:
         async with self._operation():
             dependencies = await self._readiness.run()
         return RuntimeReadiness(
+            status=dependencies.status,
             checks={"runtime": ReadinessCheckStatus.READY, **dependencies.checks},
         )
 

--- a/src/powercontext/builtin/runtime/composition.py
+++ b/src/powercontext/builtin/runtime/composition.py
@@ -47,6 +47,7 @@ from powercontext.builtin.runtime.readiness import (
     READINESS_PROBE_TIMEOUT_SECONDS,
     CachedReadinessProbe,
     ReadinessProbe,
+    ReadinessProbeDefinition,
     RuntimeReadinessChecks,
     dependency_readiness_probe,
 )
@@ -165,13 +166,22 @@ async def open_builtin_runtime(
                 memory_reranker=configured_reranker,
             )
         )
-        readiness_probes: dict[str, ReadinessProbe] = {
-            "database": dependency_readiness_probe(contexts.database.ping),
+        readiness_probes: dict[str, ReadinessProbeDefinition] = {
+            "database": ReadinessProbeDefinition(
+                probe=dependency_readiness_probe(contexts.database.ping),
+                blocking=True,
+            ),
         }
         if generation_readiness is not None:
-            readiness_probes["inference.generation"] = generation_readiness
+            readiness_probes["inference.generation"] = ReadinessProbeDefinition(
+                probe=generation_readiness,
+                blocking=False,
+            )
         if configured_embedding_source is not None:
-            readiness_probes["inference.embedding"] = _embedding_readiness_probe(configured_embedding_source)
+            readiness_probes["inference.embedding"] = ReadinessProbeDefinition(
+                probe=_embedding_readiness_probe(configured_embedding_source),
+                blocking=False,
+            )
         runtime = await resources.enter_async_context(
             BuiltinRuntime(
                 provider=contexts,

--- a/src/powercontext/builtin/runtime/composition.py
+++ b/src/powercontext/builtin/runtime/composition.py
@@ -43,6 +43,13 @@ from powercontext.builtin.persistence.tables import BUILTIN_TABLES
 from powercontext.builtin.runtime.application import BuiltinRuntime
 from powercontext.builtin.runtime.config import BuiltinConfig, ExternalSkillsConfig, InferenceConfig, RuntimeConfig
 from powercontext.builtin.runtime.models import MemorySearchMode, RuntimeCapabilities
+from powercontext.builtin.runtime.readiness import (
+    READINESS_PROBE_TIMEOUT_SECONDS,
+    CachedReadinessProbe,
+    ReadinessProbe,
+    RuntimeReadinessChecks,
+    dependency_readiness_probe,
+)
 from powercontext.builtin.runtime.relational import RelationalContexts
 from powercontext.builtin.sources import CONTENT_SOURCE_NAME, ContentSource
 from powercontext.sources import Source
@@ -114,6 +121,7 @@ async def open_builtin_runtime(
             generated_skill,
             generated_handoff,
             generated_reranker,
+            generation_readiness,
         ) = (
             await _generation_pipelines(config.inference, config.runtime, resources)
             if (
@@ -124,7 +132,7 @@ async def open_builtin_runtime(
                 or handoff_pipeline is None
                 or (config.runtime.memory_rerank_enabled and memory_reranker is None)
             )
-            else (None, None, None, None, None, None)
+            else (None, None, None, None, None, None, None)
         )
         configured_pipeline = generated_memory if candidate_pipeline is None else candidate_pipeline
         configured_incubation = generated_incubation if experience_pipeline is None else experience_pipeline
@@ -157,6 +165,13 @@ async def open_builtin_runtime(
                 memory_reranker=configured_reranker,
             )
         )
+        readiness_probes: dict[str, ReadinessProbe] = {
+            "database": dependency_readiness_probe(contexts.database.ping),
+        }
+        if generation_readiness is not None:
+            readiness_probes["inference.generation"] = generation_readiness
+        if configured_embedding_source is not None:
+            readiness_probes["inference.embedding"] = _embedding_readiness_probe(configured_embedding_source)
         runtime = await resources.enter_async_context(
             BuiltinRuntime(
                 provider=contexts,
@@ -178,6 +193,7 @@ async def open_builtin_runtime(
                 external_skill_importer=contexts.import_external_skill if contexts.external_skill_registry else None,
                 statistics_service=contexts.statistics,
                 recall_token_estimator=contexts.estimate_recall_tokens,
+                readiness=RuntimeReadinessChecks(readiness_probes),
             )
         )
         if config.handoff_report.enabled:
@@ -293,9 +309,10 @@ async def _generation_pipelines(
     SkillGenerator | None,
     HandoffGenerationPipeline | None,
     MemoryReranker | None,
+    ReadinessProbe | None,
 ]:
     if settings.generation_model is None:
-        return None, None, None, None, None, None
+        return None, None, None, None, None, None, None
 
     from pydantic_ai.models import infer_model
     from pydantic_ai.settings import ModelSettings
@@ -331,9 +348,17 @@ async def _generation_pipelines(
         LLMSkillGenerator,
         SkillGenerationOutput,
     )
-    from powercontext.builtin.inference.pydantic_ai import InferenceLimits, PydanticAIStructuredGenerator
+    from powercontext.builtin.inference.pydantic_ai import (
+        InferenceLimits,
+        PydanticAIStructuredGenerator,
+        probe_pydantic_ai_model,
+    )
 
     model = await resources.enter_async_context(infer_model(settings.generation_model))
+
+    async def probe_generation() -> None:
+        await probe_pydantic_ai_model(model, timeout_seconds=READINESS_PROBE_TIMEOUT_SECONDS)
+
     limits = InferenceLimits(
         timeout_seconds=settings.generation_timeout_seconds,
         max_requests=settings.generation_max_requests,
@@ -398,6 +423,7 @@ async def _generation_pipelines(
             evidence_projector=_ContentHandoffEvidenceProjector(),
         ),
         (None if rerank_generator is None else LLMMemoryReranker(UsageReportingStructuredGenerator(rerank_generator))),
+        CachedReadinessProbe(dependency_readiness_probe(probe_generation)),
     )
 
 
@@ -434,6 +460,13 @@ async def _embedding_model(settings: InferenceConfig, resources: AsyncExitStack)
         ),
         limits=InferenceLimits(timeout_seconds=settings.embedding_timeout_seconds),
     )
+
+
+def _embedding_readiness_probe(model: EmbeddingModel) -> ReadinessProbe:
+    async def probe_embedding() -> None:
+        await model.embed(("PowerContext readiness probe",))
+
+    return CachedReadinessProbe(dependency_readiness_probe(probe_embedding))
 
 
 def _required(value: ValueT | None) -> ValueT:

--- a/src/powercontext/builtin/runtime/readiness.py
+++ b/src/powercontext/builtin/runtime/readiness.py
@@ -1,0 +1,136 @@
+"""Runtime-owned dependency readiness checks."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from time import monotonic
+
+from powercontext.builtin.inference import InferenceConfigurationError
+
+READINESS_PROBE_TIMEOUT_SECONDS = 2.0
+READINESS_PROBE_CACHE_SECONDS = 300.0
+
+DependencyOperation = Callable[[], Awaitable[object]]
+Clock = Callable[[], float]
+
+
+class ReadinessCheckStatus(StrEnum):
+    """Stable outcomes exposed for one Runtime dependency."""
+
+    READY = "ready"
+    UNAVAILABLE = "unavailable"
+    TIMEOUT = "timeout"
+    MISCONFIGURED = "misconfigured"
+
+
+ReadinessProbe = Callable[[], Awaitable[ReadinessCheckStatus]]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeReadiness:
+    """Aggregate the safe readiness outcomes for one Runtime."""
+
+    checks: Mapping[str, ReadinessCheckStatus]
+
+    @property
+    def ready(self) -> bool:
+        """Return whether every registered dependency is ready."""
+
+        return all(status is ReadinessCheckStatus.READY for status in self.checks.values())
+
+
+class RuntimeReadinessChecks:
+    """Run independent dependency probes concurrently."""
+
+    def __init__(self, probes: Mapping[str, ReadinessProbe] | None = None) -> None:
+        self._probes = {} if probes is None else dict(probes)
+
+    async def run(self) -> RuntimeReadiness:
+        """Return safe results in registration order without exposing failures."""
+
+        names = tuple(self._probes)
+        results = await asyncio.gather(*(self._run(self._probes[name]) for name in names))
+        return RuntimeReadiness(checks=dict(zip(names, results, strict=True)))
+
+    @staticmethod
+    async def _run(probe: ReadinessProbe) -> ReadinessCheckStatus:
+        try:
+            return await probe()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return ReadinessCheckStatus.UNAVAILABLE
+
+
+class CachedReadinessProbe:
+    """Cache one dependency result and collapse concurrent refreshes."""
+
+    def __init__(
+        self,
+        probe: ReadinessProbe,
+        *,
+        ttl_seconds: float = READINESS_PROBE_CACHE_SECONDS,
+        clock: Clock = monotonic,
+    ) -> None:
+        self._probe = probe
+        self._ttl_seconds = ttl_seconds
+        self._clock = clock
+        self._lock = asyncio.Lock()
+        self._result: ReadinessCheckStatus | None = None
+        self._expires_at = 0.0
+
+    async def __call__(self) -> ReadinessCheckStatus:
+        """Return a fresh cached result, refreshing it at most once."""
+
+        result = self._fresh_result()
+        if result is not None:
+            return result
+        async with self._lock:
+            result = self._fresh_result()
+            if result is not None:
+                return result
+            result = await self._probe()
+            self._result = result
+            self._expires_at = self._clock() + self._ttl_seconds
+            return result
+
+    def _fresh_result(self) -> ReadinessCheckStatus | None:
+        return self._result if self._result is not None and self._clock() < self._expires_at else None
+
+
+def dependency_readiness_probe(
+    operation: DependencyOperation,
+    *,
+    timeout_seconds: float = READINESS_PROBE_TIMEOUT_SECONDS,
+) -> ReadinessProbe:
+    """Convert one dependency operation into a bounded, redacted probe."""
+
+    async def probe() -> ReadinessCheckStatus:
+        try:
+            await asyncio.wait_for(operation(), timeout=timeout_seconds)
+        except asyncio.CancelledError:
+            raise
+        except InferenceConfigurationError:
+            return ReadinessCheckStatus.MISCONFIGURED
+        except TimeoutError:
+            return ReadinessCheckStatus.TIMEOUT
+        except Exception:
+            return ReadinessCheckStatus.UNAVAILABLE
+        return ReadinessCheckStatus.READY
+
+    return probe
+
+
+__all__ = [
+    "READINESS_PROBE_CACHE_SECONDS",
+    "READINESS_PROBE_TIMEOUT_SECONDS",
+    "CachedReadinessProbe",
+    "ReadinessCheckStatus",
+    "ReadinessProbe",
+    "RuntimeReadiness",
+    "RuntimeReadinessChecks",
+    "dependency_readiness_probe",
+]

--- a/src/powercontext/builtin/runtime/readiness.py
+++ b/src/powercontext/builtin/runtime/readiness.py
@@ -12,6 +12,7 @@ from powercontext.builtin.inference import InferenceConfigurationError
 
 READINESS_PROBE_TIMEOUT_SECONDS = 2.0
 READINESS_PROBE_CACHE_SECONDS = 300.0
+READINESS_PROBE_TRANSIENT_CACHE_SECONDS = 30.0
 
 DependencyOperation = Callable[[], Awaitable[object]]
 Clock = Callable[[], float]
@@ -29,31 +30,58 @@ class ReadinessCheckStatus(StrEnum):
 ReadinessProbe = Callable[[], Awaitable[ReadinessCheckStatus]]
 
 
+class RuntimeReadinessStatus(StrEnum):
+    """Aggregate availability of one Runtime and its dependencies."""
+
+    READY = "ready"
+    DEGRADED = "degraded"
+    NOT_READY = "not_ready"
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessProbeDefinition:
+    """Bind one probe to whether its failure blocks Runtime readiness."""
+
+    probe: ReadinessProbe
+    blocking: bool
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeReadiness:
     """Aggregate the safe readiness outcomes for one Runtime."""
 
+    status: RuntimeReadinessStatus
     checks: Mapping[str, ReadinessCheckStatus]
 
     @property
     def ready(self) -> bool:
-        """Return whether every registered dependency is ready."""
+        """Return whether every registered dependency is fully ready."""
 
-        return all(status is ReadinessCheckStatus.READY for status in self.checks.values())
+        return self.status is RuntimeReadinessStatus.READY
 
 
 class RuntimeReadinessChecks:
     """Run independent dependency probes concurrently."""
 
-    def __init__(self, probes: Mapping[str, ReadinessProbe] | None = None) -> None:
+    def __init__(self, probes: Mapping[str, ReadinessProbeDefinition] | None = None) -> None:
         self._probes = {} if probes is None else dict(probes)
 
     async def run(self) -> RuntimeReadiness:
         """Return safe results in registration order without exposing failures."""
 
         names = tuple(self._probes)
-        results = await asyncio.gather(*(self._run(self._probes[name]) for name in names))
-        return RuntimeReadiness(checks=dict(zip(names, results, strict=True)))
+        results = await asyncio.gather(*(self._run(self._probes[name].probe) for name in names))
+        checks = dict(zip(names, results, strict=True))
+        blocking_failure = any(
+            checks[name] is not ReadinessCheckStatus.READY and self._probes[name].blocking for name in names
+        )
+        if blocking_failure:
+            status = RuntimeReadinessStatus.NOT_READY
+        elif any(result is not ReadinessCheckStatus.READY for result in results):
+            status = RuntimeReadinessStatus.DEGRADED
+        else:
+            status = RuntimeReadinessStatus.READY
+        return RuntimeReadiness(status=status, checks=checks)
 
     @staticmethod
     async def _run(probe: ReadinessProbe) -> ReadinessCheckStatus:
@@ -73,11 +101,13 @@ class CachedReadinessProbe:
         probe: ReadinessProbe,
         *,
         ttl_seconds: float = READINESS_PROBE_CACHE_SECONDS,
-        clock: Clock = monotonic,
+        transient_ttl_seconds: float = READINESS_PROBE_TRANSIENT_CACHE_SECONDS,
+        clock: Clock | None = None,
     ) -> None:
         self._probe = probe
         self._ttl_seconds = ttl_seconds
-        self._clock = clock
+        self._transient_ttl_seconds = transient_ttl_seconds
+        self._clock = monotonic if clock is None else clock
         self._lock = asyncio.Lock()
         self._result: ReadinessCheckStatus | None = None
         self._expires_at = 0.0
@@ -94,7 +124,12 @@ class CachedReadinessProbe:
                 return result
             result = await self._probe()
             self._result = result
-            self._expires_at = self._clock() + self._ttl_seconds
+            ttl_seconds = (
+                self._transient_ttl_seconds
+                if result in {ReadinessCheckStatus.TIMEOUT, ReadinessCheckStatus.UNAVAILABLE}
+                else self._ttl_seconds
+            )
+            self._expires_at = self._clock() + ttl_seconds
             return result
 
     def _fresh_result(self) -> ReadinessCheckStatus | None:
@@ -127,10 +162,13 @@ def dependency_readiness_probe(
 __all__ = [
     "READINESS_PROBE_CACHE_SECONDS",
     "READINESS_PROBE_TIMEOUT_SECONDS",
+    "READINESS_PROBE_TRANSIENT_CACHE_SECONDS",
     "CachedReadinessProbe",
     "ReadinessCheckStatus",
     "ReadinessProbe",
+    "ReadinessProbeDefinition",
     "RuntimeReadiness",
     "RuntimeReadinessChecks",
+    "RuntimeReadinessStatus",
     "dependency_readiness_probe",
 ]

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 from dataclasses import asdict, dataclass
+from enum import StrEnum
 from importlib.metadata import version
 from pathlib import Path
 from shutil import which
@@ -14,7 +15,9 @@ from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
 import typer
+from pydantic import ValidationError
 
+from powercontext.http import HealthResponse, ReadinessResponse, ReadinessStatus
 from powercontext.paths import powercontext_data_dir
 
 HELP_OPTION_NAMES = ("-h", "--help")
@@ -72,10 +75,33 @@ class CodexSetupResult:
     data_dir: str
 
 
+class DiagnosticStatus(StrEnum):
+    """Outcome of one installation diagnostic."""
+
+    OK = "ok"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
 @dataclass(frozen=True, slots=True)
 class Diagnostic:
-    ok: bool
+    status: DiagnosticStatus
     detail: str
+    checks: dict[str, str] | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Return whether this check passed."""
+
+        return self.status is DiagnosticStatus.OK
+
+    def as_json(self) -> dict[str, object]:
+        """Return the stable external diagnostic representation."""
+
+        result: dict[str, object] = {"ok": self.ok, "detail": self.detail}
+        if self.checks is not None:
+            result["checks"] = self.checks
+        return result
 
 
 @setup_app.command("codex")
@@ -101,6 +127,11 @@ def setup_codex(
         typer.echo(str(error), err=True)
         raise typer.Exit(code=1) from error
 
+    diagnostics = run_codex_diagnostics()
+    if not _diagnostics_ok(diagnostics):
+        _write_diagnostics(diagnostics, json_output=json_output)
+        raise typer.Exit(code=1)
+
     if json_output:
         typer.echo(json.dumps(asdict(result), indent=2))
         return
@@ -112,6 +143,7 @@ def setup_codex(
 
 @doctor_app.callback()
 def doctor(
+    context: typer.Context,
     server_url: Annotated[
         str,
         typer.Option(help="PowerContext Server base URL."),
@@ -121,25 +153,28 @@ def doctor(
         typer.Option("--json", help="Write the result as JSON."),
     ] = False,
 ) -> None:
-    """Check the package, Codex plugin, and configured Server."""
+    """Check the installed package and configured Server."""
 
+    if context.invoked_subcommand is not None:
+        return
     diagnostics = run_diagnostics(server_url=server_url)
-    is_healthy = all(diagnostic.ok for diagnostic in diagnostics.values())
-    if json_output:
-        typer.echo(
-            json.dumps(
-                {
-                    "ok": is_healthy,
-                    "checks": {name: asdict(diagnostic) for name, diagnostic in diagnostics.items()},
-                },
-                indent=2,
-            )
-        )
-    else:
-        for name, diagnostic in diagnostics.items():
-            status = "ok" if diagnostic.ok else "failed"
-            typer.echo(f"{name}: {status} - {diagnostic.detail}")
-    if not is_healthy:
+    _write_diagnostics(diagnostics, json_output=json_output)
+    if not _diagnostics_ok(diagnostics):
+        raise typer.Exit(code=1)
+
+
+@doctor_app.command("codex")
+def doctor_codex(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Write the result as JSON."),
+    ] = False,
+) -> None:
+    """Check the optional Codex CLI and PowerContext plugin."""
+
+    diagnostics = run_codex_diagnostics()
+    _write_diagnostics(diagnostics, json_output=json_output)
+    if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)
 
 
@@ -174,29 +209,45 @@ def install_codex_plugin(*, source: str, ref: str) -> CodexSetupResult:
 def run_diagnostics(*, server_url: str) -> dict[str, Diagnostic]:
     """Collect installed-environment diagnostics without changing state."""
 
-    package = Diagnostic(ok=True, detail=f"powercontext {version('powercontext')}")
-    codex, plugin = _codex_diagnostics()
-    server = _server_diagnostic(server_url)
+    package = Diagnostic(status=DiagnosticStatus.OK, detail=f"powercontext {version('powercontext')}")
+    liveness = _server_liveness_diagnostic(server_url)
+    readiness = (
+        _server_readiness_diagnostic(server_url)
+        if liveness.ok
+        else Diagnostic(
+            status=DiagnosticStatus.SKIPPED,
+            detail="not checked because Server liveness failed",
+        )
+    )
     return {
         "package": package,
-        "codex": codex,
-        "plugin": plugin,
-        "server": server,
+        "server_liveness": liveness,
+        "server_readiness": readiness,
     }
 
 
-def _codex_diagnostics() -> tuple[Diagnostic, Diagnostic]:
+def run_codex_diagnostics() -> dict[str, Diagnostic]:
+    """Collect diagnostics for the optional Codex integration."""
+
     executable = which("codex")
     if executable is None:
-        missing = Diagnostic(ok=False, detail="Codex CLI is not installed or is not on PATH")
-        return missing, Diagnostic(ok=False, detail="plugin cannot be inspected without Codex CLI")
+        return {
+            "codex": Diagnostic(
+                status=DiagnosticStatus.FAILED,
+                detail="Codex CLI is not installed or is not on PATH",
+            ),
+            "plugin": Diagnostic(
+                status=DiagnosticStatus.SKIPPED,
+                detail="not checked because Codex CLI is unavailable",
+            ),
+        }
     try:
         result = _run_codex_json("plugin", "list")
     except SetupError as error:
-        return (
-            Diagnostic(ok=False, detail=str(error)),
-            Diagnostic(ok=False, detail="plugin list is unavailable"),
-        )
+        return {
+            "codex": Diagnostic(status=DiagnosticStatus.FAILED, detail=str(error)),
+            "plugin": Diagnostic(status=DiagnosticStatus.SKIPPED, detail="plugin list is unavailable"),
+        }
     installed = result.get("installed")
     plugin = None
     if isinstance(installed, list):
@@ -211,20 +262,62 @@ def _codex_diagnostics() -> tuple[Diagnostic, Diagnostic]:
             ),
             None,
         )
-    return (
-        Diagnostic(ok=True, detail=executable),
-        Diagnostic(
-            ok=plugin is not None,
+    return {
+        "codex": Diagnostic(status=DiagnosticStatus.OK, detail=executable),
+        "plugin": Diagnostic(
+            status=DiagnosticStatus.OK if plugin is not None else DiagnosticStatus.FAILED,
             detail=(
                 f"{plugin.get('pluginId')} enabled={plugin.get('enabled')}"
                 if plugin is not None
                 else "PowerContext plugin is not installed"
             ),
         ),
+    }
+
+
+def _server_liveness_diagnostic(server_url: str) -> Diagnostic:
+    error = _server_url_error(server_url)
+    if error is not None:
+        return Diagnostic(status=DiagnosticStatus.FAILED, detail=error)
+    try:
+        status_code, payload = _request_json(server_url, "/health/live")
+    except OSError:
+        return Diagnostic(status=DiagnosticStatus.FAILED, detail=f"cannot reach {server_url}")
+    if status_code != 200:
+        return Diagnostic(status=DiagnosticStatus.FAILED, detail=f"liveness returned HTTP {status_code}")
+    try:
+        health = HealthResponse.model_validate(payload)
+    except ValidationError:
+        return Diagnostic(status=DiagnosticStatus.FAILED, detail="liveness returned an invalid response")
+    return Diagnostic(
+        status=DiagnosticStatus.OK if health.status == "ok" else DiagnosticStatus.FAILED,
+        detail=f"{server_url} status={health.status}",
     )
 
 
-def _server_diagnostic(server_url: str) -> Diagnostic:
+def _server_readiness_diagnostic(server_url: str) -> Diagnostic:
+    try:
+        status_code, payload = _request_json(server_url, "/health/ready")
+    except OSError:
+        return Diagnostic(status=DiagnosticStatus.FAILED, detail=f"cannot reach {server_url}")
+    if status_code not in {200, 503}:
+        return Diagnostic(status=DiagnosticStatus.FAILED, detail=f"readiness returned HTTP {status_code}")
+    try:
+        readiness = ReadinessResponse.model_validate(payload)
+    except ValidationError:
+        return Diagnostic(status=DiagnosticStatus.FAILED, detail="readiness returned an invalid response")
+    return Diagnostic(
+        status=(
+            DiagnosticStatus.OK
+            if status_code == 200 and readiness.status is ReadinessStatus.READY
+            else DiagnosticStatus.FAILED
+        ),
+        detail=f"{server_url} status={readiness.status.value}",
+        checks=readiness.checks,
+    )
+
+
+def _server_url_error(server_url: str) -> str | None:
     parsed = urlsplit(server_url)
     if (
         parsed.scheme not in {"http", "https"}
@@ -234,20 +327,53 @@ def _server_diagnostic(server_url: str) -> Diagnostic:
         or parsed.query
         or parsed.fragment
     ):
-        return Diagnostic(ok=False, detail="Server URL must be an HTTP base URL without credentials or query data")
+        return "Server URL must be an HTTP base URL without credentials or query data"
+    return None
+
+
+def _request_json(server_url: str, path: str) -> tuple[int, object]:
     request = Request(  # noqa: S310 - a user-selected diagnostics endpoint is expected.
-        f"{server_url.rstrip('/')}/health/ready",
+        f"{server_url.rstrip('/')}{path}",
         headers={"Accept": "application/json", "User-Agent": "powercontext-doctor"},
     )
     try:
         with urlopen(request, timeout=3) as response:  # noqa: S310
-            payload = json.load(response)
+            return response.getcode(), _load_json(response)
     except HTTPError as error:
-        return Diagnostic(ok=False, detail=f"readiness returned HTTP {error.code}")
-    except (OSError, ValueError) as error:
-        return Diagnostic(ok=False, detail=f"cannot reach {server_url}: {error}")
-    status = payload.get("status") if isinstance(payload, dict) else None
-    return Diagnostic(ok=status == "ready", detail=f"{server_url} status={status}")
+        try:
+            return error.code, _load_json(error)
+        finally:
+            error.close()
+
+
+def _load_json(response: Any) -> object | None:
+    try:
+        return json.load(response)
+    except (UnicodeError, ValueError):
+        return None
+
+
+def _diagnostics_ok(diagnostics: dict[str, Diagnostic]) -> bool:
+    return all(diagnostic.ok for diagnostic in diagnostics.values())
+
+
+def _write_diagnostics(diagnostics: dict[str, Diagnostic], *, json_output: bool) -> None:
+    if json_output:
+        typer.echo(
+            json.dumps(
+                {
+                    "ok": _diagnostics_ok(diagnostics),
+                    "checks": {name: diagnostic.as_json() for name, diagnostic in diagnostics.items()},
+                },
+                indent=2,
+            )
+        )
+        return
+    for name, diagnostic in diagnostics.items():
+        typer.echo(f"{name.replace('_', ' ')}: {diagnostic.status.value} - {diagnostic.detail}")
+        if diagnostic.checks is not None:
+            for check, status in diagnostic.checks.items():
+                typer.echo(f"  {check}: {status}")
 
 
 def _normalize_marketplace_source(source: str) -> tuple[str, bool]:
@@ -290,9 +416,11 @@ def _required_string(value: dict[str, Any], name: str) -> str:
 __all__ = [
     "CodexSetupResult",
     "Diagnostic",
+    "DiagnosticStatus",
     "SetupError",
     "doctor_app",
     "install_codex_plugin",
+    "run_codex_diagnostics",
     "run_diagnostics",
     "setup_app",
 ]

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -79,6 +79,7 @@ class DiagnosticStatus(StrEnum):
     """Outcome of one installation diagnostic."""
 
     OK = "ok"
+    DEGRADED = "degraded"
     FAILED = "failed"
     SKIPPED = "skipped"
 
@@ -98,7 +99,11 @@ class Diagnostic:
     def as_json(self) -> dict[str, object]:
         """Return the stable external diagnostic representation."""
 
-        result: dict[str, object] = {"ok": self.ok, "detail": self.detail}
+        result: dict[str, object] = {
+            "ok": self.ok,
+            "status": self.status.value,
+            "detail": self.detail,
+        }
         if self.checks is not None:
             result["checks"] = self.checks
         return result
@@ -306,12 +311,14 @@ def _server_readiness_diagnostic(server_url: str) -> Diagnostic:
         readiness = ReadinessResponse.model_validate(payload)
     except ValidationError:
         return Diagnostic(status=DiagnosticStatus.FAILED, detail="readiness returned an invalid response")
+    if status_code == 200 and readiness.status is ReadinessStatus.READY:
+        diagnostic_status = DiagnosticStatus.OK
+    elif status_code == 200 and readiness.status is ReadinessStatus.DEGRADED:
+        diagnostic_status = DiagnosticStatus.DEGRADED
+    else:
+        diagnostic_status = DiagnosticStatus.FAILED
     return Diagnostic(
-        status=(
-            DiagnosticStatus.OK
-            if status_code == 200 and readiness.status is ReadinessStatus.READY
-            else DiagnosticStatus.FAILED
-        ),
+        status=diagnostic_status,
         detail=f"{server_url} status={readiness.status.value}",
         checks=readiness.checks,
     )
@@ -354,15 +361,25 @@ def _load_json(response: Any) -> object | None:
 
 
 def _diagnostics_ok(diagnostics: dict[str, Diagnostic]) -> bool:
-    return all(diagnostic.ok for diagnostic in diagnostics.values())
+    return _diagnostics_status(diagnostics) is DiagnosticStatus.OK
+
+
+def _diagnostics_status(diagnostics: dict[str, Diagnostic]) -> DiagnosticStatus:
+    statuses = {diagnostic.status for diagnostic in diagnostics.values()}
+    for status in (DiagnosticStatus.FAILED, DiagnosticStatus.DEGRADED, DiagnosticStatus.SKIPPED):
+        if status in statuses:
+            return status
+    return DiagnosticStatus.OK
 
 
 def _write_diagnostics(diagnostics: dict[str, Diagnostic], *, json_output: bool) -> None:
     if json_output:
+        status = _diagnostics_status(diagnostics)
         typer.echo(
             json.dumps(
                 {
-                    "ok": _diagnostics_ok(diagnostics),
+                    "ok": status is DiagnosticStatus.OK,
+                    "status": status.value,
                     "checks": {name: diagnostic.as_json() for name, diagnostic in diagnostics.items()},
                 },
                 indent=2,

--- a/src/powercontext/http/_generated/models.py
+++ b/src/powercontext/http/_generated/models.py
@@ -562,6 +562,7 @@ class GeneratedCandidateStatus(StrEnum):
 
 class ReadinessStatus(StrEnum):
     READY = "ready"
+    DEGRADED = "degraded"
     NOT_READY = "not_ready"
 
 

--- a/src/powercontext/http/_generated/operations.py
+++ b/src/powercontext/http/_generated/operations.py
@@ -140,7 +140,7 @@ GET_READINESS = Operation[None, ReadinessResponse](
     tags=("health",),
     responses={
         200: {
-            "description": "Required Server bindings are ready.",
+            "description": "Required Server bindings are ready; optional capabilities may be degraded.",
             "headers": {"X-PowerContext-Request-ID": {"$ref": "#/components/headers/RequestId"}},
         },
         503: {

--- a/src/powercontext/http/_generated/schema.py
+++ b/src/powercontext/http/_generated/schema.py
@@ -32,7 +32,7 @@ OPENAPI_SCHEMA: dict[str, JsonValue] = {
                 "operationId": "get_readiness",
                 "responses": {
                     "200": {
-                        "description": "Required Server bindings are ready.",
+                        "description": "Required Server bindings are ready; optional capabilities may be degraded.",
                         "headers": {"X-PowerContext-Request-ID": {"$ref": "#/components/headers/RequestId"}},
                         "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ReadinessResponse"}}},
                     },
@@ -3043,7 +3043,7 @@ OPENAPI_SCHEMA: dict[str, JsonValue] = {
                 "type": "object",
                 "required": ["status", "checks"],
             },
-            "ReadinessStatus": {"type": "string", "enum": ["ready", "not_ready"]},
+            "ReadinessStatus": {"type": "string", "enum": ["ready", "degraded", "not_ready"]},
             "RememberMemoryRequest": {
                 "properties": {
                     "scope_id": {"type": "string", "maxLength": 256, "minLength": 1, "pattern": ".*\\S.*"},

--- a/src/powercontext/server/app.py
+++ b/src/powercontext/server/app.py
@@ -647,7 +647,7 @@ async def get_readiness(request: Request) -> JSONResponse:
         await readiness_probe() if readiness_probe is not None else _runtime_readiness(request.app.state.application)
     )
     response_status = (
-        status.HTTP_200_OK if readiness.status is ReadinessStatus.READY else status.HTTP_503_SERVICE_UNAVAILABLE
+        status.HTTP_503_SERVICE_UNAVAILABLE if readiness.status is ReadinessStatus.NOT_READY else status.HTTP_200_OK
     )
     return JSONResponse(content=readiness.model_dump(mode="json"), status_code=response_status)
 

--- a/src/powercontext/server/factory.py
+++ b/src/powercontext/server/factory.py
@@ -164,14 +164,14 @@ class _ServerReadinessProbe:
     def __init__(self, metrics: ServerMetrics | None) -> None:
         self._metrics = metrics
         self._runtime: BuiltinRuntime | None = None
-        self._last_ready: bool | None = None
+        self._last_status: ReadinessStatus | None = None
 
     def bind(self, runtime: BuiltinRuntime) -> None:
         self._runtime = runtime
 
     def unbind(self) -> None:
         self._runtime = None
-        self._last_ready = None
+        self._last_status = None
         if self._metrics is not None:
             self._metrics.set_ready(False)
 
@@ -184,7 +184,7 @@ class _ServerReadinessProbe:
             )
         else:
             response = await self._check(runtime)
-        self._observe(response.status is ReadinessStatus.READY)
+        self._observe(response.status)
         return response
 
     async def _check(self, runtime: BuiltinRuntime) -> ReadinessResponse:
@@ -198,20 +198,22 @@ class _ServerReadinessProbe:
                 checks={"runtime": "unavailable"},
             )
         return ReadinessResponse(
-            status=ReadinessStatus.READY if readiness.ready else ReadinessStatus.NOT_READY,
+            status=ReadinessStatus(readiness.status.value),
             checks={name: status.value for name, status in readiness.checks.items()},
         )
 
-    def _observe(self, ready: bool) -> None:
+    def _observe(self, status: ReadinessStatus) -> None:
         if self._metrics is not None:
-            self._metrics.set_ready(ready)
-        if ready == self._last_ready:
+            self._metrics.set_ready(status is not ReadinessStatus.NOT_READY)
+        if status is self._last_status:
             return
-        self._last_ready = ready
-        _log_lifecycle(
-            "server.ready" if ready else "server.not_ready",
-            "PowerContext Server is ready" if ready else "PowerContext Server is not ready",
-        )
+        self._last_status = status
+        event, message = {
+            ReadinessStatus.READY: ("server.ready", "PowerContext Server is ready"),
+            ReadinessStatus.DEGRADED: ("server.degraded", "PowerContext Server is degraded"),
+            ReadinessStatus.NOT_READY: ("server.not_ready", "PowerContext Server is not ready"),
+        }[status]
+        _log_lifecycle(event, message)
 
 
 def _log_lifecycle(event: str, message: str) -> None:

--- a/src/powercontext/server/factory.py
+++ b/src/powercontext/server/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
@@ -21,7 +22,7 @@ from powercontext.builtin.runtime import BuiltinRuntime
 from powercontext.builtin.runtime.composition import open_builtin_runtime
 from powercontext.builtin.runtime.config import BuiltinConfig
 from powercontext.builtin.sources import CONTENT_SOURCE_NAME
-from powercontext.http import Capabilities, MemorySearchMode, PreparedContextSchema
+from powercontext.http import Capabilities, MemorySearchMode, PreparedContextSchema, ReadinessResponse, ReadinessStatus
 from powercontext.paths import default_scheduler_path
 from powercontext.server.access import HttpAccessLogMiddleware
 from powercontext.server.app import create_app
@@ -63,6 +64,7 @@ def create_server_app(
     resolved_tracing = ServerTracing.context_only() if tracing is None else tracing
     if metrics is not None:
         metrics.set_ready(False)
+    readiness_probe = _ServerReadinessProbe(metrics)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -78,18 +80,16 @@ def create_server_app(
             handoff_pipeline=handoff_pipeline,
             embedding_model=embedding_model,
         ) as runtime:
+            readiness_probe.bind(runtime)
             app.state.application = runtime
             app.state.capabilities = await _server_capabilities(runtime)
-            if metrics is not None:
-                metrics.set_ready(True)
-            _log_lifecycle("server.ready", "PowerContext Server is ready")
+            await readiness_probe()
             try:
                 yield
             finally:
                 _log_lifecycle("server.stopping", "PowerContext Server is stopping")
+                readiness_probe.unbind()
                 app.state.application = None
-                if metrics is not None:
-                    metrics.set_ready(False)
                 app.state.capabilities = Capabilities(
                     source_types=[],
                     artifact_families=[],
@@ -113,6 +113,7 @@ def create_server_app(
 
     app = create_app(
         lifespan=lifespan,
+        readiness_probe=readiness_probe,
         middleware=configured_middleware,
         metrics=metrics,
         tracing=resolved_tracing,
@@ -157,6 +158,60 @@ def create_server_app(
             tracing=resolved_tracing,
         )
     return app
+
+
+class _ServerReadinessProbe:
+    def __init__(self, metrics: ServerMetrics | None) -> None:
+        self._metrics = metrics
+        self._runtime: BuiltinRuntime | None = None
+        self._last_ready: bool | None = None
+
+    def bind(self, runtime: BuiltinRuntime) -> None:
+        self._runtime = runtime
+
+    def unbind(self) -> None:
+        self._runtime = None
+        self._last_ready = None
+        if self._metrics is not None:
+            self._metrics.set_ready(False)
+
+    async def __call__(self) -> ReadinessResponse:
+        runtime = self._runtime
+        if runtime is None:
+            response = ReadinessResponse(
+                status=ReadinessStatus.NOT_READY,
+                checks={"runtime": "not_ready"},
+            )
+        else:
+            response = await self._check(runtime)
+        self._observe(response.status is ReadinessStatus.READY)
+        return response
+
+    async def _check(self, runtime: BuiltinRuntime) -> ReadinessResponse:
+        try:
+            readiness = await runtime.readiness()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return ReadinessResponse(
+                status=ReadinessStatus.NOT_READY,
+                checks={"runtime": "unavailable"},
+            )
+        return ReadinessResponse(
+            status=ReadinessStatus.READY if readiness.ready else ReadinessStatus.NOT_READY,
+            checks={name: status.value for name, status in readiness.checks.items()},
+        )
+
+    def _observe(self, ready: bool) -> None:
+        if self._metrics is not None:
+            self._metrics.set_ready(ready)
+        if ready == self._last_ready:
+            return
+        self._last_ready = ready
+        _log_lifecycle(
+            "server.ready" if ready else "server.not_ready",
+            "PowerContext Server is ready" if ready else "PowerContext Server is not ready",
+        )
 
 
 def _log_lifecycle(event: str, message: str) -> None:

--- a/src/powercontext/server/metrics.py
+++ b/src/powercontext/server/metrics.py
@@ -51,7 +51,7 @@ class ServerMetrics:
         )
         self.runtime_ready = Gauge(
             "powercontext_server_runtime_ready",
-            "Whether the built-in Runtime is ready.",
+            "Whether the built-in Runtime can accept operations.",
             registry=self.registry,
         )
 

--- a/tests/builtin/inference/test_pydantic_ai.py
+++ b/tests/builtin/inference/test_pydantic_ai.py
@@ -31,8 +31,10 @@ from powercontext.builtin.inference import (
 )
 from powercontext.builtin.inference.pydantic_ai import (
     InferenceLimits,
+    PydanticAIConfigurationError,
     PydanticAIEmbeddingModel,
     PydanticAIStructuredGenerator,
+    probe_pydantic_ai_model,
 )
 
 
@@ -219,6 +221,32 @@ def test_structured_generator_times_out_and_cancels_underlying_call() -> None:
         with pytest.raises(InferenceTimeoutError):
             await generation
         assert cleaned_up.is_set()
+
+    asyncio.run(scenario())
+
+
+def test_generation_readiness_probe_uses_one_bounded_text_request() -> None:
+    observed_max_tokens: list[int | None] = []
+
+    async def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        assert messages
+        observed_max_tokens.append(None if info.model_settings is None else info.model_settings.get("max_tokens"))
+        return ModelResponse(parts=[TextPart("ok")])
+
+    asyncio.run(probe_pydantic_ai_model(FunctionModel(respond), timeout_seconds=1))
+
+    assert observed_max_tokens == [1]
+
+
+def test_generation_readiness_probe_maps_bad_provider_endpoint_without_leaking_body() -> None:
+    async def reject(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        del messages, info
+        raise ModelHTTPError(404, "test-model", {"api_key": "secret-provider-body"})
+
+    async def scenario() -> None:
+        with pytest.raises(PydanticAIConfigurationError) as error:
+            await probe_pydantic_ai_model(FunctionModel(reject), timeout_seconds=1)
+        assert "secret-provider-body" not in str(error.value)
 
     asyncio.run(scenario())
 

--- a/tests/builtin/runtime/test_readiness.py
+++ b/tests/builtin/runtime/test_readiness.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from powercontext.builtin.inference import InferenceConfigurationError
+from powercontext.builtin.persistence.sqlite import SQLiteConfig
+from powercontext.builtin.runtime import (
+    BuiltinConfig,
+    ReadinessCheckStatus,
+    open_builtin_runtime,
+)
+from powercontext.builtin.runtime.readiness import CachedReadinessProbe, dependency_readiness_probe
+
+
+def test_dependency_readiness_maps_failures_to_stable_redacted_statuses() -> None:
+    async def ready() -> None:
+        return None
+
+    async def misconfigured() -> None:
+        raise InferenceConfigurationError("secret provider response")  # noqa: TRY003 - verifies redaction
+
+    async def unavailable() -> None:
+        raise OSError("https://user:secret@example.test/v1")
+
+    async def slow() -> None:
+        await asyncio.Event().wait()
+
+    async def scenario() -> None:
+        results = await asyncio.gather(
+            dependency_readiness_probe(ready)(),
+            dependency_readiness_probe(misconfigured)(),
+            dependency_readiness_probe(unavailable)(),
+            dependency_readiness_probe(slow, timeout_seconds=0.01)(),
+        )
+
+        assert results == [
+            ReadinessCheckStatus.READY,
+            ReadinessCheckStatus.MISCONFIGURED,
+            ReadinessCheckStatus.UNAVAILABLE,
+            ReadinessCheckStatus.TIMEOUT,
+        ]
+        assert "secret" not in repr(results)
+
+    asyncio.run(scenario())
+
+
+def test_cached_readiness_probe_collapses_concurrency_and_refreshes_after_ttl() -> None:
+    now = 0.0
+    calls = 0
+
+    async def probe() -> ReadinessCheckStatus:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0)
+        return ReadinessCheckStatus.UNAVAILABLE
+
+    async def scenario() -> None:
+        nonlocal now
+        cached = CachedReadinessProbe(probe, ttl_seconds=300, clock=lambda: now)
+
+        assert await asyncio.gather(*(cached() for _ in range(5))) == [ReadinessCheckStatus.UNAVAILABLE] * 5
+        assert await cached() is ReadinessCheckStatus.UNAVAILABLE
+        assert calls == 1
+
+        now = 300
+        assert await cached() is ReadinessCheckStatus.UNAVAILABLE
+        assert calls == 2
+
+    asyncio.run(scenario())
+
+
+def test_builtin_runtime_reports_runtime_and_database_readiness(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        config = BuiltinConfig(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+        )
+        async with open_builtin_runtime(config) as runtime:
+            readiness = await runtime.readiness()
+
+        assert readiness.ready is True
+        assert readiness.checks == {
+            "runtime": ReadinessCheckStatus.READY,
+            "database": ReadinessCheckStatus.READY,
+        }
+
+    asyncio.run(scenario())

--- a/tests/builtin/runtime/test_readiness.py
+++ b/tests/builtin/runtime/test_readiness.py
@@ -3,71 +3,13 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from powercontext.builtin.inference import InferenceConfigurationError
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.builtin.runtime import (
     BuiltinConfig,
     ReadinessCheckStatus,
+    RuntimeReadinessStatus,
     open_builtin_runtime,
 )
-from powercontext.builtin.runtime.readiness import CachedReadinessProbe, dependency_readiness_probe
-
-
-def test_dependency_readiness_maps_failures_to_stable_redacted_statuses() -> None:
-    async def ready() -> None:
-        return None
-
-    async def misconfigured() -> None:
-        raise InferenceConfigurationError("secret provider response")  # noqa: TRY003 - verifies redaction
-
-    async def unavailable() -> None:
-        raise OSError("https://user:secret@example.test/v1")
-
-    async def slow() -> None:
-        await asyncio.Event().wait()
-
-    async def scenario() -> None:
-        results = await asyncio.gather(
-            dependency_readiness_probe(ready)(),
-            dependency_readiness_probe(misconfigured)(),
-            dependency_readiness_probe(unavailable)(),
-            dependency_readiness_probe(slow, timeout_seconds=0.01)(),
-        )
-
-        assert results == [
-            ReadinessCheckStatus.READY,
-            ReadinessCheckStatus.MISCONFIGURED,
-            ReadinessCheckStatus.UNAVAILABLE,
-            ReadinessCheckStatus.TIMEOUT,
-        ]
-        assert "secret" not in repr(results)
-
-    asyncio.run(scenario())
-
-
-def test_cached_readiness_probe_collapses_concurrency_and_refreshes_after_ttl() -> None:
-    now = 0.0
-    calls = 0
-
-    async def probe() -> ReadinessCheckStatus:
-        nonlocal calls
-        calls += 1
-        await asyncio.sleep(0)
-        return ReadinessCheckStatus.UNAVAILABLE
-
-    async def scenario() -> None:
-        nonlocal now
-        cached = CachedReadinessProbe(probe, ttl_seconds=300, clock=lambda: now)
-
-        assert await asyncio.gather(*(cached() for _ in range(5))) == [ReadinessCheckStatus.UNAVAILABLE] * 5
-        assert await cached() is ReadinessCheckStatus.UNAVAILABLE
-        assert calls == 1
-
-        now = 300
-        assert await cached() is ReadinessCheckStatus.UNAVAILABLE
-        assert calls == 2
-
-    asyncio.run(scenario())
 
 
 def test_builtin_runtime_reports_runtime_and_database_readiness(tmp_path: Path) -> None:
@@ -78,7 +20,7 @@ def test_builtin_runtime_reports_runtime_and_database_readiness(tmp_path: Path) 
         async with open_builtin_runtime(config) as runtime:
             readiness = await runtime.readiness()
 
-        assert readiness.ready is True
+        assert readiness.status is RuntimeReadinessStatus.READY
         assert readiness.checks == {
             "runtime": ReadinessCheckStatus.READY,
             "database": ReadinessCheckStatus.READY,

--- a/tests/e2e/test_runtime_server.py
+++ b/tests/e2e/test_runtime_server.py
@@ -166,7 +166,7 @@ def test_server_databases_share_source_to_memory_search_behavior(
             )
             entries = await client.list_memory_entries(ListMemoryEntriesRequest(scope_id=scope_id))
 
-        assert readiness.checks == {"runtime": "ready"}
+        assert readiness.checks == {"runtime": "ready", "database": "ready"}
         assert capabilities.source_types == ["content"]
         assert capabilities.memory_extraction is True
         assert capabilities.search_modes == ["auto", "fts"]

--- a/tests/e2e/test_runtime_server.py
+++ b/tests/e2e/test_runtime_server.py
@@ -25,7 +25,7 @@ from powercontext.builtin.artifacts.memory import (
     MemoryCandidateRequest,
     MemoryEntryInput,
 )
-from powercontext.builtin.inference import EmbeddingResult
+from powercontext.builtin.inference import EmbeddingResult, InferenceConfigurationError
 from powercontext.builtin.persistence.oceanbase import OceanBaseConfig
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.builtin.runtime import InferenceConfig
@@ -43,6 +43,7 @@ from powercontext.http import (
     ListMemoryChangesRequest,
     ListMemoryEntriesRequest,
     PrepareContextRequest,
+    ReadinessStatus,
     RememberMemoryRequest,
     RetireMemoryEntryRequest,
     ReviseMemoryEntryRequest,
@@ -83,6 +84,13 @@ class KeywordEmbeddingModel:
         return EmbeddingResult(
             vectors=tuple((1.0, 0.0, 0.0) if "alpha" in text.casefold() else (0.0, 1.0, 0.0) for text in texts)
         )
+
+
+class MisconfiguredEmbeddingModel:
+    profile = EMBEDDING_PROFILE
+
+    async def embed(self, _texts: tuple[str, ...], /) -> EmbeddingResult:
+        raise InferenceConfigurationError("secret provider response")  # noqa: TRY003 - verifies redaction
 
 
 class DeterministicHandoffPipeline:
@@ -185,6 +193,41 @@ def test_server_databases_share_source_to_memory_search_behavior(
         assert unrelated.hits == []
         assert entries.memory == flushed.memory
         assert entries.entries[0].source_refs[0].source_id == "turn-1"
+
+    asyncio.run(scenario())
+
+
+def test_inference_failure_degrades_readiness_without_blocking_database_operations(tmp_path: Path) -> None:
+    app = create_server_app(
+        settings=_server_settings(tmp_path / "degraded.db"),
+        embedding_model=MisconfiguredEmbeddingModel(),
+    )
+
+    async def scenario() -> None:
+        async with (
+            app.router.lifespan_context(app),
+            httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+            ) as transport,
+        ):
+            client = PowerContextClient("http://testserver", http_client=transport)
+            readiness = await client.get_readiness()
+            captured = await client.capture_content_source(
+                CaptureContentSourceRequest(
+                    scope_id="degraded-readiness",
+                    source_id="turn-1",
+                    content="Database-backed capture remains available.",
+                )
+            )
+
+        assert readiness.status is ReadinessStatus.DEGRADED
+        assert readiness.checks == {
+            "runtime": "ready",
+            "database": "ready",
+            "inference.embedding": "misconfigured",
+        }
+        assert captured.position == 1
 
     asyncio.run(scenario())
 

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -34,6 +34,7 @@ from powercontext.http import (
     PrepareHandoffRequest,
     ProposeExperienceRequest,
     ProposeSkillRequest,
+    ReadinessStatus,
     ResolveExternalSkillRequest,
     ReviseArtifactCandidateRequest,
     ScanExternalSkillsRequest,
@@ -130,6 +131,11 @@ def test_capabilities_report_semantics_without_runtime_tuning_values() -> None:
 
 def test_readiness_operation_declares_the_unavailable_response() -> None:
     assert 503 in GET_READINESS.responses
+    assert tuple(ReadinessStatus) == (
+        ReadinessStatus.READY,
+        ReadinessStatus.DEGRADED,
+        ReadinessStatus.NOT_READY,
+    )
 
 
 def test_capture_operation_declares_its_typed_accepted_exchange() -> None:

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -34,7 +34,6 @@ from powercontext.http import (
     PrepareHandoffRequest,
     ProposeExperienceRequest,
     ProposeSkillRequest,
-    ReadinessStatus,
     ResolveExternalSkillRequest,
     ReviseArtifactCandidateRequest,
     ScanExternalSkillsRequest,
@@ -131,11 +130,6 @@ def test_capabilities_report_semantics_without_runtime_tuning_values() -> None:
 
 def test_readiness_operation_declares_the_unavailable_response() -> None:
     assert 503 in GET_READINESS.responses
-    assert tuple(ReadinessStatus) == (
-        ReadinessStatus.READY,
-        ReadinessStatus.DEGRADED,
-        ReadinessStatus.NOT_READY,
-    )
 
 
 def test_capture_operation_declares_its_typed_accepted_exchange() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,9 +7,11 @@ from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
 from powercontext.builtin.artifacts.experience import ExperienceCandidateInput
+from powercontext.builtin.artifacts.memory import EmbeddingProfile
+from powercontext.builtin.inference import EmbeddingResult, InferenceConfigurationError
 from powercontext.builtin.persistence.oceanbase import OceanBaseConfig
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
-from powercontext.builtin.runtime import MemoryExtractionProfile, RuntimeConfig
+from powercontext.builtin.runtime import InferenceConfig, MemoryExtractionProfile, RuntimeConfig
 from powercontext.http import (
     Capabilities,
     ReadinessResponse,
@@ -24,6 +26,23 @@ from powercontext.sources import Source
 class _NoopExperiencePipeline:
     async def incubate(self, _sources: tuple[Source, ...], /) -> tuple[ExperienceCandidateInput, ...]:
         return ()
+
+
+class _MisconfiguredEmbeddingModel:
+    profile = EmbeddingProfile(
+        profile_id="readiness-test",
+        model="test:embedding",
+        dimension=3,
+        distance="l2",
+        normalization="none",
+    )
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def embed(self, _texts: tuple[str, ...], /) -> EmbeddingResult:
+        self.calls += 1
+        raise InferenceConfigurationError("secret provider response")  # noqa: TRY003 - verifies redaction
 
 
 def test_settings_load_server_environment(monkeypatch) -> None:
@@ -180,6 +199,64 @@ def test_readiness_reports_unavailable_bindings() -> None:
         "checks": {"database": "unavailable"},
     }
     assert response.headers["X-PowerContext-Request-ID"]
+
+
+def test_server_factory_reports_database_and_configured_generation_readiness(tmp_path) -> None:
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+            inference=InferenceConfig(generation_model="test"),
+            mcp=McpConfig(enabled=False),
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ready",
+        "checks": {
+            "runtime": "ready",
+            "database": "ready",
+            "inference.generation": "ready",
+        },
+    }
+
+
+def test_server_factory_caches_and_redacts_failed_embedding_readiness(caplog, tmp_path) -> None:
+    embedding = _MisconfiguredEmbeddingModel()
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+            mcp=McpConfig(enabled=False),
+        ),
+        embedding_model=embedding,
+    )
+
+    with caplog.at_level(logging.INFO, logger="powercontext.server.factory"), TestClient(app) as client:
+        first = client.get("/health/ready")
+        second = client.get("/health/ready")
+        metrics = client.get("/metrics")
+
+    assert first.status_code == second.status_code == 503
+    assert (
+        first.json()
+        == second.json()
+        == {
+            "status": "not_ready",
+            "checks": {
+                "runtime": "ready",
+                "database": "ready",
+                "inference.embedding": "misconfigured",
+            },
+        }
+    )
+    assert embedding.calls == 1
+    assert "powercontext_server_runtime_ready 0.0" in metrics.text
+    assert [getattr(record, "event", None) for record in caplog.records].count("server.not_ready") == 1
+    assert "secret provider response" not in first.text
+    assert "secret provider response" not in caplog.text
 
 
 def test_unhandled_errors_return_the_server_request_id() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,14 +1,21 @@
+import asyncio
 import logging
 import re
 from datetime import datetime, timedelta
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.messages import ModelMessage, ModelResponse
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.providers.openai import OpenAIProvider
 
 from powercontext.builtin.artifacts.experience import ExperienceCandidateInput
 from powercontext.builtin.artifacts.memory import EmbeddingProfile
 from powercontext.builtin.inference import EmbeddingResult, InferenceConfigurationError
+from powercontext.builtin.persistence.database import AsyncDatabase
 from powercontext.builtin.persistence.oceanbase import OceanBaseConfig
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.builtin.runtime import InferenceConfig, MemoryExtractionProfile, RuntimeConfig
@@ -28,7 +35,7 @@ class _NoopExperiencePipeline:
         return ()
 
 
-class _MisconfiguredEmbeddingModel:
+class _FailingEmbeddingModel:
     profile = EmbeddingProfile(
         profile_id="readiness-test",
         model="test:embedding",
@@ -37,12 +44,28 @@ class _MisconfiguredEmbeddingModel:
         normalization="none",
     )
 
-    def __init__(self) -> None:
-        self.calls = 0
+    def __init__(self, error: Exception) -> None:
+        self.error = error
 
     async def embed(self, _texts: tuple[str, ...], /) -> EmbeddingResult:
-        self.calls += 1
-        raise InferenceConfigurationError("secret provider response")  # noqa: TRY003 - verifies redaction
+        raise self.error
+
+
+class _SequencedEmbeddingModel:
+    profile = _FailingEmbeddingModel.profile
+
+    def __init__(self, outcomes: list[Exception | None], now: list[float]) -> None:
+        self._outcomes = outcomes
+        self._now = now
+        self.requests: list[float] = []
+
+    async def embed(self, texts: tuple[str, ...], /) -> EmbeddingResult:
+        self.requests.append(self._now[0])
+        await asyncio.sleep(0)
+        outcome = self._outcomes.pop(0)
+        if outcome is not None:
+            raise outcome
+        return EmbeddingResult(vectors=tuple((1.0, 0.0, 0.0) for _ in texts))
 
 
 def test_settings_load_server_environment(monkeypatch) -> None:
@@ -201,6 +224,50 @@ def test_readiness_reports_unavailable_bindings() -> None:
     assert response.headers["X-PowerContext-Request-ID"]
 
 
+def test_readiness_keeps_degraded_bindings_in_traffic() -> None:
+    async def probe() -> ReadinessResponse:
+        return ReadinessResponse(
+            status=ReadinessStatus.DEGRADED,
+            checks={"inference.embedding": "unavailable"},
+        )
+
+    response = TestClient(create_app(readiness_probe=probe)).get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "degraded",
+        "checks": {"inference.embedding": "unavailable"},
+    }
+
+
+def test_server_factory_reports_database_failure_as_not_ready(monkeypatch, tmp_path) -> None:
+    async def fail_ping(_database: AsyncDatabase) -> None:
+        raise OSError("secret database URL")  # noqa: TRY003 - verifies redaction
+
+    monkeypatch.setattr(AsyncDatabase, "ping", fail_ping)
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+            mcp=McpConfig(enabled=False),
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/health/ready")
+        metrics = client.get("/metrics")
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "status": "not_ready",
+        "checks": {
+            "runtime": "ready",
+            "database": "unavailable",
+        },
+    }
+    assert "powercontext_server_runtime_ready 0.0" in metrics.text
+    assert "secret database URL" not in response.text
+
+
 def test_server_factory_reports_database_and_configured_generation_readiness(tmp_path) -> None:
     app = create_server_app(
         settings=ServerSettings(
@@ -224,8 +291,36 @@ def test_server_factory_reports_database_and_configured_generation_readiness(tmp
     }
 
 
-def test_server_factory_caches_and_redacts_failed_embedding_readiness(caplog, tmp_path) -> None:
-    embedding = _MisconfiguredEmbeddingModel()
+def test_server_factory_reports_generation_failure_as_degraded(monkeypatch, tmp_path) -> None:
+    async def rate_limited(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        raise ModelHTTPError(429, "test-model", {"secret": "provider response"})
+
+    monkeypatch.setattr("pydantic_ai.models.infer_model", lambda _name: FunctionModel(rate_limited))
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+            inference=InferenceConfig(generation_model="provider:test-model"),
+            mcp=McpConfig(enabled=False),
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "degraded",
+        "checks": {
+            "runtime": "ready",
+            "database": "ready",
+            "inference.generation": "unavailable",
+        },
+    }
+    assert "provider response" not in response.text
+
+
+def test_server_factory_caches_and_redacts_degraded_embedding_readiness(caplog, tmp_path) -> None:
+    embedding = _FailingEmbeddingModel(InferenceConfigurationError("secret provider response"))
     app = create_server_app(
         settings=ServerSettings(
             database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
@@ -239,12 +334,12 @@ def test_server_factory_caches_and_redacts_failed_embedding_readiness(caplog, tm
         second = client.get("/health/ready")
         metrics = client.get("/metrics")
 
-    assert first.status_code == second.status_code == 503
+    assert first.status_code == second.status_code == 200
     assert (
         first.json()
         == second.json()
         == {
-            "status": "not_ready",
+            "status": "degraded",
             "checks": {
                 "runtime": "ready",
                 "database": "ready",
@@ -252,10 +347,152 @@ def test_server_factory_caches_and_redacts_failed_embedding_readiness(caplog, tm
             },
         }
     )
-    assert embedding.calls == 1
-    assert "powercontext_server_runtime_ready 0.0" in metrics.text
-    assert [getattr(record, "event", None) for record in caplog.records].count("server.not_ready") == 1
+    assert "powercontext_server_runtime_ready 1.0" in metrics.text
     assert "secret provider response" not in first.text
+    assert "secret provider response" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_status"),
+    [
+        (TimeoutError("secret provider timeout"), "timeout"),
+        (OSError("https://secret-provider.example/v1"), "unavailable"),
+    ],
+)
+def test_server_factory_reports_transient_embedding_failures_as_degraded(
+    error: Exception,
+    expected_status: str,
+    tmp_path,
+) -> None:
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+            mcp=McpConfig(enabled=False),
+        ),
+        embedding_model=_FailingEmbeddingModel(error),
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "degraded",
+        "checks": {
+            "runtime": "ready",
+            "database": "ready",
+            "inference.embedding": expected_status,
+        },
+    }
+    assert "secret" not in response.text
+
+
+def test_server_provider_cache_shares_refreshes_and_retries_transient_failures_sooner(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    now = [0.0]
+    monkeypatch.setattr("powercontext.builtin.runtime.readiness.monotonic", lambda: now[0])
+    embedding = _SequencedEmbeddingModel(
+        [OSError("provider unavailable"), None, None],
+        now,
+    )
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+            mcp=McpConfig(enabled=False),
+        ),
+        embedding_model=embedding,
+    )
+
+    async def scenario() -> None:
+        async with (
+            app.router.lifespan_context(app),
+            httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+            ) as client,
+        ):
+            now[0] = 29
+            cached_transient = await client.get("/health/ready")
+            now[0] = 30
+            refreshed = await asyncio.gather(*(client.get("/health/ready") for _ in range(5)))
+            now[0] = 329
+            cached_ready = await client.get("/health/ready")
+            now[0] = 330
+            refreshed_ready = await client.get("/health/ready")
+
+        assert cached_transient.json()["status"] == "degraded"
+        assert all(response.json()["status"] == "ready" for response in refreshed)
+        assert cached_ready.json()["status"] == "ready"
+        assert refreshed_ready.json()["status"] == "ready"
+
+    asyncio.run(scenario())
+
+    assert embedding.requests == [0, 30, 330]
+
+
+def test_server_factory_reports_missing_embedding_api_prefix_as_degraded(caplog, monkeypatch, tmp_path) -> None:
+    now = [0.0]
+    monkeypatch.setattr("powercontext.builtin.runtime.readiness.monotonic", lambda: now[0])
+    requests: list[httpx.Request] = []
+
+    def reject(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            404,
+            json={
+                "error": {
+                    "message": "secret provider response",
+                    "type": "invalid_request_error",
+                }
+            },
+            request=request,
+        )
+
+    provider = OpenAIProvider(
+        base_url="https://provider.example",
+        api_key="secret-api-key",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(reject)),
+    )
+    monkeypatch.setattr("pydantic_ai.providers.infer_provider", lambda _name: provider)
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+            inference=InferenceConfig(
+                embedding_model="openai:text-embedding-3-small",
+                embedding_profile_id="readiness-test",
+                embedding_dimension=3,
+            ),
+            mcp=McpConfig(enabled=False),
+        )
+    )
+
+    with caplog.at_level(logging.INFO, logger="powercontext.server.factory"), TestClient(app) as client:
+        first = client.get("/health/ready")
+        now[0] = 299
+        second = client.get("/health/ready")
+        now[0] = 300
+        third = client.get("/health/ready")
+
+    assert first.status_code == second.status_code == third.status_code == 200
+    assert (
+        first.json()
+        == second.json()
+        == third.json()
+        == {
+            "status": "degraded",
+            "checks": {
+                "runtime": "ready",
+                "database": "ready",
+                "inference.embedding": "misconfigured",
+            },
+        }
+    )
+    assert [request.url.path for request in requests] == ["/embeddings", "/embeddings"]
+    assert "secret-api-key" not in first.text
+    assert "secret provider response" not in first.text
+    assert "secret-api-key" not in caplog.text
     assert "secret provider response" not in caplog.text
 
 

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -154,11 +154,13 @@ def test_doctor_reports_each_check_and_exits_nonzero_on_failure(monkeypatch) -> 
     assert result.exit_code == 1
     assert json.loads(result.output) == {
         "ok": False,
+        "status": "failed",
         "checks": {
-            "package": {"ok": True, "detail": "powercontext 0.0.1"},
-            "server_liveness": {"ok": False, "detail": "cannot connect"},
+            "package": {"ok": True, "status": "ok", "detail": "powercontext 0.0.1"},
+            "server_liveness": {"ok": False, "status": "failed", "detail": "cannot connect"},
             "server_readiness": {
                 "ok": False,
+                "status": "skipped",
                 "detail": "not checked because Server liveness failed",
             },
         },
@@ -196,6 +198,7 @@ def test_default_doctor_checks_server_without_inspecting_codex(monkeypatch) -> N
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["ok"] is True
+    assert payload["status"] == "ok"
     assert list(payload["checks"]) == ["package", "server_liveness", "server_readiness"]
 
 
@@ -224,8 +227,7 @@ def test_default_doctor_preserves_not_ready_checks_in_human_and_json_output(monk
                     "status": "not_ready",
                     "checks": {
                         "runtime": "ready",
-                        "database": "ready",
-                        "inference.embedding": "misconfigured",
+                        "database": "unavailable",
                     },
                 },
             ),
@@ -239,15 +241,70 @@ def test_default_doctor_preserves_not_ready_checks_in_human_and_json_output(monk
 
     assert human.exit_code == 1
     assert "server readiness: failed - http://127.0.0.1:8000 status=not_ready" in human.output
-    assert "  inference.embedding: misconfigured" in human.output
+    assert "  database: unavailable" in human.output
     assert machine.exit_code == 1
+    assert json.loads(machine.output)["status"] == "failed"
     assert json.loads(machine.output)["checks"]["server_readiness"] == {
         "ok": False,
+        "status": "failed",
         "detail": "http://127.0.0.1:8000 status=not_ready",
         "checks": {
             "runtime": "ready",
-            "database": "ready",
-            "inference.embedding": "misconfigured",
+            "database": "unavailable",
+        },
+    }
+
+
+def test_default_doctor_preserves_degraded_checks_in_human_and_json_output(monkeypatch) -> None:
+    def responses() -> list[_Response]:
+        return [
+            _Response(200, {"status": "ok"}),
+            _Response(
+                200,
+                {
+                    "status": "degraded",
+                    "checks": {
+                        "runtime": "ready",
+                        "database": "ready",
+                        "inference.embedding": "misconfigured",
+                    },
+                },
+            ),
+        ]
+
+    monkeypatch.setattr(system_cli, "urlopen", Mock(side_effect=responses()))
+    human = CliRunner().invoke(create_cli([doctor_app]), ["doctor"])
+    monkeypatch.setattr(system_cli, "urlopen", Mock(side_effect=responses()))
+    machine = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "--json"])
+
+    assert human.exit_code == 1
+    assert "server readiness: degraded - http://127.0.0.1:8000 status=degraded" in human.output
+    assert "  inference.embedding: misconfigured" in human.output
+    assert machine.exit_code == 1
+    assert json.loads(machine.output) == {
+        "ok": False,
+        "status": "degraded",
+        "checks": {
+            "package": {
+                "ok": True,
+                "status": "ok",
+                "detail": "powercontext 0.0.1",
+            },
+            "server_liveness": {
+                "ok": True,
+                "status": "ok",
+                "detail": "http://127.0.0.1:8000 status=ok",
+            },
+            "server_readiness": {
+                "ok": False,
+                "status": "degraded",
+                "detail": "http://127.0.0.1:8000 status=degraded",
+                "checks": {
+                    "runtime": "ready",
+                    "database": "ready",
+                    "inference.embedding": "misconfigured",
+                },
+            },
         },
     }
 
@@ -260,9 +317,18 @@ def test_doctor_codex_reports_missing_cli_and_skipped_plugin(monkeypatch) -> Non
     assert result.exit_code == 1
     assert json.loads(result.output) == {
         "ok": False,
+        "status": "failed",
         "checks": {
-            "codex": {"ok": False, "detail": "Codex CLI is not installed or is not on PATH"},
-            "plugin": {"ok": False, "detail": "not checked because Codex CLI is unavailable"},
+            "codex": {
+                "ok": False,
+                "status": "failed",
+                "detail": "Codex CLI is not installed or is not on PATH",
+            },
+            "plugin": {
+                "ok": False,
+                "status": "skipped",
+                "detail": "not checked because Codex CLI is unavailable",
+            },
         },
     }
 

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import json
+from email.message import Message
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import Mock
+from urllib.error import HTTPError
 
 from typer.testing import CliRunner
 
 import powercontext.cli.system as system_cli
 from powercontext.cli.app import create_cli
-from powercontext.cli.system import Diagnostic, doctor_app, setup_app
+from powercontext.cli.system import Diagnostic, DiagnosticStatus, doctor_app, setup_app
 from powercontext.paths import default_scheduler_path
 from powercontext.server.settings import ServerSettings
 
@@ -38,6 +41,16 @@ def test_setup_codex_installs_from_a_remote_ref_and_prepares_storage(
         side_effect=[
             {"marketplaceName": "powercontext", "alreadyAdded": False},
             {"name": "powercontext", "version": "0.1.0"},
+            {
+                "installed": [
+                    {
+                        "name": "powercontext",
+                        "pluginId": "powercontext@powercontext",
+                        "installed": True,
+                        "enabled": True,
+                    }
+                ]
+            },
         ]
     )
     monkeypatch.setattr(system_cli, "_run_codex_json", run_codex)
@@ -76,6 +89,7 @@ def test_setup_codex_installs_from_a_remote_ref_and_prepares_storage(
         "add",
         "powercontext@powercontext",
     )
+    assert run_codex.call_args_list[2].args == ("plugin", "list")
 
 
 def test_setup_codex_uses_an_absolute_local_marketplace_without_a_ref(
@@ -90,6 +104,16 @@ def test_setup_codex_uses_an_absolute_local_marketplace_without_a_ref(
         side_effect=[
             {"marketplaceName": "powercontext-local"},
             {"name": "powercontext", "version": "0.1.0"},
+            {
+                "installed": [
+                    {
+                        "name": "powercontext",
+                        "pluginId": "powercontext@powercontext-local",
+                        "installed": True,
+                        "enabled": True,
+                    }
+                ]
+            },
         ]
     )
     monkeypatch.setattr(system_cli, "_run_codex_json", run_codex)
@@ -113,8 +137,12 @@ def test_doctor_reports_each_check_and_exits_nonzero_on_failure(monkeypatch) -> 
         system_cli,
         "run_diagnostics",
         lambda **_kwargs: {
-            "package": Diagnostic(ok=True, detail="powercontext 0.0.1"),
-            "server": Diagnostic(ok=False, detail="cannot connect"),
+            "package": Diagnostic(status=DiagnosticStatus.OK, detail="powercontext 0.0.1"),
+            "server_liveness": Diagnostic(status=DiagnosticStatus.FAILED, detail="cannot connect"),
+            "server_readiness": Diagnostic(
+                status=DiagnosticStatus.SKIPPED,
+                detail="not checked because Server liveness failed",
+            ),
         },
     )
 
@@ -128,6 +156,123 @@ def test_doctor_reports_each_check_and_exits_nonzero_on_failure(monkeypatch) -> 
         "ok": False,
         "checks": {
             "package": {"ok": True, "detail": "powercontext 0.0.1"},
-            "server": {"ok": False, "detail": "cannot connect"},
+            "server_liveness": {"ok": False, "detail": "cannot connect"},
+            "server_readiness": {
+                "ok": False,
+                "detail": "not checked because Server liveness failed",
+            },
         },
     }
+
+
+class _Response(BytesIO):
+    def __init__(self, status: int, payload: object) -> None:
+        super().__init__(json.dumps(payload).encode())
+        self._status = status
+
+    def getcode(self) -> int:
+        return self._status
+
+
+def test_default_doctor_checks_server_without_inspecting_codex(monkeypatch) -> None:
+    monkeypatch.setattr(
+        system_cli,
+        "run_codex_diagnostics",
+        Mock(side_effect=AssertionError("default doctor must not inspect Codex")),
+    )
+    monkeypatch.setattr(
+        system_cli,
+        "urlopen",
+        Mock(
+            side_effect=[
+                _Response(200, {"status": "ok"}),
+                _Response(200, {"status": "ready", "checks": {"runtime": "ready", "database": "ready"}}),
+            ]
+        ),
+    )
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert list(payload["checks"]) == ["package", "server_liveness", "server_readiness"]
+
+
+def test_default_doctor_skips_readiness_when_liveness_is_unreachable(monkeypatch) -> None:
+    urlopen = Mock(side_effect=OSError("connection refused"))
+    monkeypatch.setattr(system_cli, "urlopen", urlopen)
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor"])
+
+    assert result.exit_code == 1
+    assert "server liveness: failed - cannot reach http://127.0.0.1:8000" in result.output
+    assert "server readiness: skipped - not checked because Server liveness failed" in result.output
+    assert urlopen.call_count == 1
+
+
+def test_default_doctor_preserves_not_ready_checks_in_human_and_json_output(monkeypatch) -> None:
+    def responses() -> list[object]:
+        readiness = HTTPError(
+            "http://127.0.0.1:8000/health/ready",
+            503,
+            "Service Unavailable",
+            hdrs=Message(),
+            fp=_Response(
+                503,
+                {
+                    "status": "not_ready",
+                    "checks": {
+                        "runtime": "ready",
+                        "database": "ready",
+                        "inference.embedding": "misconfigured",
+                    },
+                },
+            ),
+        )
+        return [_Response(200, {"status": "ok"}), readiness]
+
+    monkeypatch.setattr(system_cli, "urlopen", Mock(side_effect=responses()))
+    human = CliRunner().invoke(create_cli([doctor_app]), ["doctor"])
+    monkeypatch.setattr(system_cli, "urlopen", Mock(side_effect=responses()))
+    machine = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "--json"])
+
+    assert human.exit_code == 1
+    assert "server readiness: failed - http://127.0.0.1:8000 status=not_ready" in human.output
+    assert "  inference.embedding: misconfigured" in human.output
+    assert machine.exit_code == 1
+    assert json.loads(machine.output)["checks"]["server_readiness"] == {
+        "ok": False,
+        "detail": "http://127.0.0.1:8000 status=not_ready",
+        "checks": {
+            "runtime": "ready",
+            "database": "ready",
+            "inference.embedding": "misconfigured",
+        },
+    }
+
+
+def test_doctor_codex_reports_missing_cli_and_skipped_plugin(monkeypatch) -> None:
+    monkeypatch.setattr(system_cli, "which", lambda _name: None)
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "codex", "--json"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.output) == {
+        "ok": False,
+        "checks": {
+            "codex": {"ok": False, "detail": "Codex CLI is not installed or is not on PATH"},
+            "plugin": {"ok": False, "detail": "not checked because Codex CLI is unavailable"},
+        },
+    }
+
+
+def test_doctor_codex_requires_an_enabled_powercontext_plugin(monkeypatch) -> None:
+    monkeypatch.setattr(system_cli, "which", lambda _name: "/usr/bin/codex")
+    monkeypatch.setattr(system_cli, "_run_codex_json", lambda *_args: {"installed": []})
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "codex"])
+
+    assert result.exit_code == 1
+    assert "codex: ok - /usr/bin/codex" in result.output
+    assert "plugin: failed - PowerContext plugin is not installed" in result.output


### PR DESCRIPTION
# Which issue or RFC does this PR close?

<!--
Link the related issue or RFC using GitHub syntax.
For example, `Closes #123` indicates that this PR will close issue #123.
If this PR implements an RFC, link the RFC and any existing tracking issue.
-->

Closes #1215 .

# Rationale for this change

<!--
Explain why this change is needed. If the linked issue or RFC already explains the rationale clearly, a short summary is enough.
-->
`powercontext doctor` currently mixes core PowerContext checks with optional Codex integration checks. This causes the default doctor command to fail when Codex is not installed, even when PowerContext itself is healthy.

Server readiness also needs to reflect the availability of configured runtime dependencies, while keeping database and inference credentials within the Server process.

# What changes are included in this PR?

<!--
Summarize the important changes. Focus on behavior, API, docs, tests, and migration impact.
-->
- Split the doctor commands by responsibility:
  - `powercontext doctor` checks the installed package, Server liveness, and Server readiness.
  - `powercontext doctor codex` explicitly checks the Codex CLI and PowerContext plugin.
  - `powercontext setup codex` reuses the same Codex diagnostics after installation.
- Added explicit `ok`, `degraded`, `failed`, and `skipped` diagnostic states. JSON output includes `status` at the top level and for each check while preserving the existing `ok` field.
- Distinguished an unreachable Server from a live-but-not-ready Server.
- Preserved nested readiness details from expected HTTP 503 responses in both human-readable and JSON output.
- Added transport-independent Runtime readiness aggregation for:
  - Runtime availability.
  - Database connectivity using `SELECT 1`.
  - Configured generation and embedding providers.
- Added real inference canaries with:
  - A two-second timeout per dependency.
  - A 300-second cache for `ready` and `misconfigured` results, and a 30-second cache for `timeout` and `unavailable` results.
  - Single-flight protection for concurrent checks.
  - Stable and sanitized dependency statuses.
- Integrated Runtime readiness with the production Server factory, lifecycle events, and readiness metrics.
- Added startup readiness warm-up without making dependency failures terminate the Server.
- Updated English and Chinese documentation for the new doctor commands, health semantics, readiness statuses, and provider canary behavior.
- Added CLI, Runtime, Server, caching, security, and regression tests.

# Are there any user-facing changes?

<!--
If there are user-facing changes, documentation may need to be updated before approval.
If there are breaking changes to public APIs or persisted formats, call them out explicitly.
-->
Yes.

- The default `powercontext doctor` command no longer requires Codex or the PowerContext Codex plugin.
- Codex integration checks are now run explicitly with `powercontext doctor codex`.
- `powercontext doctor --json` now reports:
  - `package`
  - `server_liveness`
  - `server_readiness`
- The previous `server`, `codex`, and `plugin` keys are no longer emitted by the default doctor command. Scripts consuming the old JSON keys will need to be updated.
- Readiness failures now include safe, nested dependency details.
- `/health/ready` returns HTTP 503 with `not_ready` when the Runtime or database is unavailable. Configured inference failures return HTTP 200 with `degraded`.
- Inference readiness canaries run during startup. `ready` and `misconfigured` results are cached for 300 seconds; `timeout` and `unavailable` results are retried after 30 seconds. Concurrent checks share one refresh. Generation probes request at most one output token.

There are no persisted-format changes. The HTTP/OpenAPI contract adds the `degraded` readiness status. The `doctor` JSON key changes are described above and require consumers of the previous keys to update.

# How was this change tested?

<!--
List commands run, tests added or updated, and any manual validation performed.
-->
Automated validation:

- `make test`: 452 passed, 7 skipped.
- `make contract-test`: 24 passed.
- `make check`: passed.
- `make docs-test`: passed.
- `git diff --check`: passed.

Manual validation with real Server processes included:

- Verified that the default doctor succeeds without Codex when the Server is healthy.
- Verified that `doctor codex` fails correctly when the Codex CLI or plugin is missing.
- Verified that an unreachable Server skips readiness after liveness fails.
- Verified HTTP 200 for a healthy readiness response.
- Verified HTTP 503 with nested details for a live-but-not-ready Server.
- Verified generation readiness using an actual configured model adapter.
- Verified that an OpenAI-compatible provider returning HTTP 404 is reported as `misconfigured`, covering the #1189 regression.
- Verified that inference failures are cached and concurrent checks do not repeat provider canaries.
- Verified that API keys, provider URLs, database URLs, exception messages, and response bodies are not exposed in CLI output, health responses, or logs.
- Verified that the CLI does not load or use Server database and inference credentials.

# AI usage statement

<!--
If AI tools were used to build this PR, describe the tool and model where possible.
If not applicable, write `Not used`.
-->
