### PR TITLE
docs(locomo): remove dead CONVERSATION_PROFILE_AB link

### DIFF
--- a/benchmark/locomo/README.md
+++ b/benchmark/locomo/README.md
@@ -186,5 +186,6 @@ Each run writes under `benchmark/locomo/results/<run-id>/`:
 The `results/` directory is ignored because raw outputs can be large and deployment-specific. Publish a reviewed,
 non-secret result separately when it should become repository evidence.
 
-The reviewed full-run comparison for the built-in `coding` and `conversation` extraction profiles is published in
-[`CONVERSATION_PROFILE_AB.md`](CONVERSATION_PROFILE_AB.md).
+Reviewed non-secret comparison reports should be published as separate artifacts with the
+`run.json` identity (dataset hash, extraction profile, top-k, judge profile, and model names).
+This repository does not currently include a reviewed coding-versus-conversation A/B report.


### PR DESCRIPTION
## Summary

- Refs https://github.com/oceanbase/powercontext/issues/1263
- Remove the dead `CONVERSATION_PROFILE_AB.md` link from `benchmark/locomo/README.md`.
- Do not publish a coding-versus-conversation A/B report. Point readers at the `run.json` identity instead.

This is the small, separate docs change requested in the tracking issue discussion. The e2e sample guide and LoCoMo-derived acceptance cases stay in #1272.

## Test plan

- Confirm `CONVERSATION_PROFILE_AB.md` is still absent from the tree.
- Confirm the LoCoMo README no longer links to that file.

## AI usage statement

Used an AI coding assistant to draft this small docs change.