### PR TITLE
chore(ci): Add CI flow for post-release verification

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -19,7 +19,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v10
+      uses: astral-sh/setup-uv@v10.0.0
       with:
         version: ${{ inputs.uv-version }}
         enable-cache: 'true'

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -14,12 +14,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v9.0.0
+      uses: astral-sh/setup-uv@v10
       with:
         version: ${{ inputs.uv-version }}
         enable-cache: 'true'

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -49,12 +49,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@v10
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -54,7 +54,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Resolve image metadata
         id: metadata

--- a/.github/workflows/e2e-harness.yml
+++ b/.github/workflows/e2e-harness.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10
 
       - name: Validate harness and Compose definitions
         run: |

--- a/.github/workflows/e2e-harness.yml
+++ b/.github/workflows/e2e-harness.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.0
 
       - name: Validate harness and Compose definitions
         run: |

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,185 @@
+name: Verify release
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Published PowerContext Release tag to verify
+        required: true
+        type: string
+      release_package:
+        description: Package contract to verify
+        required: false
+        default: powercontext
+        type: string
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Published Release tag to verify
+        required: true
+        type: string
+      release_package:
+        description: Package contract to verify; auto detects legacy PowerMem Releases
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - powercontext
+          - powermem
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out verification scripts
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Resolve release metadata
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_PACKAGE: ${{ inputs.release_package }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          import urllib.parse
+          import urllib.request
+
+          tag = os.environ["RELEASE_TAG"]
+          version = tag.removeprefix("v")
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version):
+              raise SystemExit("release_tag must use vX.Y.Z or X.Y.Z stable semantic versioning")
+
+          package = os.environ["RELEASE_PACKAGE"]
+          if package == "auto":
+              quoted_tag = urllib.parse.quote(tag, safe="")
+              request = urllib.request.Request(
+                  f"https://api.github.com/repos/{os.environ['REPOSITORY']}/releases/tags/{quoted_tag}",
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  release = json.load(response)
+              assets = {asset["name"] for asset in release.get("assets", [])}
+              candidates = [
+                  candidate
+                  for candidate in ("powercontext", "powermem")
+                  if f"{candidate}-{version}-py3-none-any.whl" in assets
+              ]
+              if len(candidates) != 1:
+                  raise SystemExit(
+                      "could not uniquely detect the package contract from Release wheel assets; "
+                      "select release_package explicitly"
+                  )
+              package = candidates[0]
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"package={package}\n")
+              output.write(f"version={version}\n")
+              output.write(f"wheel={package}-{version}-py3-none-any.whl\n")
+              output.write(f"sdist={package}-{version}.tar.gz\n")
+          PY
+
+      - name: Verify GitHub Release assets
+        id: github_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/ci_verify_github_release.py \
+            --repository "${{ github.repository }}" \
+            --tag "${{ inputs.release_tag }}" \
+            --expected-asset "${{ steps.release.outputs.wheel }}" \
+            --expected-asset "${{ steps.release.outputs.sdist }}"
+
+      - name: Verify public PyPI distributions
+        id: pypi
+        run: |
+          python scripts/ci_verify_pypi_release.py \
+            --package "${{ steps.release.outputs.package }}" \
+            --version "${{ steps.release.outputs.version }}"
+
+      - name: Create clean verification environment
+        run: python -m venv "$RUNNER_TEMP/powercontext-release-verify"
+
+      - name: Install PowerContext from public PyPI
+        id: install
+        env:
+          PACKAGE: ${{ steps.release.outputs.package }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          verification_python="$RUNNER_TEMP/powercontext-release-verify/bin/python"
+          "$verification_python" -m pip install --upgrade pip
+          if [ "$PACKAGE" = powercontext ]; then
+            requirement="powercontext[cli,server]==$VERSION"
+          else
+            requirement="powermem==$VERSION"
+          fi
+          "$verification_python" -m pip install \
+            --index-url https://pypi.org/simple \
+            --no-cache-dir \
+            "$requirement"
+          "$verification_python" -m pip check
+          "$verification_python" -c \
+            "from importlib.metadata import version; assert version('$PACKAGE') == '$VERSION'"
+
+      - name: Verify CLI entrypoints
+        id: cli
+        if: steps.release.outputs.package == 'powercontext'
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          verification_bin="$RUNNER_TEMP/powercontext-release-verify/bin"
+          test "$("$verification_bin/powercontext" --version)" = "$VERSION"
+          "$verification_bin/powercontext" --help
+          "$verification_bin/powercontext" server --help
+
+      - name: Run Server, MCP, and Memory smoke test
+        id: smoke
+        if: steps.release.outputs.package == 'powercontext'
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          "$RUNNER_TEMP/powercontext-release-verify/bin/python" \
+            scripts/ci_release_smoke.py \
+            --version "$VERSION"
+
+      - name: Summarize release health
+        if: always()
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          PACKAGE: ${{ steps.release.outputs.package }}
+          VERSION: ${{ steps.release.outputs.version }}
+          GITHUB_RELEASE: ${{ steps.github_release.outcome }}
+          PYPI: ${{ steps.pypi.outcome }}
+          INSTALL: ${{ steps.install.outcome }}
+          CLI: ${{ steps.cli.outcome }}
+          SMOKE: ${{ steps.smoke.outcome }}
+        run: |
+          {
+            echo "## Release health"
+            echo
+            echo "- Release tag: \`$RELEASE_TAG\`"
+            echo "- Package contract: \`$PACKAGE\`"
+            echo "- Version: \`$VERSION\`"
+            echo "- GitHub Release assets: **$GITHUB_RELEASE**"
+            echo "- PyPI distributions: **$PYPI**"
+            echo "- Clean install and dependency check: **$INSTALL**"
+            echo "- CLI entrypoints: **$CLI**"
+            echo "- Server, MCP, and Memory smoke: **$SMOKE**"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -64,6 +64,8 @@ jobs:
               raise SystemExit("release_tag must use vX.Y.Z or X.Y.Z stable semantic versioning")
 
           package = os.environ["RELEASE_PACKAGE"]
+          if package not in {"auto", "powercontext", "powermem"}:
+              raise SystemExit("release_package must be one of: auto, powercontext, powermem")
           if package == "auto":
               quoted_tag = urllib.parse.quote(tag, safe="")
               request = urllib.request.Request(

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -60,8 +60,8 @@ jobs:
 
           tag = os.environ["RELEASE_TAG"]
           version = tag.removeprefix("v")
-          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version):
-              raise SystemExit("release_tag must use vX.Y.Z or X.Y.Z stable semantic versioning")
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", version):
+              raise SystemExit("release_tag must use vX.Y.Z or X.Y.Z semantic versioning")
 
           package = os.environ["RELEASE_PACKAGE"]
           if package not in {"auto", "powercontext", "powermem"}:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,34 @@ jobs:
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+  release-assets:
+    runs-on: ubuntu-latest
+    needs: release-build
+    permissions:
+      contents: write
+    steps:
+      - name: Download release distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Upload GitHub Release assets
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: dist/*
+          fail_on_unmatched_files: true
+
+  release-verify:
+    needs: [pypi-publish, release-assets]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      release_tag: ${{ github.event.release.tag_name }}
+      release_package: powercontext
+
   deploy-docs:
     needs: pypi-publish
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
 
           release_tag = os.environ["RELEASE_TAG"]
           release_version = release_tag.removeprefix("v")
-          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", release_version):
-              raise SystemExit("Release tag must use vX.Y.Z or X.Y.Z semantic versioning")
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", release_version):
+              raise SystemExit("Release tag must use vX.Y.Z or X.Y.Z stable semantic versioning")
 
           pyproject_path = Path("pyproject.toml")
           pyproject_text = pyproject_path.read_text()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
 
           release_tag = os.environ["RELEASE_TAG"]
           release_version = release_tag.removeprefix("v")
-          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", release_version):
-              raise SystemExit("Release tag must use vX.Y.Z or X.Y.Z stable semantic versioning")
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", release_version):
+              raise SystemExit("Release tag must use vX.Y.Z or X.Y.Z semantic versioning")
 
           pyproject_path = Path("pyproject.toml")
           pyproject_text = pyproject_path.read_text()

--- a/scripts/ci_release_smoke.py
+++ b/scripts/ci_release_smoke.py
@@ -1,0 +1,156 @@
+"""Run a public-interface smoke test against an installed PowerContext release."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from importlib.metadata import version
+from pathlib import Path
+
+import httpx
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+from powercontext.client import PowerContextClient
+from powercontext.http import MemorySearchMode, RememberMemoryRequest, SearchMemoryRequest
+
+
+def _available_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _wait_until_ready(base_url: str, process: subprocess.Popen[str], timeout_seconds: float) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error = "Server did not respond"
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"PowerContext Server exited with status {process.returncode}")  # noqa: TRY003
+        try:
+            response = httpx.get(f"{base_url}/health/ready", timeout=2)
+            if response.status_code == 200 and response.json().get("status") in {"ready", "degraded"}:
+                return
+            last_error = f"readiness returned HTTP {response.status_code}: {response.text}"
+        except (httpx.HTTPError, ValueError) as error:
+            last_error = str(error)
+        time.sleep(0.25)
+    raise RuntimeError(f"PowerContext Server was not ready within {timeout_seconds:g} seconds: {last_error}")  # noqa: TRY003
+
+
+def _stop_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        process.send_signal(signal.CTRL_BREAK_EVENT)
+    else:
+        os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired as error:
+        if os.name == "nt":
+            taskkill = shutil.which("taskkill")
+            if taskkill is None:
+                raise RuntimeError(  # noqa: TRY003
+                    "Could not locate taskkill to stop the PowerContext Server"
+                ) from error
+            subprocess.run(  # noqa: S603 - exact child process tree created by this script
+                [taskkill, "/PID", str(process.pid), "/T", "/F"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        else:
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=10)
+
+
+async def _exercise_public_interfaces(base_url: str) -> None:
+    scope_id = "release-verification"
+    memory_text = "PowerContext release verification stores and retrieves this exact memory."
+    async with PowerContextClient(base_url) as client:
+        readiness = await client.get_readiness()
+        if readiness.status.value not in {"ready", "degraded"}:
+            raise RuntimeError(f"Unexpected readiness status: {readiness.status.value}")  # noqa: TRY003
+        remembered = await client.remember_memory(
+            RememberMemoryRequest(scope_id=scope_id, kind="fact", text=memory_text)
+        )
+        if remembered.entry is None or remembered.entry.text != memory_text:
+            raise RuntimeError("Remember operation did not return the stored Memory entry")  # noqa: TRY003
+        found = await client.search_memory(
+            SearchMemoryRequest(
+                scope_id=scope_id,
+                query="release verification retrieves",
+                mode=MemorySearchMode.FTS,
+            )
+        )
+        if [hit.text for hit in found.hits] != [memory_text]:
+            raise RuntimeError(f"Search did not return the expected Memory entry: {found.hits!r}")  # noqa: TRY003
+
+    async with Client(StreamableHttpTransport(f"{base_url}/mcp/")) as mcp:
+        tools = {tool.name for tool in await mcp.list_tools()}
+    required_tools = {"remember_memory", "search_memory"}
+    if missing := required_tools - tools:
+        raise RuntimeError(f"MCP endpoint is missing tools: {', '.join(sorted(missing))}")  # noqa: TRY003
+
+
+def run_smoke(expected_version: str, timeout_seconds: float) -> None:
+    installed_version = version("powercontext")
+    if installed_version != expected_version:
+        raise RuntimeError(  # noqa: TRY003
+            f"Installed PowerContext version mismatch: expected {expected_version}, received {installed_version}"
+        )
+
+    executable = shutil.which("powercontext")
+    if executable is None:
+        raise RuntimeError("The powercontext console script is not installed")  # noqa: TRY003
+
+    with tempfile.TemporaryDirectory(prefix="powercontext-release-") as temporary:
+        root = Path(temporary)
+        port = _available_port()
+        base_url = f"http://127.0.0.1:{port}"
+        log_path = root / "server.log"
+        environment = os.environ.copy()
+        environment["POWERCONTEXT_HOME"] = str(root / "home")
+        environment["POWERCONTEXT_SERVER_DATABASE_URL"] = f"sqlite+aiosqlite:///{root / 'runtime.db'}"
+        with log_path.open("w", encoding="utf-8") as log:
+            process = subprocess.Popen(  # noqa: S603 - resolved installed console script and fixed arguments
+                [executable, "server", "run", "--host", "127.0.0.1", "--port", str(port)],
+                cwd=root,
+                env=environment,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                text=True,
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0,
+                start_new_session=os.name != "nt",
+            )
+            try:
+                _wait_until_ready(base_url, process, timeout_seconds)
+                asyncio.run(_exercise_public_interfaces(base_url))
+            except BaseException:
+                log.flush()
+                print("PowerContext Server log:")
+                print(log_path.read_text(encoding="utf-8", errors="replace"))
+                raise
+            finally:
+                _stop_process(process)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--timeout-seconds", type=float, default=60)
+    args = parser.parse_args()
+    run_smoke(args.version, args.timeout_seconds)
+    print(f"Verified PowerContext {args.version} CLI, Server, MCP, and SQLite Memory search.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci_release_smoke.py
+++ b/scripts/ci_release_smoke.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 from importlib.metadata import version
@@ -26,6 +27,16 @@ def _available_port() -> int:
     with socket.socket() as listener:
         listener.bind(("127.0.0.1", 0))
         return int(listener.getsockname()[1])
+
+
+def _console_script(python_executable: str | Path) -> Path:
+    name = "powercontext.exe" if os.name == "nt" else "powercontext"
+    executable = Path(python_executable).resolve().with_name(name)
+    if not executable.is_file():
+        raise RuntimeError(  # noqa: TRY003 - diagnostics identify the exact verification environment
+            f"The powercontext console script is not installed next to {python_executable}"
+        )
+    return executable
 
 
 def _wait_until_ready(base_url: str, process: subprocess.Popen[str], timeout_seconds: float) -> None:
@@ -108,9 +119,7 @@ def run_smoke(expected_version: str, timeout_seconds: float) -> None:
             f"Installed PowerContext version mismatch: expected {expected_version}, received {installed_version}"
         )
 
-    executable = shutil.which("powercontext")
-    if executable is None:
-        raise RuntimeError("The powercontext console script is not installed")  # noqa: TRY003
+    executable = _console_script(sys.executable)
 
     with tempfile.TemporaryDirectory(prefix="powercontext-release-") as temporary:
         root = Path(temporary)

--- a/scripts/ci_release_smoke.py
+++ b/scripts/ci_release_smoke.py
@@ -31,7 +31,7 @@ def _available_port() -> int:
 
 def _console_script(python_executable: str | Path) -> Path:
     name = "powercontext.exe" if os.name == "nt" else "powercontext"
-    executable = Path(python_executable).resolve().with_name(name)
+    executable = Path(python_executable).with_name(name)
     if not executable.is_file():
         raise RuntimeError(  # noqa: TRY003 - diagnostics identify the exact verification environment
             f"The powercontext console script is not installed next to {python_executable}"

--- a/scripts/ci_verify_github_release.py
+++ b/scripts/ci_verify_github_release.py
@@ -49,9 +49,6 @@ def validate_release(metadata: dict[str, Any], tag: str, expected_assets: set[st
         )
     if metadata.get("draft") is not False:
         raise ReleaseVerificationError(f"GitHub Release {tag} is still a draft")  # noqa: TRY003
-    if metadata.get("prerelease") is not False:
-        raise ReleaseVerificationError(f"GitHub Release {tag} is marked as a prerelease")  # noqa: TRY003
-
     assets = metadata.get("assets")
     if not isinstance(assets, list):
         raise ReleaseVerificationError(f"GitHub Release {tag} returned no asset list")  # noqa: TRY003

--- a/scripts/ci_verify_github_release.py
+++ b/scripts/ci_verify_github_release.py
@@ -1,0 +1,86 @@
+"""Verify GitHub Release state and required PowerContext assets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+class ReleaseVerificationError(RuntimeError):
+    """Report an invalid GitHub Release or missing asset."""
+
+
+def fetch_release(repository: str, tag: str, token: str | None = None) -> dict[str, Any]:
+    """Read one GitHub Release by tag."""
+
+    quoted_tag = urllib.parse.quote(tag, safe="")
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/releases/tags/{quoted_tag}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            **({"Authorization": f"Bearer {token}"} if token else {}),
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed GitHub API origin
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics include the exact Release
+            f"GitHub returned HTTP {error.code} for Release {repository}@{tag}"
+        ) from error
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics include the upstream failure
+            f"Could not read GitHub Release {repository}@{tag}: {error}"
+        ) from error
+
+
+def validate_release(metadata: dict[str, Any], tag: str, expected_assets: set[str]) -> tuple[str, ...]:
+    """Validate Release identity, publication state, and exact required assets."""
+
+    if metadata.get("tag_name") != tag:
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics include expected and actual tags
+            f"GitHub Release tag mismatch: expected {tag}, received {metadata.get('tag_name')!r}"
+        )
+    if metadata.get("draft") is not False:
+        raise ReleaseVerificationError(f"GitHub Release {tag} is still a draft")  # noqa: TRY003
+    if metadata.get("prerelease") is not False:
+        raise ReleaseVerificationError(f"GitHub Release {tag} is marked as a prerelease")  # noqa: TRY003
+
+    assets = metadata.get("assets")
+    if not isinstance(assets, list):
+        raise ReleaseVerificationError(f"GitHub Release {tag} returned no asset list")  # noqa: TRY003
+    asset_names = {str(item["name"]) for item in assets if isinstance(item, dict) and "name" in item}
+    missing = sorted(expected_assets - asset_names)
+    if missing:
+        available = ", ".join(sorted(asset_names)) or "none"
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics enumerate missing assets
+            f"GitHub Release {tag} is missing assets: {', '.join(missing)}; available: {available}"
+        )
+    return tuple(sorted(asset_names))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--expected-asset", action="append", required=True)
+    args = parser.parse_args()
+
+    try:
+        metadata = fetch_release(args.repository, args.tag, os.environ.get("GITHUB_TOKEN"))
+        assets = validate_release(metadata, args.tag, set(args.expected_asset))
+    except ReleaseVerificationError as error:
+        raise SystemExit(str(error)) from error
+    print(f"Verified GitHub Release {args.repository}@{args.tag}:")
+    for asset in assets:
+        print(f"- {asset}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci_verify_pypi_release.py
+++ b/scripts/ci_verify_pypi_release.py
@@ -1,0 +1,119 @@
+"""Verify that one PowerContext release is available from the public PyPI API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+PYPI_RELEASE_URL = "https://pypi.org/pypi/{package}/{version}/json"
+REQUIRED_PACKAGE_TYPES = frozenset({"bdist_wheel", "sdist"})
+
+
+class ReleaseVerificationError(RuntimeError):
+    """Report an unavailable or incomplete published package."""
+
+
+def fetch_release(package: str, version: str) -> dict[str, Any]:
+    """Read one exact release from PyPI."""
+
+    url = PYPI_RELEASE_URL.format(package=package, version=version)
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310 - fixed PyPI origin
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics include the exact release
+            f"PyPI returned HTTP {error.code} for {package}=={version}"
+        ) from error
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics include the upstream failure
+            f"Could not read PyPI metadata for {package}=={version}: {error}"
+        ) from error
+
+
+def validate_release(metadata: dict[str, Any], package: str, version: str) -> tuple[str, ...]:
+    """Validate version metadata and required distribution types."""
+
+    published_version = metadata.get("info", {}).get("version")
+    if published_version != version:
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics include expected and actual versions
+            f"PyPI metadata version mismatch for {package}: expected {version}, received {published_version!r}"
+        )
+
+    files = metadata.get("urls")
+    if not isinstance(files, list):
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics include the exact release
+            f"PyPI returned no distribution list for {package}=={version}"
+        )
+    package_types = {item.get("packagetype") for item in files if isinstance(item, dict)}
+    missing = sorted(REQUIRED_PACKAGE_TYPES - package_types)
+    if missing:
+        available = ", ".join(sorted(value for value in package_types if isinstance(value, str))) or "none"
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics enumerate missing distributions
+            f"PyPI release {package}=={version} is missing distribution types: {', '.join(missing)}; "
+            f"available: {available}"
+        )
+
+    filenames = tuple(sorted(str(item["filename"]) for item in files if isinstance(item, dict) and "filename" in item))
+    if not filenames:
+        raise ReleaseVerificationError(  # noqa: TRY003 - command diagnostics include the exact release
+            f"PyPI returned no distribution filenames for {package}=={version}"
+        )
+    return filenames
+
+
+def verify_with_retry(
+    package: str,
+    version: str,
+    *,
+    attempts: int,
+    delay_seconds: float,
+    fetch: Callable[[str, str], dict[str, Any]] = fetch_release,
+) -> tuple[str, ...]:
+    """Retry verification while PyPI propagates a newly published release."""
+
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")  # noqa: TRY003
+    last_error: ReleaseVerificationError | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return validate_release(fetch(package, version), package, version)
+        except ReleaseVerificationError as error:
+            last_error = error
+            if attempt == attempts:
+                break
+            print(f"Attempt {attempt}/{attempts} failed: {error}. Retrying in {delay_seconds:g} seconds.")
+            time.sleep(delay_seconds)
+    if last_error is None:
+        raise RuntimeError("verification retry loop completed without a result")  # noqa: TRY003
+    raise last_error
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package", default="powercontext")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--attempts", type=int, default=20)
+    parser.add_argument("--delay-seconds", type=float, default=15)
+    args = parser.parse_args()
+
+    try:
+        filenames = verify_with_retry(
+            args.package,
+            args.version,
+            attempts=args.attempts,
+            delay_seconds=args.delay_seconds,
+        )
+    except ReleaseVerificationError as error:
+        raise SystemExit(str(error)) from error
+    print(f"Verified PyPI release {args.package}=={args.version}:")
+    for filename in filenames:
+        print(f"- {filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ci_release_verification.py
+++ b/tests/test_ci_release_verification.py
@@ -21,16 +21,18 @@ pypi = _load_script("ci_verify_pypi_release")
 smoke = _load_script("ci_release_smoke")
 
 
-def test_release_smoke_resolves_console_script_from_verification_python(tmp_path, monkeypatch) -> None:
-    scripts = tmp_path / "verification" / ("Scripts" if smoke.os.name == "nt" else "bin")
+@pytest.mark.skipif(smoke.os.name == "nt", reason="POSIX venv symlink regression")
+def test_release_smoke_resolves_console_script_from_verification_python(tmp_path) -> None:
+    scripts = tmp_path / "verification" / "bin"
     scripts.mkdir(parents=True)
-    python = scripts / ("python.exe" if smoke.os.name == "nt" else "python")
-    console_script = scripts / ("powercontext.exe" if smoke.os.name == "nt" else "powercontext")
-    python.touch()
+    base_python = tmp_path / "base-python"
+    base_python.touch()
+    python = scripts / "python"
+    python.symlink_to(base_python)
+    console_script = scripts / "powercontext"
     console_script.touch()
-    monkeypatch.setenv("PATH", str(tmp_path / "ambient-install"))
 
-    assert smoke._console_script(python) == console_script.resolve()
+    assert smoke._console_script(python) == console_script
 
 
 def test_pypi_release_requires_wheel_and_sdist() -> None:

--- a/tests/test_ci_release_verification.py
+++ b/tests/test_ci_release_verification.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_script(name: str) -> ModuleType:
+    path = Path(__file__).parents[1] / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+github = _load_script("ci_verify_github_release")
+pypi = _load_script("ci_verify_pypi_release")
+
+
+def test_pypi_release_requires_wheel_and_sdist() -> None:
+    metadata = {
+        "info": {"version": "1.2.3"},
+        "urls": [
+            {"packagetype": "bdist_wheel", "filename": "powercontext-1.2.3-py3-none-any.whl"},
+            {"packagetype": "sdist", "filename": "powercontext-1.2.3.tar.gz"},
+        ],
+    }
+
+    assert pypi.validate_release(metadata, "powercontext", "1.2.3") == (
+        "powercontext-1.2.3-py3-none-any.whl",
+        "powercontext-1.2.3.tar.gz",
+    )
+
+    metadata["urls"].pop()
+    with pytest.raises(pypi.ReleaseVerificationError, match="missing distribution types: sdist"):
+        pypi.validate_release(metadata, "powercontext", "1.2.3")
+
+
+def test_pypi_verification_retries_until_release_is_complete(monkeypatch) -> None:
+    responses = iter([
+        {"info": {"version": "1.2.3"}, "urls": []},
+        {
+            "info": {"version": "1.2.3"},
+            "urls": [
+                {"packagetype": "bdist_wheel", "filename": "powercontext-1.2.3-py3-none-any.whl"},
+                {"packagetype": "sdist", "filename": "powercontext-1.2.3.tar.gz"},
+            ],
+        },
+    ])
+    monkeypatch.setattr(pypi.time, "sleep", lambda _: None)
+
+    files = pypi.verify_with_retry(
+        "powercontext",
+        "1.2.3",
+        attempts=2,
+        delay_seconds=0,
+        fetch=lambda _package, _version: next(responses),
+    )
+
+    assert len(files) == 2
+
+
+def test_github_release_requires_published_state_and_expected_assets() -> None:
+    metadata = {
+        "tag_name": "v1.2.3",
+        "draft": False,
+        "prerelease": False,
+        "assets": [
+            {"name": "powercontext-1.2.3-py3-none-any.whl"},
+            {"name": "powercontext-1.2.3.tar.gz"},
+        ],
+    }
+    expected = {"powercontext-1.2.3-py3-none-any.whl", "powercontext-1.2.3.tar.gz"}
+
+    assert set(github.validate_release(metadata, "v1.2.3", expected)) == expected
+
+    metadata["assets"].pop()
+    with pytest.raises(github.ReleaseVerificationError, match=r"missing assets: powercontext-1\.2\.3\.tar\.gz"):
+        github.validate_release(metadata, "v1.2.3", expected)

--- a/tests/test_ci_release_verification.py
+++ b/tests/test_ci_release_verification.py
@@ -95,3 +95,21 @@ def test_github_release_requires_published_state_and_expected_assets() -> None:
     metadata["assets"].pop()
     with pytest.raises(github.ReleaseVerificationError, match=r"missing assets: powercontext-1\.2\.3\.tar\.gz"):
         github.validate_release(metadata, "v1.2.3", expected)
+
+
+def test_github_release_allows_prereleases() -> None:
+    metadata = {
+        "tag_name": "v1.2.3-rc.1",
+        "draft": False,
+        "prerelease": True,
+        "assets": [
+            {"name": "powercontext-1.2.3-rc.1-py3-none-any.whl"},
+            {"name": "powercontext-1.2.3-rc.1.tar.gz"},
+        ],
+    }
+
+    assert github.validate_release(
+        metadata,
+        "v1.2.3-rc.1",
+        {"powercontext-1.2.3-rc.1-py3-none-any.whl", "powercontext-1.2.3-rc.1.tar.gz"},
+    )

--- a/tests/test_ci_release_verification.py
+++ b/tests/test_ci_release_verification.py
@@ -18,6 +18,19 @@ def _load_script(name: str) -> ModuleType:
 
 github = _load_script("ci_verify_github_release")
 pypi = _load_script("ci_verify_pypi_release")
+smoke = _load_script("ci_release_smoke")
+
+
+def test_release_smoke_resolves_console_script_from_verification_python(tmp_path, monkeypatch) -> None:
+    scripts = tmp_path / "verification" / ("Scripts" if smoke.os.name == "nt" else "bin")
+    scripts.mkdir(parents=True)
+    python = scripts / ("python.exe" if smoke.os.name == "nt" else "python")
+    console_script = scripts / ("powercontext.exe" if smoke.os.name == "nt" else "powercontext")
+    python.touch()
+    console_script.touch()
+    monkeypatch.setenv("PATH", str(tmp_path / "ambient-install"))
+
+    assert smoke._console_script(python) == console_script.resolve()
 
 
 def test_pypi_release_requires_wheel_and_sdist() -> None:


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1121.

# Rationale for this change

Release verification previously required manual checks across GitHub Release assets, PyPI availability, clean installation, entrypoints, and basic runtime behavior. This made missing distributions and broken published packages difficult to detect immediately.

This PR adds repeatable post-release verification for the current PowerContext release contract. It also supports manually checking existing PowerMem releases so historical releases can be verified without failing due to package-name differences.

# What changes are included in this PR?

- Add a reusable and manually dispatchable `Verify release` workflow.
- Publish PowerContext wheel and source distributions as GitHub Release assets using `softprops/action-gh-release`.
- Run release verification after both PyPI publication and GitHub Release asset upload succeed.
- Verify that the expected wheel and source distribution exist on GitHub Releases.
- Verify that the expected wheel and source distribution are available on PyPI.
- Retry PyPI verification to account for publication propagation delays.
- Install the released package from public PyPI in a clean virtual environment.
- Run `pip check` and verify the installed package version.
- Verify the PowerContext CLI and Server entrypoints.
- Start a real PowerContext Server backed by a temporary SQLite database.
- Verify Server readiness and the Streamable HTTP MCP endpoint.
- Run a Memory write and FTS search smoke test through the public SDK.
- Produce a concise release health summary in GitHub Actions.
- Support manually verifying existing releases with package selection:
  - `auto`
  - `powercontext`
  - `powermem`
- Automatically detect legacy PowerMem releases from their GitHub Release wheel assets when `release_package=auto`.
- Skip PowerContext-specific CLI, Server, MCP, and Memory smoke tests for PowerMem releases.
- Update GitHub Actions dependencies to their latest available release tags.
- Add focused tests for release metadata validation, missing distributions, missing assets, and PyPI retry behavior.

# Are there any user-facing changes?

no

# How was this change tested?

The following repository checks were run locally:

```bash
uv lock --locked
uv run prek run -a
uv run ty check
uv run python -m pytest \
  tests/test_ci_release_verification.py \
  tests/test_cli.py \
  tests/e2e/test_server_cli.py \
  tests/e2e/test_mcp_transport.py
```

The following checks passed:

- Dependency lock consistency.
- All repository pre-commit hooks.
- Ruff linting and formatting.
- Static type checking with `ty`.
- 29 focused release, CLI, Server, and MCP tests.
- Workflow YAML validation.
- Git diff validation.

The local PowerContext smoke test was also run:

```bash
$version = uv run python -c "from importlib.metadata import version; print(version('powercontext'))"
uv run python scripts/ci_release_smoke.py \
  --version $version \
  --timeout-seconds 30
```

This successfully verified:

- Installed PowerContext version.
- CLI availability.
- Server startup.
- Server readiness.
- SQLite database initialization.
- Memory write through the public SDK.
- FTS Memory search.
- MCP endpoint startup.
- MCP tool discovery.
- Server process cleanup.

The PowerMem compatibility path was tested against the existing public `v1.1.7` release:

```bash
uv run python scripts/ci_verify_github_release.py \
  --repository oceanbase/powercontext \
  --tag v1.1.7 \
  --expected-asset powermem-1.1.7-py3-none-any.whl \
  --expected-asset powermem-1.1.7.tar.gz

uv run python scripts/ci_verify_pypi_release.py \
  --package powermem \
  --version 1.1.7 \
  --attempts 1
```

Both GitHub Release and PyPI verification passed.

`powermem==1.1.7` was also installed from the public PyPI index into a clean Python 3.12 virtual environment. The package version check and `pip check` passed for all installed dependencies.

## CI verification workflow

The `Verify release` workflow can be triggered in two ways.

### Automatic trigger

The main `Release` workflow runs when a GitHub Release is published:

```yaml
on:
  release:
    types: [published]
```

The release flow is:

```text
Release published
    |
    v
Build PowerContext wheel and sdist
    |
    +--> Publish distributions to PyPI
    |
    +--> Upload distributions to GitHub Release
              |
              v
       Verify release
```

The verification job starts only after both of these jobs succeed:

- `pypi-publish`
- `release-assets`

For an automated PowerContext release, the workflow explicitly uses:

```yaml
release_package: powercontext
```

The CI verification then checks:

- GitHub Release state and assets.
- PyPI package availability.
- Clean installation from public PyPI.
- Dependency consistency with `pip check`.
- Package version metadata.
- PowerContext CLI entrypoints.
- Server readiness.
- MCP endpoint and tools.
- SQLite Memory write and FTS search.

### Manual trigger

The workflow can be run from GitHub:

1. Open the repository on GitHub.
2. Go to **Actions**.
3. Select **Verify release**.
4. Click **Run workflow**.
5. Select the branch containing the verification workflow.
6. Enter the published release tag, for example `v1.1.7`.
7. Select the package contract:
   - `auto`
   - `powercontext`
   - `powermem`
8. Start the workflow.

For old PowerMem releases, use:

```text
release_tag: v1.1.7
release_package: powermem
```

For current PowerContext releases, use:

```text
release_tag: vX.Y.Z
release_package: powercontext
```

The `auto` option detects the package contract from the GitHub Release wheel asset. It recognizes:

```text
powercontext-X.Y.Z-py3-none-any.whl
powermem-X.Y.Z-py3-none-any.whl
```

If the package cannot be uniquely detected, the workflow fails with a message asking for an explicit package selection.

The workflow can also be triggered with GitHub CLI:

```bash
gh workflow run release-verify.yml \
  --repo oceanbase/powercontext \
  --ref master \
  -f release_tag=v1.1.7 \
  -f release_package=auto
```

To list the latest verification run:

```bash
gh run list \
  --repo oceanbase/powercontext \
  --workflow release-verify.yml \
  --limit 1
```

To wait for the workflow result:

```bash
gh run watch <run-id> \
  --repo oceanbase/powercontext \
  --exit-status
```

# AI usage statement

Coworked with OpenAI Codex.