### PR TITLE
Fix: normalizes cursor race into PowerContext's `GenerationConflictError`.

### DIFF
--- a/src/powercontext/builtin/persistence/cursors.py
+++ b/src/powercontext/builtin/persistence/cursors.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel
 from sqlalchemy import insert, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from powercontext.builtin.persistence.codec import dump_model, load_model, stored_bytes
@@ -37,21 +38,18 @@ class SourceCursorRepository:
         scope_id: str,
         binding_name: str,
         /,
+        *,
+        for_update: bool = False,
     ) -> StoredSourceCursor | None:
         _require_identifier("scope_id", scope_id, MAX_SCOPE_ID_LENGTH)
         _require_identifier("binding_name", binding_name, MAX_BINDING_NAME_LENGTH)
-        row = (
-            (
-                await connection.execute(
-                    select(SOURCE_CURSORS_TABLE).where(
-                        SOURCE_CURSORS_TABLE.c.scope_id == scope_id,
-                        SOURCE_CURSORS_TABLE.c.binding_name == binding_name,
-                    )
-                )
-            )
-            .mappings()
-            .one_or_none()
+        statement = select(SOURCE_CURSORS_TABLE).where(
+            SOURCE_CURSORS_TABLE.c.scope_id == scope_id,
+            SOURCE_CURSORS_TABLE.c.binding_name == binding_name,
         )
+        if for_update:
+            statement = statement.with_for_update()
+        row = (await connection.execute(statement)).mappings().one_or_none()
         return None if row is None else _decode_row(row)
 
     async def save(
@@ -74,14 +72,29 @@ class SourceCursorRepository:
             if existing is not None:
                 raise GenerationConflictError(binding_name, None, existing.generation)
             generation = 1
-            await connection.execute(
-                insert(SOURCE_CURSORS_TABLE).values(
-                    scope_id=scope_id,
-                    binding_name=binding_name,
-                    cursor=payload,
-                    generation=generation,
+            try:
+                async with connection.begin_nested():
+                    await connection.execute(
+                        insert(SOURCE_CURSORS_TABLE).values(
+                            scope_id=scope_id,
+                            binding_name=binding_name,
+                            cursor=payload,
+                            generation=generation,
+                        )
+                    )
+            except IntegrityError:
+                # Another runtime may have inserted the same cursor after our
+                # initial read. Normalize that database race to the same CAS
+                # conflict used for concurrent updates.
+                existing = await self.load(
+                    connection,
+                    scope_id,
+                    binding_name,
+                    for_update=True,
                 )
-            )
+                if existing is None:
+                    raise
+                raise GenerationConflictError(binding_name, None, existing.generation) from None
         else:
             generation = expected_generation + 1
             result = await connection.execute(

--- a/tests/builtin/persistence/test_cursors.py
+++ b/tests/builtin/persistence/test_cursors.py
@@ -49,76 +49,54 @@ def test_source_cursor_uses_generation_compare_and_swap() -> None:
     asyncio.run(scenario())
 
 
-def test_source_cursor_initial_creation_translates_a_racing_insert() -> None:
-    class StaleInitialReadRepository(SourceCursorRepository):
-        def __init__(self) -> None:
-            self._first_read = True
-
-        async def load(
-            self,
-            connection: AsyncConnection,
-            scope_id: str,
-            binding_name: str,
-            /,
-            *,
-            for_update: bool = False,
-        ) -> StoredSourceCursor | None:
-            if self._first_read and not for_update:
-                self._first_read = False
-                return None
-            return await super().load(connection, scope_id, binding_name, for_update=for_update)
-
+def test_source_cursor_initial_creation_is_safe_across_connections(tmp_path: Path) -> None:
     async def scenario() -> None:
-        async with repository_profile() as (profile, _):  # noqa: SIM117
-            async with profile.database.transaction() as connection:
-                await SourceCursorRepository().save(
-                    connection,
-                    "scope-a",
-                    "memory-source-window",
-                    SourceCursor(sequence=1),
-                    expected_generation=None,
-                )
+        barrier = asyncio.Barrier(2)
 
-                repository = StaleInitialReadRepository()
-                with pytest.raises(GenerationConflictError) as error:
-                    await repository.save(
+        class SynchronizedRepository(SourceCursorRepository):
+            async def load(
+                self,
+                connection: AsyncConnection,
+                scope_id: str,
+                binding_name: str,
+                /,
+                *,
+                for_update: bool = False,
+            ) -> StoredSourceCursor | None:
+                result = await super().load(connection, scope_id, binding_name, for_update=for_update)
+                if not for_update and result is None:
+                    await barrier.wait()
+                return result
+
+        url = f"sqlite+aiosqlite:///{tmp_path / 'cursor-race.db'}"
+        config = SQLiteConfig(url=url)
+
+        async def create_cursor(profile: SQLiteProfile, sequence: int) -> StoredSourceCursor | GenerationConflictError:
+            repository = SynchronizedRepository()
+            try:
+                async with profile.database.transaction() as connection:
+                    return await repository.save(
                         connection,
                         "scope-a",
                         "memory-source-window",
-                        SourceCursor(sequence=2),
+                        SourceCursor(sequence=sequence),
                         expected_generation=None,
                     )
-                assert error.value.actual == 1
-
-    asyncio.run(scenario())
-
-
-def test_source_cursor_initial_creation_normalizes_unique_conflict(tmp_path: Path) -> None:
-    async def scenario() -> None:
-        url = f"sqlite+aiosqlite:///{tmp_path / 'cursor-race.db'}"
-        config = SQLiteConfig(url=url)
-        repository = SourceCursorRepository()
+            except GenerationConflictError as error:
+                return error
 
         async with SQLiteProfile.open(config, tables=SHARED_TABLES) as first_profile:  # noqa: SIM117
-            async with first_profile.database.transaction() as first_connection:
-                await repository.save(
-                    first_connection,
-                    "scope-a",
-                    "memory-source-window",
-                    SourceCursor(sequence=1),
-                    expected_generation=None,
+            async with SQLiteProfile.open(config, tables=SHARED_TABLES) as second_profile:
+                results = await asyncio.gather(
+                    create_cursor(first_profile, 1),
+                    create_cursor(second_profile, 2),
                 )
 
-        async with SQLiteProfile.open(config, tables=SHARED_TABLES) as second_profile:  # noqa: SIM117
-            async with second_profile.database.transaction() as second_connection:
-                with pytest.raises(GenerationConflictError) as error:
-                    await repository.save(
-                        second_connection,
-                        "scope-a",
-                        "memory-source-window",
-                        SourceCursor(sequence=2),
-                        expected_generation=None,
-                    )
-                assert error.value.actual == 1
+        created = [result for result in results if isinstance(result, StoredSourceCursor)]
+        conflicts = [result for result in results if isinstance(result, GenerationConflictError)]
+        assert len(created) == 1
+        assert created[0].generation == 1
+        assert len(conflicts) == 1
+        assert conflicts[0].actual == 1
 
     asyncio.run(scenario())

--- a/tests/builtin/persistence/test_cursors.py
+++ b/tests/builtin/persistence/test_cursors.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncConnection
 
 from powercontext.builtin.persistence import GenerationConflictError
+from powercontext.builtin.persistence.cursors import SourceCursorRepository, StoredSourceCursor
+from powercontext.builtin.persistence.sqlite import SQLiteConfig, SQLiteProfile
+from powercontext.builtin.persistence.tables import SHARED_TABLES
 from powercontext.builtin.sources import SourceCursor
 from tests.builtin.persistence.contract import repository_profile
 
@@ -40,5 +45,80 @@ def test_source_cursor_uses_generation_compare_and_swap() -> None:
                         expected_generation=first.generation,
                     )
                 assert error.value.actual == 2
+
+    asyncio.run(scenario())
+
+
+def test_source_cursor_initial_creation_translates_a_racing_insert() -> None:
+    class StaleInitialReadRepository(SourceCursorRepository):
+        def __init__(self) -> None:
+            self._first_read = True
+
+        async def load(
+            self,
+            connection: AsyncConnection,
+            scope_id: str,
+            binding_name: str,
+            /,
+            *,
+            for_update: bool = False,
+        ) -> StoredSourceCursor | None:
+            if self._first_read and not for_update:
+                self._first_read = False
+                return None
+            return await super().load(connection, scope_id, binding_name, for_update=for_update)
+
+    async def scenario() -> None:
+        async with repository_profile() as (profile, _):  # noqa: SIM117
+            async with profile.database.transaction() as connection:
+                await SourceCursorRepository().save(
+                    connection,
+                    "scope-a",
+                    "memory-source-window",
+                    SourceCursor(sequence=1),
+                    expected_generation=None,
+                )
+
+                repository = StaleInitialReadRepository()
+                with pytest.raises(GenerationConflictError) as error:
+                    await repository.save(
+                        connection,
+                        "scope-a",
+                        "memory-source-window",
+                        SourceCursor(sequence=2),
+                        expected_generation=None,
+                    )
+                assert error.value.actual == 1
+
+    asyncio.run(scenario())
+
+
+def test_source_cursor_initial_creation_normalizes_unique_conflict(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        url = f"sqlite+aiosqlite:///{tmp_path / 'cursor-race.db'}"
+        config = SQLiteConfig(url=url)
+        repository = SourceCursorRepository()
+
+        async with SQLiteProfile.open(config, tables=SHARED_TABLES) as first_profile:  # noqa: SIM117
+            async with first_profile.database.transaction() as first_connection:
+                await repository.save(
+                    first_connection,
+                    "scope-a",
+                    "memory-source-window",
+                    SourceCursor(sequence=1),
+                    expected_generation=None,
+                )
+
+        async with SQLiteProfile.open(config, tables=SHARED_TABLES) as second_profile:  # noqa: SIM117
+            async with second_profile.database.transaction() as second_connection:
+                with pytest.raises(GenerationConflictError) as error:
+                    await repository.save(
+                        second_connection,
+                        "scope-a",
+                        "memory-source-window",
+                        SourceCursor(sequence=2),
+                        expected_generation=None,
+                    )
+                assert error.value.actual == 1
 
     asyncio.run(scenario())


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1273

# Rationale for this change

`SourceCursorRepository.save()` used a check-then-insert flow for initial cursor creation. When independent Runtime instances created the same cursor concurrently, both could observe that the row did not exist, causing one writer to receive a raw database `IntegrityError`.

This change normalizes that race into PowerContext's `GenerationConflictError`.

# What changes are included in this PR?

- Wrap initial cursor insertion in a savepoint.
- Catch concurrent unique-key conflicts.
- Reload the existing cursor using a locking read where supported.
- Raise `GenerationConflictError` for the losing writer.
- Add regression tests covering the concurrent initial-creation path.
- No schema or migration changes.

# Are there any user-facing changes?

No

# How was this change tested?

- `uv run pytest tests/builtin/persistence -q`
  - `39 passed, 1 skipped`
- `uv run ruff check src/powercontext/builtin/persistence/cursors.py 
# AI usage statement

Developed with Codex