### PR TITLE
feat(tracing): cover context setup and scope lock waits

### DIFF
--- a/docs/en/docs/how-to/trace-with-phoenix.md
+++ b/docs/en/docs/how-to/trace-with-phoenix.md
@@ -77,10 +77,13 @@ Open <http://localhost:6006>, select the `default` project, and open the most re
 | `invoke_agent memory_extraction` | One PowerContext generation task. The name identifies the purpose, not the model. |
 | `chat <model>` | One request to the model provider, with token usage and latency. |
 
-Memory read operations add the following internal stage spans beneath their application operation:
+Scoped operations add the following internal stage spans beneath their application operation. Read-only searches never
+take the write lock, so they emit no `scope.lock` span:
 
 | Span | Meaning |
 | --- | --- |
+| `scope.context` | Resolving the scope's context from the configured provider; near zero for the built-in provider, visible when a provider does I/O here. |
+| `scope.lock` | Waiting for the scope write lock, ending the moment it is acquired. `powercontext.scope.lock.contended` reports whether another operation already held it. |
 | `memory.search` | Memory lookup for `search_memory` or `prepare_context`; embedding and reranking spans, when present, are nested beneath it. |
 | `memory.rerank` | One actual reranker call; model-backed reranking nests `invoke_agent memory_rerank` beneath it. |
 | `experience.search` | Experience recall during `prepare_context`; emitted even when recall is not configured. |

--- a/docs/zh/docs/how-to/trace-with-phoenix.md
+++ b/docs/zh/docs/how-to/trace-with-phoenix.md
@@ -75,10 +75,13 @@ Memory extraction 发生在 flush 阶段，而不是捕获阶段。
 | `invoke_agent memory_extraction` | 一次 PowerContext generation 任务。名字标识用途，不是模型名。 |
 | `chat <model>` | 一次发往模型 provider 的请求，包含 token 用量和耗时。 |
 
-Memory 读取操作还会在 application operation 之下添加以下内部 stage span：
+scope 相关操作还会在 application operation 之下添加以下内部 stage span。只读查询不获取写锁，因此不会产生
+`scope.lock` span：
 
 | Span | 含义 |
 | --- | --- |
+| `scope.context` | 从配置的 provider 解析该 scope 的 context；内建 provider 下接近零，provider 在此做 I/O 时才可见。 |
+| `scope.lock` | 等待该 scope 的写锁，在获取到锁的瞬间结束。`powercontext.scope.lock.contended` 表示进入时是否已被其他操作持有。 |
 | `memory.search` | `search_memory` 或 `prepare_context` 中的 Memory 查询；存在 embedding 或 reranking span 时，它们嵌套在其下。 |
 | `memory.rerank` | 一次实际 reranker 调用；使用模型的 reranking 会在其下嵌套 `invoke_agent memory_rerank`。 |
 | `experience.search` | `prepare_context` 中的 Experience recall；未配置 recall 时也会产生。 |

--- a/src/powercontext/builtin/runtime/application.py
+++ b/src/powercontext/builtin/runtime/application.py
@@ -277,7 +277,7 @@ class ScopedContextApplication:
         builder = PreparedContextBuilder()
         async with (
             self._runtime._context(self.scope_id, embedding_purpose=ModelUsagePurpose.MEMORY_RECALL) as context,
-            self._runtime._lock(self.scope_id),
+            self._runtime._locked(self.scope_id),
         ):
             with self._runtime._stage(
                 _MEMORY_SEARCH_STAGE,
@@ -384,7 +384,7 @@ class ScopedExperienceApplication:
         self.scope_id = validate_scope_id(scope_id)
 
     async def propose(self, request: ProposeExperienceRequest, /) -> ExperienceCandidate:
-        async with self._runtime._scoped_operation(self.scope_id), self._runtime._lock(self.scope_id):
+        async with self._runtime._scoped_operation(self.scope_id), self._runtime._locked(self.scope_id):
             service = self._runtime._review(self.scope_id)
             return await service.propose_experience(
                 request.proposal,
@@ -400,7 +400,7 @@ class ScopedExperienceApplication:
                 self.scope_id,
                 generation_purpose=ModelUsagePurpose.EXPERIENCE_GENERATION,
             ),
-            self._runtime._lock(self.scope_id),
+            self._runtime._locked(self.scope_id),
         ):
             return await self._runtime._generation(self.scope_id).experience(
                 sources=request.sources,
@@ -427,7 +427,7 @@ class ScopedExperienceApplication:
                 self.scope_id,
                 generation_purpose=ModelUsagePurpose.EXPERIENCE_GENERATION,
             ),
-            self._runtime._lock(self.scope_id),
+            self._runtime._locked(self.scope_id),
         ):
             return await incubator(self.scope_id, window_limit)
 
@@ -450,7 +450,7 @@ class ScopedSkillApplication:
         self.scope_id = validate_scope_id(scope_id)
 
     async def propose(self, request: ProposeSkillRequest, /) -> SkillCandidate:
-        async with self._runtime._scoped_operation(self.scope_id), self._runtime._lock(self.scope_id):
+        async with self._runtime._scoped_operation(self.scope_id), self._runtime._locked(self.scope_id):
             service = self._runtime._review(self.scope_id)
             return await service.propose_skill(
                 request.proposal,
@@ -466,7 +466,7 @@ class ScopedSkillApplication:
                 self.scope_id,
                 generation_purpose=ModelUsagePurpose.SKILL_GENERATION,
             ),
-            self._runtime._lock(self.scope_id),
+            self._runtime._locked(self.scope_id),
         ):
             return await self._runtime._generation(self.scope_id).skill(
                 origin=request.origin,
@@ -517,7 +517,7 @@ class ScopedHandoffApplication:
             return await context.artifacts.handoff.finalize(draft)
 
     async def commit(self, prepared: PreparedHandoff, /) -> Handoff:
-        async with self._runtime._context(self.scope_id) as context, self._runtime._lock(self.scope_id):
+        async with self._runtime._context(self.scope_id) as context, self._runtime._locked(self.scope_id):
             return await context.artifacts.handoff.commit(prepared)
 
     async def continue_from(
@@ -572,7 +572,7 @@ class ScopedExternalSkillApplication:
         self.scope_id = validate_scope_id(scope_id)
 
     async def scan(self) -> ExternalSkillScanResult:
-        async with self._runtime._scoped_operation(self.scope_id), self._runtime._lock(self.scope_id):
+        async with self._runtime._scoped_operation(self.scope_id), self._runtime._locked(self.scope_id):
             return await self._runtime._external_skills(self.scope_id).scan()
 
     async def list(self, request: ListExternalSkillsRequest, /) -> ExternalSkillList:
@@ -597,7 +597,7 @@ class ScopedExternalSkillApplication:
                 self.scope_id,
                 generation_purpose=ModelUsagePurpose.SKILL_GENERATION,
             ),
-            self._runtime._lock(self.scope_id),
+            self._runtime._locked(self.scope_id),
         ):
             return await importer(
                 self.scope_id,
@@ -639,14 +639,14 @@ class ScopedReviewApplication:
             return await self._runtime._review(self.scope_id).get_candidate(request.candidate_id)
 
     async def approve(self, request: ApproveArtifactCandidateRequest, /) -> ReviewedCandidate:
-        async with self._runtime._scoped_operation(self.scope_id), self._runtime._lock(self.scope_id):
+        async with self._runtime._scoped_operation(self.scope_id), self._runtime._locked(self.scope_id):
             return await self._runtime._review(self.scope_id).approve(
                 request.candidate_id,
                 request.expected_version,
             )
 
     async def reject(self, request: RejectArtifactCandidateRequest, /) -> ReviewedCandidate:
-        async with self._runtime._scoped_operation(self.scope_id), self._runtime._lock(self.scope_id):
+        async with self._runtime._scoped_operation(self.scope_id), self._runtime._locked(self.scope_id):
             return await self._runtime._review(self.scope_id).reject(
                 request.candidate_id,
                 request.expected_version,
@@ -654,7 +654,7 @@ class ScopedReviewApplication:
             )
 
     async def revise(self, request: ReviseArtifactCandidateRequest, /) -> ReviewedCandidate:
-        async with self._runtime._scoped_operation(self.scope_id), self._runtime._lock(self.scope_id):
+        async with self._runtime._scoped_operation(self.scope_id), self._runtime._locked(self.scope_id):
             return await self._runtime._review(self.scope_id).revise(
                 request.candidate_id,
                 request.expected_version,
@@ -688,7 +688,7 @@ class ScopedMemoryApplication:
             self.scope_id,
             embedding_purpose=ModelUsagePurpose.MEMORY_INDEXING,
         ) as context:
-            async with self._runtime._lock(self.scope_id):
+            async with self._runtime._locked(self.scope_id):
                 service = context.artifacts.memory
                 current = await _head_or_none(service, context.artifacts.memory_artifact_id)
                 _validate_expected_revision(current, request.expected_revision)
@@ -784,7 +784,7 @@ class ScopedMemoryApplication:
             self.scope_id,
             embedding_purpose=ModelUsagePurpose.MEMORY_INDEXING,
         ) as context:
-            async with self._runtime._lock(self.scope_id):
+            async with self._runtime._locked(self.scope_id):
                 service = context.artifacts.memory
                 current, entry = await _current_citation(
                     service,
@@ -817,7 +817,7 @@ class ScopedMemoryApplication:
             self.scope_id,
             embedding_purpose=ModelUsagePurpose.MEMORY_INDEXING,
         ) as context:
-            async with self._runtime._lock(self.scope_id):
+            async with self._runtime._locked(self.scope_id):
                 service = context.artifacts.memory
                 current, entry = await _current_citation(
                     service,
@@ -852,7 +852,7 @@ class ScopedMemoryApplication:
             embedding_purpose=ModelUsagePurpose.MEMORY_INDEXING,
         ) as context:
             window_limit = self._runtime.source_window_limit if limit is None else limit
-            async with self._runtime._lock(self.scope_id):
+            async with self._runtime._locked(self.scope_id):
                 return await context.triggers.flush(limit=window_limit)
 
     async def cursor(self) -> SourceCursor:
@@ -1198,10 +1198,22 @@ class BuiltinRuntime:
             generation_purpose=generation_purpose,
             embedding_purpose=embedding_purpose,
         ):
-            yield await self._provider.get(validate_scope_id(scope_id))
+            # The stage covers provider resolution only; a third-party provider may do I/O here.
+            with self._stage("scope.context", attributes={}):
+                context = await self._provider.get(validate_scope_id(scope_id))
+            yield context
 
-    def _lock(self, scope_id: str) -> asyncio.Lock:
-        return self._locks.setdefault(validate_scope_id(scope_id), asyncio.Lock())
+    @asynccontextmanager
+    async def _locked(self, scope_id: str) -> AsyncIterator[None]:
+        """Serialize writes for one scope and trace only the wait, not the critical section."""
+
+        lock = self._locks.setdefault(validate_scope_id(scope_id), asyncio.Lock())
+        with self._stage("scope.lock", attributes={"powercontext.scope.lock.contended": lock.locked()}):
+            await lock.acquire()
+        try:
+            yield
+        finally:
+            lock.release()
 
     def _stage(
         self,

--- a/src/powercontext/builtin/runtime/application.py
+++ b/src/powercontext/builtin/runtime/application.py
@@ -1208,12 +1208,16 @@ class BuiltinRuntime:
         """Serialize writes for one scope and trace only the wait, not the critical section."""
 
         lock = self._locks.setdefault(validate_scope_id(scope_id), asyncio.Lock())
-        with self._stage("scope.lock", attributes={"powercontext.scope.lock.contended": lock.locked()}):
-            await lock.acquire()
+        acquired = False
         try:
+            # Injected tracing must never leak the lock, so the release is armed before the stage is closed.
+            with self._stage("scope.lock", attributes={"powercontext.scope.lock.contended": lock.locked()}):
+                await lock.acquire()
+                acquired = True
             yield
         finally:
-            lock.release()
+            if acquired:
+                lock.release()
 
     def _stage(
         self,

--- a/tests/e2e/test_observability.py
+++ b/tests/e2e/test_observability.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 
 import httpx
+import pytest
 from fastapi.testclient import TestClient
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
@@ -24,19 +25,33 @@ from powercontext.artifacts import ArtifactRef
 from powercontext.builtin.artifacts.memory import (
     EmbeddingProfile,
     MemoryCapabilities,
+    MemoryEntryInput,
     MemoryProjection,
     MemorySearchChannels,
     MemorySearchRequest,
 )
 from powercontext.builtin.inference.pydantic_ai import PydanticAIEmbeddingModel
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
+from powercontext.builtin.runtime import BuiltinConfig, RememberMemoryRequest, open_builtin_runtime
 from powercontext.builtin.runtime.config import InferenceConfig, RuntimeConfig
+from powercontext.errors import RevisionConflictError
 from powercontext.server.factory import create_server_app
 from powercontext.server.logging import OperationalContextFilter
 from powercontext.server.settings import McpConfig, ServerSettings
 from powercontext.server.tracing import ServerTracing
 
 _STAGE_ATTRIBUTE_KEYS = {
+    "scope.context": {
+        "powercontext.operation.name",
+        "powercontext.operation.unit",
+        "powercontext.operation.outcome",
+    },
+    "scope.lock": {
+        "powercontext.operation.name",
+        "powercontext.operation.unit",
+        "powercontext.operation.outcome",
+        "powercontext.scope.lock.contended",
+    },
     "memory.search": {
         "powercontext.operation.name",
         "powercontext.operation.unit",
@@ -344,6 +359,13 @@ def test_memory_read_stage_spans_are_bounded_and_nested(monkeypatch, tmp_path) -
         for application in search_applications
     }
     search_application = search_applications_by_result[(True, 1)]
+    assert dict(_only_child(spans, search_application, "scope.context").attributes or {}) == {
+        "powercontext.operation.name": "scope.context",
+        "powercontext.operation.unit": "stage",
+        "powercontext.operation.outcome": "success",
+    }
+    # Read-only searches never serialize on the scope write lock, so they emit no wait span.
+    assert not _children(spans, search_application, "scope.lock")
     search = _only_child(spans, search_application, "memory.search")
     search_attributes = dict(search.attributes or {})
     assert search_attributes == {
@@ -393,6 +415,20 @@ def test_memory_read_stage_spans_are_bounded_and_nested(monkeypatch, tmp_path) -
     ready_application = prepared_by_memory_presence[True]
     empty_application = prepared_by_memory_presence[False]
 
+    # Both setup spans stay siblings of the recall stages: neither one covers the operation body.
+    for application in (ready_application, empty_application):
+        assert dict(_only_child(spans, application, "scope.context").attributes or {}) == {
+            "powercontext.operation.name": "scope.context",
+            "powercontext.operation.unit": "stage",
+            "powercontext.operation.outcome": "success",
+        }
+        assert dict(_only_child(spans, application, "scope.lock").attributes or {}) == {
+            "powercontext.operation.name": "scope.lock",
+            "powercontext.operation.unit": "stage",
+            "powercontext.scope.lock.contended": False,
+            "powercontext.operation.outcome": "success",
+        }
+
     ready_memory = _only_child(spans, ready_application, "memory.search")
     assert (ready_memory.attributes or {})["powercontext.memory.search.result_count"] == 1
     assert _only_child(spans, ready_memory, "memory.rerank")
@@ -436,6 +472,61 @@ def test_memory_read_stage_spans_are_bounded_and_nested(monkeypatch, tmp_path) -
     assert memory_content not in exported
     assert query not in exported
     assert no_match_query not in exported
+
+
+def test_scope_lock_stage_span_reports_contention_and_closes_at_acquisition(tmp_path) -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(sampler=ALWAYS_ON, shutdown_on_exit=False)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    scope_id = "project:private-lock-scope"
+    memory_content = "Private lock sentinel evidence."
+
+    async def scenario() -> None:
+        async with open_builtin_runtime(
+            BuiltinConfig(database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'scope-lock.db'}")),
+            tracing=ServerTracing(provider),
+        ) as runtime:
+            memory = runtime.memory.for_scope(scope_id)
+            first = await memory.remember(
+                RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text=memory_content),))
+            )
+
+            # Holding the scope lock outside the Runtime makes the next write observe real contention.
+            lock = runtime._locks[scope_id]
+            await lock.acquire()
+            contending = asyncio.create_task(
+                memory.remember(RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text="Second fact."),)))
+            )
+            await asyncio.sleep(0.05)
+            assert not contending.done()
+            lock.release()
+            await contending
+
+            # A failure inside the critical section must still release the lock for later writes.
+            with pytest.raises(RevisionConflictError):
+                await memory.remember(
+                    RememberMemoryRequest(
+                        entries=(MemoryEntryInput(kind="fact", text="Conflicting fact."),),
+                        expected_revision=first.memory_ref.revision,
+                    )
+                )
+            assert not lock.locked()
+            await memory.remember(RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text="Third fact."),)))
+
+    asyncio.run(scenario())
+
+    spans = list(exporter.get_finished_spans())
+    assert [
+        (span.attributes or {})["powercontext.scope.lock.contended"] for span in spans if span.name == "scope.lock"
+    ] == [False, True, False, False]
+    # Every wait span succeeds, including the conflicting write's: the span closes before the critical section runs.
+    for span in spans:
+        assert (span.attributes or {}).get("powercontext.operation.outcome") == "success"
+        allowed_keys = _STAGE_ATTRIBUTE_KEYS.get(span.name)
+        assert allowed_keys is None or (span.attributes or {}).keys() <= allowed_keys
+    exported = _exported_span_data(spans)
+    assert scope_id not in exported
+    assert memory_content not in exported
 
 
 def test_vector_search_exports_embedding_under_memory_search_without_recording_text(monkeypatch, tmp_path) -> None:

--- a/tests/e2e/test_observability.py
+++ b/tests/e2e/test_observability.py
@@ -101,6 +101,33 @@ _VECTOR_PROFILE = EmbeddingProfile(
 )
 
 
+class _StageTeardownError(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__("stage teardown failed")
+
+
+class _StageTeardown:
+    def __init__(self, *, failing: bool) -> None:
+        self._failing = failing
+
+    def __enter__(self) -> _StageTeardown:
+        return self
+
+    def set_attributes(self, _attributes: object, /) -> None:
+        pass
+
+    def __exit__(self, *_: object) -> None:
+        if self._failing:
+            raise _StageTeardownError
+
+
+class _ScopeLockTeardownFailingTracing:
+    """Fail while closing `scope.lock`, the way a faulty injected tracing adapter would."""
+
+    def stage(self, name: str, **_: object) -> _StageTeardown:
+        return _StageTeardown(failing=name == "scope.lock")
+
+
 class _VectorMemoryIndex:
     """Expose deterministic vector capability without a platform extension."""
 
@@ -527,6 +554,23 @@ def test_scope_lock_stage_span_reports_contention_and_closes_at_acquisition(tmp_
     exported = _exported_span_data(spans)
     assert scope_id not in exported
     assert memory_content not in exported
+
+
+def test_scope_lock_is_released_when_stage_teardown_fails(tmp_path) -> None:
+    scope_id = "project:private-broken-tracing"
+
+    async def scenario() -> bool:
+        async with open_builtin_runtime(
+            BuiltinConfig(database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'broken-tracing.db'}")),
+            tracing=_ScopeLockTeardownFailingTracing(),
+        ) as runtime:
+            with pytest.raises(_StageTeardownError):
+                await runtime.memory.for_scope(scope_id).remember(
+                    RememberMemoryRequest(entries=(MemoryEntryInput(kind="fact", text="Guarded fact."),))
+                )
+            return runtime._locks[scope_id].locked()
+
+    assert asyncio.run(scenario()) is False
 
 
 def test_vector_search_exports_embedding_under_memory_search_without_recording_text(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1257.

# Rationale for this change

Application spans were not fully explained by their children: the provider resolution and the scope write lock wait
before the first stage span were invisible. A slow request gave no way to tell Memory recall latency apart from time
spent queued behind another write on the same scope.

# What changes are included in this PR?

Two new Runtime stage spans, reusing the existing `stage` unit:

```
powercontext search_memory              powercontext prepare_context
├── scope.context      <- new           ├── scope.context      <- new
└── memory.search                       ├── scope.lock         <- new
    ├── embeddings <model>               ├── memory.search
    └── memory.rerank                    ├── experience.search
                                         └── context.build
```

- **`scope.context`** wraps `await self._provider.get(...)` in `_context()` and nothing else, closing before the context
  is yielded. No attributes. Near zero with the built-in provider (`RelationalContexts.get()` is a cached in-memory
  lookup), kept because a third-party `PowerContextProvider` may do I/O in `get()` — this span is the only place that
  becomes visible.
- **`scope.lock`** measures the lock wait and ends at acquisition, so the critical section stays outside the span. Adds
  `_locked()`, since `_lock()` only returned the `asyncio.Lock` and the wait happened in each caller's `async with`.
  One bounded boolean, `powercontext.scope.lock.contended`.

All 16 `_lock(self.scope_id)` call sites now use `_locked(...)`; `_lock()` had one caller left and was inlined.
Read-only searches still take no lock, so they emit no `scope.lock`. Docs: one row per span in the stage span tables
(en + zh). RFC 0046 already lists the `Runtime stage` unit and is unchanged.

# Are there any user-facing changes?

No — API, OpenAPI, CLI, persisted formats, and dependencies are untouched. Neither span records queries, content,
vectors, `scope_id`, artifact identifiers, or exception messages; both are registered in the test attribute allow-list.

# How was this change tested?

`make check` and `make test` pass (547 passed, 12 skipped).

- Extended `test_memory_read_stage_spans_are_bounded_and_nested`: both spans present with expected attributes and
  parents, no `scope.lock` under `search_memory`. The recall stages staying direct children of the application span is
  what proves neither setup span covers the operation body.
- Added `test_scope_lock_stage_span_reports_contention_and_closes_at_acquisition`: real contention via an externally
  held lock, and a failure inside the critical section still releases it. The conflicting write's wait span stays
  `success`, which is the direct evidence the span closes before the critical section.

Outcome semantics are already covered for every stage span in `tests/test_server_tracing.py`, so they are not re-tested
per span.