### PR TITLE
feat(handoff): enable reports by default

### DIFF
--- a/src/powercontext/builtin/runtime/config.py
+++ b/src/powercontext/builtin/runtime/config.py
@@ -27,7 +27,7 @@ class RuntimeConfig(BaseModel):
 class HandoffReportConfig(BaseModel):
     """Optional Handoff Report feature registration."""
 
-    enabled: bool = False
+    enabled: bool = True
 
 
 class InferenceConfig(BaseModel):

--- a/tests/e2e/test_mcp_transport.py
+++ b/tests/e2e/test_mcp_transport.py
@@ -120,6 +120,8 @@ def test_mcp_projects_curated_tools_at_the_configured_server_path(tmp_path: Path
         "continue_handoff",
         "finalize_handoff",
         "get_artifact_candidate",
+        "get_handoff_report",
+        "get_handoff_report_workspace",
         "get_memory_entry",
         "list_artifact_candidates",
         "list_memory_entries",

--- a/tests/test_handoff_report_http.py
+++ b/tests/test_handoff_report_http.py
@@ -235,6 +235,7 @@ def test_disabled_handoff_report_does_not_create_report_tables(tmp_path) -> None
         settings=ServerSettings(
             database=SQLiteConfig(url=f"sqlite+aiosqlite:///{database_path}"),
             mcp=McpConfig(enabled=False),
+            handoff_report=HandoffReportConfig(enabled=False),
         )
     )
 


### PR DESCRIPTION
## Which issue or RFC does this PR close?

Closes #1254

## Rationale for this change

Handoff Report is already implemented, but its default opt-in setting makes the Dashboard page difficult to discover. The Dashboard should expose the existing Handoff Report interface by default while keeping the statistics Dashboard at / and preserving an explicit opt-out.

## What changes are included in this PR?

- Change HandoffReportConfig.enabled default from false to true.
- Keep handoff_report.enabled=false as the explicit opt-out path.
- Update the HTTP test to verify that the opt-out still prevents Report-owned tables from being created.

## Are there any user-facing changes?

With default settings, an authenticated Dashboard deployment exposes the Handoff Report page and navigation entry. The existing statistics Dashboard remains at /; this change does not redirect / to /handoff-reports or automatically select the Handoff Report tab. Core Handoff behavior is unchanged.

## How was this change tested?

- env -u POWERCONTEXT_SERVER_AUTH_ENABLED -u POWERCONTEXT_SERVER_AUTH_TOKEN -u POWERCONTEXT_SERVER_DASHBOARD_ENABLED -u POWERCONTEXT_SERVER_DASHBOARD_SCOPES uv run pytest -q tests/test_dashboard.py tests/test_handoff_report_http.py
- Result: 6 passed.

## AI usage statement

Implemented and validated with OpenAI Codex (GPT-5).