### PR TITLE
fix(memory): prevent stale-head search misses during concurrent append

### DIFF
--- a/openapi/powercontext.yaml
+++ b/openapi/powercontext.yaml
@@ -369,6 +369,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SearchMemoryResponse"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "422":

--- a/src/powercontext/builtin/persistence/memory.py
+++ b/src/powercontext/builtin/persistence/memory.py
@@ -271,13 +271,34 @@ class RelationalMemoryBackend:
             return await self._index.vector_complete(connection, self._scope_id, memories, profile)
 
     async def search(self, request: MemorySearchRequest, /) -> MemorySearchChannels:
-        for memory in request.memories:
-            exact = await self.get(memory)
-            latest = await self.latest(memory.artifact_id)
+        async with self._database.connection(self._bound_connection) as connection:
+            await self._validate_search_heads(connection, request.memories)
+            channels = await self._index.search(connection, self._scope_id, request)
+            await self._validate_search_heads(connection, request.memories)
+        return channels
+
+    async def _validate_search_heads(
+        self,
+        connection: AsyncConnection,
+        memories: tuple[ArtifactRef, ...],
+    ) -> None:
+        """Reject a projection read when any requested head has advanced."""
+
+        for memory in memories:
+            try:
+                exact = _require_memory(await self._artifacts.get(connection, self._scope_id, memory))
+                latest = _require_memory(
+                    await self._artifacts.latest(
+                        connection,
+                        self._scope_id,
+                        Memory.family,
+                        memory.artifact_id,
+                    )
+                )
+            except RepositoryNotFoundError:
+                raise ArtifactNotFoundError(memory) from None
             if exact.as_ref() != latest.as_ref():
                 raise InvalidMemoryCitationError("memory-mismatch")
-        async with self._database.connection(self._bound_connection) as connection:
-            return await self._index.search(connection, self._scope_id, request)
 
     async def expand(self, hits: tuple[MemoryHit, ...], /) -> tuple[MemoryEntryVersion, ...]:
         expanded: list[MemoryEntryVersion] = []

--- a/src/powercontext/builtin/runtime/application.py
+++ b/src/powercontext/builtin/runtime/application.py
@@ -680,21 +680,12 @@ class ScopedMemoryApplication:
                     attempt += 1
                     continue
 
-                # Reranking may await model I/O, so verify optimistically instead
-                # of serializing the complete search under the scope write lock.
-                latest = await _head_or_none(service, context.artifacts.memory_artifact_id)
-                if latest is not None and latest.as_ref() == current.as_ref():
-                    return MemorySearchPage(
-                        memory_ref=current.as_ref(),
-                        mode=result.mode,
-                        hits=result.hits,
-                        rerank=result.rerank,
-                    )
-                if latest is None:
-                    raise ArtifactNotFoundError(current.as_ref())
-                if attempt == _MEMORY_SEARCH_ATTEMPTS:
-                    raise RevisionConflictError(current, latest)
-                attempt += 1
+                return MemorySearchPage(
+                    memory_ref=current.as_ref(),
+                    mode=result.mode,
+                    hits=result.hits,
+                    rerank=result.rerank,
+                )
 
     async def list(self, *, include_inactive: bool = False) -> MemoryEntriesPage:
         async with self._runtime._context(self.scope_id) as context:

--- a/src/powercontext/builtin/runtime/application.py
+++ b/src/powercontext/builtin/runtime/application.py
@@ -36,7 +36,11 @@ from powercontext.builtin.artifacts.memory import (
     MemoryEntryVersion,
     MemoryService,
 )
-from powercontext.builtin.artifacts.memory.errors import MemoryEntryNotFoundError
+from powercontext.builtin.artifacts.memory.errors import (
+    CapabilityNotSupportedError,
+    InvalidMemoryCitationError,
+    MemoryEntryNotFoundError,
+)
 from powercontext.builtin.artifacts.skill import (
     ExternalSkillRegistryUnavailableError,
     ExternalSkillResolution,
@@ -127,6 +131,7 @@ ExperienceRecall = Callable[[str, str, int], Awaitable[tuple[ExperienceSearchHit
 StatisticsServiceFactory = Callable[[str], RelationalScopedStatistics]
 RecallTokenEstimator = Callable[[str, PreparedContextBuild], Awaitable[RecallTokenMeasurement | None]]
 Clock = Callable[[], datetime]
+_MEMORY_SEARCH_ATTEMPTS = 3
 
 
 class _RuntimeConfigurationError(ValueError):
@@ -654,21 +659,42 @@ class ScopedMemoryApplication:
             embedding_purpose=ModelUsagePurpose.MEMORY_RECALL,
         ) as context:
             service = context.artifacts.memory
-            current = await _head_or_none(service, context.artifacts.memory_artifact_id)
-            if current is None:
-                return MemorySearchPage(memory_ref=None, mode=None)
-            result = await service.search(
-                request.query,
-                memories=(current,),
-                limit=request.limit,
-                mode=request.mode,
-            )
-            return MemorySearchPage(
-                memory_ref=current.as_ref(),
-                mode=result.mode,
-                hits=result.hits,
-                rerank=result.rerank,
-            )
+            attempt = 1
+            while True:
+                current = await _head_or_none(service, context.artifacts.memory_artifact_id)
+                if current is None:
+                    return MemorySearchPage(memory_ref=None, mode=None)
+                try:
+                    result = await service.search(
+                        request.query,
+                        memories=(current,),
+                        limit=request.limit,
+                        mode=request.mode,
+                    )
+                except (CapabilityNotSupportedError, InvalidMemoryCitationError) as error:
+                    latest = await _head_or_none(service, context.artifacts.memory_artifact_id)
+                    if not _is_stale_memory_search(error) or latest is None or latest.as_ref() == current.as_ref():
+                        raise
+                    if attempt == _MEMORY_SEARCH_ATTEMPTS:
+                        raise RevisionConflictError(current, latest) from error
+                    attempt += 1
+                    continue
+
+                # Reranking may await model I/O, so verify optimistically instead
+                # of serializing the complete search under the scope write lock.
+                latest = await _head_or_none(service, context.artifacts.memory_artifact_id)
+                if latest is not None and latest.as_ref() == current.as_ref():
+                    return MemorySearchPage(
+                        memory_ref=current.as_ref(),
+                        mode=result.mode,
+                        hits=result.hits,
+                        rerank=result.rerank,
+                    )
+                if latest is None:
+                    raise ArtifactNotFoundError(current.as_ref())
+                if attempt == _MEMORY_SEARCH_ATTEMPTS:
+                    raise RevisionConflictError(current, latest)
+                attempt += 1
 
     async def list(self, *, include_inactive: bool = False) -> MemoryEntriesPage:
         async with self._runtime._context(self.scope_id) as context:
@@ -1144,6 +1170,12 @@ async def _head_or_none(service: MemoryService, artifact_id: str) -> Memory | No
         return await service.head(artifact_id)
     except ArtifactNotFoundError:
         return None
+
+
+def _is_stale_memory_search(error: CapabilityNotSupportedError | InvalidMemoryCitationError) -> bool:
+    return (isinstance(error, CapabilityNotSupportedError) and error.capability == "head") or (
+        isinstance(error, InvalidMemoryCitationError) and error.code == "memory-mismatch"
+    )
 
 
 def _validate_expected_revision(memory: Memory | None, expected_revision: int | None) -> None:

--- a/src/powercontext/http/_generated/operations.py
+++ b/src/powercontext/http/_generated/operations.py
@@ -390,6 +390,7 @@ SEARCH_MEMORY = Operation[SearchMemoryRequest, SearchMemoryResponse](
             "description": "Matching Memory entries, or an empty result when the scope has no Memory.",
             "headers": {"X-PowerContext-Request-ID": {"$ref": "#/components/headers/RequestId"}},
         },
+        409: {"$ref": "#/components/responses/Conflict"},
         401: {"$ref": "#/components/responses/Unauthorized"},
         422: {"$ref": "#/components/responses/InvalidRequest"},
         503: {"$ref": "#/components/responses/Unavailable"},

--- a/src/powercontext/http/_generated/schema.py
+++ b/src/powercontext/http/_generated/schema.py
@@ -317,6 +317,7 @@ OPENAPI_SCHEMA: dict[str, JsonValue] = {
                             "application/json": {"schema": {"$ref": "#/components/schemas/SearchMemoryResponse"}}
                         },
                     },
+                    "409": {"$ref": "#/components/responses/Conflict"},
                     "401": {"$ref": "#/components/responses/Unauthorized"},
                     "422": {"$ref": "#/components/responses/InvalidRequest"},
                     "503": {"$ref": "#/components/responses/Unavailable"},

--- a/tests/e2e/test_memory_search_concurrency.py
+++ b/tests/e2e/test_memory_search_concurrency.py
@@ -11,8 +11,14 @@ from uuid import uuid4
 import pytest
 from pydantic import SecretStr
 
-from powercontext.builtin.artifacts.memory import EmbeddingProfile, MemoryEntryInput, MemorySearchMode
-from powercontext.builtin.inference import EmbeddingResult
+from powercontext.builtin.artifacts.memory import (
+    EmbeddingProfile,
+    MemoryEntryInput,
+    MemoryHit,
+    MemoryRerankDecision,
+    MemorySearchMode,
+)
+from powercontext.builtin.inference import EmbeddingResult, InferenceUsage
 from powercontext.builtin.persistence.oceanbase import OceanBaseConfig
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.builtin.runtime import (
@@ -21,6 +27,7 @@ from powercontext.builtin.runtime import (
     SearchMemoryRequest,
     open_builtin_runtime,
 )
+from powercontext.errors import RevisionConflictError
 
 DatabaseKind = Literal["sqlite", "oceanbase"]
 TIMEOUT_SECONDS = 15
@@ -46,6 +53,28 @@ class _KeywordEmbeddingModel:
         return EmbeddingResult(vectors=vectors)
 
 
+class _PausingReranker:
+    policy_id = "test.concurrent-memory-search.v1"
+
+    def __init__(self) -> None:
+        self.paused = asyncio.Event()
+        self.resume = asyncio.Event()
+
+    async def rerank(
+        self,
+        _query: str,
+        candidates: tuple[MemoryHit, ...],
+        _limit: int,
+        /,
+    ) -> MemoryRerankDecision:
+        self.paused.set()
+        await self.resume.wait()
+        return MemoryRerankDecision(
+            selected_ranks=(1,),
+            usage=InferenceUsage(requests=1),
+        )
+
+
 @pytest.mark.parametrize("database_kind", ["sqlite", "oceanbase"])
 @pytest.mark.parametrize("mode", ["fts", "vector", "hybrid"])
 def test_memory_search_stays_consistent_when_append_advances_head_before_index_query(
@@ -61,7 +90,7 @@ def test_memory_search_stays_consistent_when_append_advances_head_before_index_q
             embedding_model=embedding_model,
         ) as runtime:
             memory = runtime.memory.for_scope(f"concurrent-memory-search-{uuid4()}")
-            await memory.remember(
+            initial = await memory.remember(
                 RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text="Stable searchable fact."),))
             )
 
@@ -100,10 +129,86 @@ def test_memory_search_stays_consistent_when_append_advances_head_before_index_q
                     with suppress(asyncio.CancelledError):
                         await pending
 
-            assert result.memory_ref == new_head.memory_ref
+            assert result.memory_ref in (initial.memory_ref, new_head.memory_ref)
             assert result.mode == mode
             assert tuple(hit.text for hit in result.hits) == ("Stable searchable fact.",)
+            assert result.hits[0].memory_ref == result.memory_ref
             assert result.hits[0].matched_by == EXPECTED_CHANNELS[mode]
+
+    asyncio.run(scenario())
+
+
+def test_memory_search_keeps_the_completed_revision_snapshot_when_head_advances_during_reranking(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        reranker = _PausingReranker()
+        database = SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'rerank-snapshot.db'}")
+        async with open_builtin_runtime(BuiltinConfig(database=database), memory_reranker=reranker) as runtime:
+            memory = runtime.memory.for_scope("rerank-snapshot")
+            initial = await memory.remember(
+                RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text="Stable searchable fact."),))
+            )
+            pending = asyncio.create_task(
+                memory.search(SearchMemoryRequest(query="stable searchable", mode="fts", limit=1))
+            )
+            try:
+                await asyncio.wait_for(reranker.paused.wait(), timeout=TIMEOUT_SECONDS)
+                new_head = await memory.remember(
+                    RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text="Unrelated appended fact."),))
+                )
+                reranker.resume.set()
+                result = await asyncio.wait_for(pending, timeout=TIMEOUT_SECONDS)
+            finally:
+                reranker.resume.set()
+                if not pending.done():
+                    pending.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await pending
+
+            assert new_head.memory_ref.revision == initial.memory_ref.revision + 1
+            assert result.memory_ref == initial.memory_ref
+            assert tuple(hit.text for hit in result.hits) == ("Stable searchable fact.",)
+            assert result.hits[0].memory_ref == initial.memory_ref
+            assert result.rerank is not None
+
+    asyncio.run(scenario())
+
+
+def test_memory_search_reports_revision_conflict_when_every_attempt_starts_from_a_stale_head() -> None:
+    async def scenario() -> None:
+        async with open_builtin_runtime(BuiltinConfig(database=SQLiteConfig())) as runtime:
+            scope_id = "perpetually-stale-search"
+            memory = runtime.memory.for_scope(scope_id)
+            await memory.remember(
+                RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text="Stable searchable fact."),))
+            )
+
+            provider: Any = runtime._provider
+            context = await provider.get(scope_id)
+            service = context.artifacts.memory
+            original_search = service.search
+            update_number = 0
+
+            async def advance_head_before_search(_self: Any, *args: Any, **kwargs: Any) -> Any:
+                nonlocal update_number
+                update_number += 1
+                await memory.remember(
+                    RememberMemoryRequest(
+                        entries=(MemoryEntryInput(kind="fact", text=f"Concurrent update {update_number}."),)
+                    )
+                )
+                return await original_search(*args, **kwargs)
+
+            service.search = MethodType(advance_head_before_search, service)
+            try:
+                with pytest.raises(RevisionConflictError):
+                    await asyncio.wait_for(
+                        memory.search(SearchMemoryRequest(query="stable searchable", mode="fts")),
+                        timeout=TIMEOUT_SECONDS,
+                    )
+            finally:
+                service.search = original_search
 
     asyncio.run(scenario())
 

--- a/tests/e2e/test_memory_search_concurrency.py
+++ b/tests/e2e/test_memory_search_concurrency.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import suppress
+from pathlib import Path
+from types import MethodType
+from typing import Any, Literal
+from uuid import uuid4
+
+import pytest
+from pydantic import SecretStr
+
+from powercontext.builtin.artifacts.memory import EmbeddingProfile, MemoryEntryInput, MemorySearchMode
+from powercontext.builtin.inference import EmbeddingResult
+from powercontext.builtin.persistence.oceanbase import OceanBaseConfig
+from powercontext.builtin.persistence.sqlite import SQLiteConfig
+from powercontext.builtin.runtime import (
+    BuiltinConfig,
+    RememberMemoryRequest,
+    SearchMemoryRequest,
+    open_builtin_runtime,
+)
+
+DatabaseKind = Literal["sqlite", "oceanbase"]
+TIMEOUT_SECONDS = 15
+PROFILE = EmbeddingProfile(
+    profile_id="concurrent-search-test-v1",
+    model="test",
+    dimension=3,
+    distance="l2",
+    normalization="unit",
+)
+EXPECTED_CHANNELS = {
+    "fts": ("fts",),
+    "vector": ("vector",),
+    "hybrid": ("fts", "vector"),
+}
+
+
+class _KeywordEmbeddingModel:
+    profile = PROFILE
+
+    async def embed(self, texts: tuple[str, ...], /) -> EmbeddingResult:
+        vectors = tuple((1.0, 0.0, 0.0) if "stable" in text.casefold() else (0.0, 1.0, 0.0) for text in texts)
+        return EmbeddingResult(vectors=vectors)
+
+
+@pytest.mark.parametrize("database_kind", ["sqlite", "oceanbase"])
+@pytest.mark.parametrize("mode", ["fts", "vector", "hybrid"])
+def test_memory_search_stays_consistent_when_append_advances_head_before_index_query(
+    database_kind: DatabaseKind,
+    mode: MemorySearchMode,
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        database = _database_config(database_kind, mode, tmp_path)
+        embedding_model = None if mode == "fts" else _KeywordEmbeddingModel()
+        async with open_builtin_runtime(
+            BuiltinConfig(database=database),
+            embedding_model=embedding_model,
+        ) as runtime:
+            memory = runtime.memory.for_scope(f"concurrent-memory-search-{uuid4()}")
+            await memory.remember(
+                RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text="Stable searchable fact."),))
+            )
+
+            provider: Any = runtime._provider
+            index = provider.index
+            original_search = index.search
+            paused = asyncio.Event()
+            resume = asyncio.Event()
+            pending: asyncio.Task[Any] | None = None
+
+            async def pause_first_search(
+                _self: Any,
+                connection: Any,
+                scope_id: str,
+                request: Any,
+            ) -> Any:
+                if not paused.is_set():
+                    paused.set()
+                    await resume.wait()
+                return await original_search(connection, scope_id, request)
+
+            index.search = MethodType(pause_first_search, index)
+            try:
+                pending = asyncio.create_task(memory.search(SearchMemoryRequest(query="stable searchable", mode=mode)))
+                await asyncio.wait_for(paused.wait(), timeout=TIMEOUT_SECONDS)
+                new_head = await memory.remember(
+                    RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text="Unrelated appended fact."),))
+                )
+                resume.set()
+                result = await asyncio.wait_for(pending, timeout=TIMEOUT_SECONDS)
+            finally:
+                resume.set()
+                index.search = original_search
+                if pending is not None and not pending.done():
+                    pending.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await pending
+
+            assert result.memory_ref == new_head.memory_ref
+            assert result.mode == mode
+            assert tuple(hit.text for hit in result.hits) == ("Stable searchable fact.",)
+            assert result.hits[0].matched_by == EXPECTED_CHANNELS[mode]
+
+    asyncio.run(scenario())
+
+
+def _database_config(
+    database_kind: DatabaseKind,
+    mode: MemorySearchMode,
+    tmp_path: Path,
+) -> SQLiteConfig | OceanBaseConfig:
+    if database_kind == "oceanbase":
+        url = os.environ.get("POWERCONTEXT_TEST_OCEANBASE_URL")
+        if url is None:
+            pytest.skip("set POWERCONTEXT_TEST_OCEANBASE_URL to a dedicated OceanBase MySQL-mode test database")
+        return OceanBaseConfig(url=SecretStr(url))
+
+    extension = os.environ.get("POWERCONTEXT_VEC1_EXTENSION")
+    if mode in {"vector", "hybrid"} and (extension is None or not Path(extension).is_file()):
+        pytest.skip("set POWERCONTEXT_VEC1_EXTENSION to a Vec1 extension file")
+    return SQLiteConfig(
+        url=f"sqlite+aiosqlite:///{tmp_path / f'memory-search-{mode}.db'}",
+        vec1_extension=None if extension is None else Path(extension),
+    )

--- a/tests/e2e/test_runtime_server.py
+++ b/tests/e2e/test_runtime_server.py
@@ -28,9 +28,17 @@ from powercontext.builtin.artifacts.memory import (
 from powercontext.builtin.inference import EmbeddingResult, InferenceConfigurationError
 from powercontext.builtin.persistence.oceanbase import OceanBaseConfig
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
-from powercontext.builtin.runtime import InferenceConfig
+from powercontext.builtin.runtime import (
+    InferenceConfig,
+    MemorySearchPage,
+    ScopedMemoryApplication,
+)
+from powercontext.builtin.runtime import (
+    SearchMemoryRequest as RuntimeSearchMemoryRequest,
+)
 from powercontext.builtin.sources import ContentSource
 from powercontext.client import PowerContextClient, ServerResponseError
+from powercontext.errors import RevisionConflictError
 from powercontext.http import (
     ActivateHandoffRequest,
     CaptureContentSourceRequest,
@@ -551,6 +559,36 @@ def test_runtime_conflicts_keep_http_and_sdk_error_context(tmp_path: Path) -> No
         assert caught.value.request_id is not None
 
     asyncio.run(stale_revision())
+
+
+def test_memory_search_returns_revision_conflict_as_http_409(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def conflicting_search(
+        _self: ScopedMemoryApplication,
+        _request: RuntimeSearchMemoryRequest,
+        /,
+    ) -> MemorySearchPage:
+        raise RevisionConflictError("stale", "current")
+
+    monkeypatch.setattr(ScopedMemoryApplication, "search", conflicting_search)
+    app = create_server_app(settings=_server_settings(tmp_path / "runtime.db"))
+
+    with TestClient(app) as transport:
+        response = transport.post(
+            "/v1/memory/search",
+            json={"scope_id": "project", "query": "stable searchable"},
+        )
+
+    assert response.status_code == 409
+    assert len(response.headers["X-PowerContext-Request-ID"]) == 16
+    assert int(response.headers["X-PowerContext-Request-ID"], 16) > 0
+    assert response.json()["error"] == {
+        "code": "revision_conflict",
+        "message": "The Memory Revision is stale.",
+        "details": None,
+    }
 
 
 def test_runtime_server_rejects_non_strict_transport_values(tmp_path: Path) -> None:

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -183,6 +183,10 @@ def test_memory_operations_use_family_prefixed_paths_and_typed_requests() -> Non
     assert SEARCH_MEMORY.request_type is SearchMemoryRequest
 
 
+def test_memory_search_declares_the_revision_conflict_response() -> None:
+    assert SEARCH_MEMORY.responses[409] == {"$ref": "#/components/responses/Conflict"}
+
+
 def test_prepared_context_is_a_generic_typed_operation_outside_the_mcp_memory_tools() -> None:
     assert PREPARE_CONTEXT.path == "/v1/context/prepare"
     assert PREPARE_CONTEXT.request_type is PrepareContextRequest


### PR DESCRIPTION
# Which issue or RFC does this PR close?

<!--
Link the related issue or RFC using GitHub syntax.
For example, `Closes #123` indicates that this PR will close issue #123.
If this PR implements an RFC, link the RFC and any existing tracking issue.
-->

Closes #1249 .

# Rationale for this change

<!--
Explain why this change is needed. If the linked issue or RFC already explains the rationale clearly, a short summary is enough.
-->

Memory search had a TOCTOU race during concurrent appends. A search could validate revision N, then query the mutable index projection after another request had advanced the head to revision N+1. The results would still be filtered using revision N, potentially producing an empty result even when an unchanged matching entry existed.

This failure was silent: callers received a successful response associated with revision N but no indication that the result was inconsistent.

# What changes are included in this PR?

<!--
Summarize the important changes. Focus on behavior, API, docs, tests, and migration impact.
-->

- Validate requested memory revisions before and after the index query.
- Detect when the memory head advances during index lookup or reranking.
- Retry the search with the latest head for a bounded number of attempts.
- Raise `RevisionConflictError` instead of returning potentially inconsistent results if concurrent updates continue beyond the retry limit.
- Add a deterministic concurrency regression test using synchronization barriers.
- Cover SQLite and OceanBase across FTS, vector, and hybrid search modes.


# Are there any user-facing changes?

<!--
If there are user-facing changes, documentation may need to be updated before approval.
If there are breaking changes to public APIs or persisted formats, call them out explicitly.
-->

Yes. Under sustained concurrent Memory updates, `POST /v1/memory/search` may now return `409 revision_conflict` when a consistent revision cannot be obtained within the bounded retry limit. This response is now declared in the OpenAPI contract. There are no request, success-response, or persisted-format changes.

# How was this change tested?

<!--
List commands run, tests added or updated, and any manual validation performed.
-->

Added `tests/e2e/test_memory_search_concurrency.py`, which deterministically pauses a search after initial head validation but before the index query, performs a concurrent append, and verifies that:

- the search retries against the new head;
- the unchanged matching entry is returned;
- the returned `memory_ref` points to the new revision;
- the expected FTS, vector, and hybrid channels are used.

Code quality checks:

```bash
make check
```

Result: all formatting, lint, and type checks passed.

Full test suite:

```bash
make test
```

Result:

```text
534 passed, 12 skipped
```

The OceanBase matrix was tested against a temporary real OceanBase CE 4.3.5.6 instance:

```bash
POWERCONTEXT_TEST_OCEANBASE_URL="<dedicated-oceanbase-url>" \
  .venv/bin/python -m pytest \
  tests/e2e/test_memory_search_concurrency.py \
  -k oceanbase -q
```

Result:

```text
3 passed, 3 deselected in 22.71s
```

The three passing OceanBase cases cover FTS, vector, and hybrid search.

# AI usage statement

<!--
If AI tools were used to build this PR, describe the tool and model where possible.
If not applicable, write `Not used`.
-->
