### PR TITLE
fix(scheduler): fail to create the parent directory for its SQLite job store

### DIFF
--- a/src/powercontext/builtin/runtime/scheduler.py
+++ b/src/powercontext/builtin/runtime/scheduler.py
@@ -103,7 +103,9 @@ def _processor(runtime_key: str, name: str) -> Processor:
 def create_scheduler(scheduler_path: str | Path) -> AsyncIOScheduler:
     """Create an APScheduler instance with an isolated SQLite job-store."""
 
-    url = URL.create("sqlite+pysqlite", database=scheduler_database_path(scheduler_path))
+    database = Path(scheduler_database_path(scheduler_path))
+    database.parent.mkdir(parents=True, exist_ok=True)
+    url = URL.create("sqlite+pysqlite", database=str(database))
     return AsyncIOScheduler(
         jobstores={
             "default": SQLAlchemyJobStore(

--- a/tests/builtin/runtime/test_scheduler.py
+++ b/tests/builtin/runtime/test_scheduler.py
@@ -109,6 +109,21 @@ def test_scheduler_persists_one_stable_source_window_job(tmp_path) -> None:
     asyncio.run(scenario())
 
 
+def test_scheduler_creates_missing_database_parent_directory(tmp_path) -> None:
+    async def scenario() -> None:
+        database = tmp_path / "missing" / "nested" / "scheduler.db"
+        assert not database.parent.exists()
+
+        runtime = _runtime(_ScheduledTriggers())
+        try:
+            runtime.start_scheduler(database, 3_600)
+            assert database.is_file()
+        finally:
+            await runtime.close()
+
+    asyncio.run(scenario())
+
+
 def test_scheduler_interval_activates_the_source_window_policy(tmp_path) -> None:
     async def scenario() -> None:
         triggers = _ScheduledTriggers()


### PR DESCRIPTION
# Which issue or RFC does this PR close?

<!--
Link the related issue or RFC using GitHub syntax.
For example, `Closes #123` indicates that this PR will close issue #123.
If this PR implements an RFC, link the RFC and any existing tracking issue.
-->

Closes #1221 .

# Rationale for this change

<!--
Explain why this change is needed. If the linked issue or RFC already explains the rationale clearly, a short summary is enough.
-->

When the scheduler database is located under a parent directory that does not yet exist, PowerContext passes the path directly to APScheduler's SQLite job store. Scheduler startup then fails with `sqlite3.OperationalError: unable to open database file`.

This is especially visible when using OceanBase with a fresh `POWERCONTEXT_HOME`, because the OceanBase backend does not create the local directory. The default SQLite backend previously masked the issue by creating the directory while initializing the main database.

The scheduler owns its SQLite sidecar database and should create the required parent directory independently of the main persistence backend.

# What changes are included in this PR?

<!--
Summarize the important changes. Focus on behavior, API, docs, tests, and migration impact.
-->

- Create the scheduler database parent directory before initializing the SQLite job store.
- Support missing nested parent directories using `mkdir(parents=True, exist_ok=True)`.
- Add a regression test covering scheduler startup with a previously nonexistent parent directory.
- Preserve the existing validation for unsupported paths such as `:memory:`.

# Are there any user-facing changes?

<!--
If there are user-facing changes, documentation may need to be updated before approval.
If there are breaking changes to public APIs or persisted formats, call them out explicitly.
-->

NONE

# How was this change tested?

<!--
List commands run, tests added or updated, and any manual validation performed.
-->

Added `test_scheduler_creates_missing_database_parent_directory`, which verifies that `BuiltinRuntime.start_scheduler()` creates nested parent directories and initializes the scheduler database.

Validation performed:

- `uv run pytest tests/builtin/runtime/test_scheduler.py -q` — 8 passed
- `make check` — passed
- `make test` — 434 passed, 7 skipped
- Manually started the Server against OceanBase CE 4.4.2.1 with scheduled processing enabled and a fresh `POWERCONTEXT_HOME`; the Server started successfully and created `scheduler.db`.

The regression test was also confirmed to fail before the fix with `sqlite3.OperationalError: unable to open database file`.

# AI usage statement

<!--
If AI tools were used to build this PR, describe the tool and model where possible.
If not applicable, write `Not used`.
-->
