### PR TITLE
fix: oceanbase identity collation collapses case-variant scope_id and source_id

### DIFF
--- a/src/powercontext/builtin/handoff_report/catalog_store.py
+++ b/src/powercontext/builtin/handoff_report/catalog_store.py
@@ -19,7 +19,6 @@ from sqlalchemy import (
     Index,
     Integer,
     MetaData,
-    String,
     Table,
     Text,
     UniqueConstraint,
@@ -46,6 +45,7 @@ from powercontext.builtin.handoff_report.models import (
     ProjectDescriptor,
     WorkstreamDescriptor,
 )
+from powercontext.builtin.persistence.tables import identity_string
 from powercontext.limits import MAX_SCOPE_ID_LENGTH
 
 HANDOFF_REPORT_CATALOG_METADATA = MetaData()
@@ -53,10 +53,10 @@ HANDOFF_REPORT_CATALOG_METADATA = MetaData()
 HANDOFF_REPORT_PROJECTS_TABLE = Table(
     "pc_handoff_report_projects",
     HANDOFF_REPORT_CATALOG_METADATA,
-    Column("project_id", String(MAX_REPORT_ID_LENGTH), primary_key=True),
-    Column("project_key", String(MAX_PROJECT_KEY_LENGTH), nullable=False, unique=True),
+    Column("project_id", identity_string(MAX_REPORT_ID_LENGTH), primary_key=True),
+    Column("project_key", identity_string(MAX_PROJECT_KEY_LENGTH), nullable=False, unique=True),
     Column("version", Integer, nullable=False),
-    Column("catalog_state", String(16), nullable=False),
+    Column("catalog_state", identity_string(16), nullable=False),
     Column("payload", Text, nullable=False),
     CheckConstraint("version > 0", name="ck_pc_handoff_report_projects_version_positive"),
 )
@@ -64,9 +64,9 @@ HANDOFF_REPORT_PROJECTS_TABLE = Table(
 HANDOFF_REPORT_PROJECT_REVISIONS_TABLE = Table(
     "pc_handoff_report_project_revisions",
     HANDOFF_REPORT_CATALOG_METADATA,
-    Column("project_id", String(MAX_REPORT_ID_LENGTH), primary_key=True),
+    Column("project_id", identity_string(MAX_REPORT_ID_LENGTH), primary_key=True),
     Column("version", Integer, primary_key=True),
-    Column("effective_at", String(32), nullable=False),
+    Column("effective_at", identity_string(32), nullable=False),
     Column("payload", Text, nullable=False),
     CheckConstraint("version > 0", name="ck_pc_handoff_report_project_revisions_version_positive"),
 )
@@ -80,11 +80,11 @@ Index(
 HANDOFF_REPORT_WORKSTREAMS_TABLE = Table(
     "pc_handoff_report_workstreams",
     HANDOFF_REPORT_CATALOG_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("project_id", String(MAX_REPORT_ID_LENGTH), nullable=False),
-    Column("workstream_key", String(MAX_WORKSTREAM_KEY_LENGTH)),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("project_id", identity_string(MAX_REPORT_ID_LENGTH), nullable=False),
+    Column("workstream_key", identity_string(MAX_WORKSTREAM_KEY_LENGTH)),
     Column("version", Integer, nullable=False),
-    Column("catalog_state", String(16), nullable=False),
+    Column("catalog_state", identity_string(16), nullable=False),
     Column("payload", Text, nullable=False),
     UniqueConstraint(
         "project_id",
@@ -102,10 +102,10 @@ Index(
 HANDOFF_REPORT_WORKSTREAM_REVISIONS_TABLE = Table(
     "pc_handoff_report_workstream_revisions",
     HANDOFF_REPORT_CATALOG_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
     Column("version", Integer, primary_key=True),
-    Column("project_id", String(MAX_REPORT_ID_LENGTH), nullable=False),
-    Column("effective_at", String(32), nullable=False),
+    Column("project_id", identity_string(MAX_REPORT_ID_LENGTH), nullable=False),
+    Column("effective_at", identity_string(32), nullable=False),
     Column("payload", Text, nullable=False),
     CheckConstraint("version > 0", name="ck_pc_handoff_report_workstream_revisions_version_positive"),
 )

--- a/src/powercontext/builtin/handoff_report/sqlite.py
+++ b/src/powercontext/builtin/handoff_report/sqlite.py
@@ -14,7 +14,6 @@ from sqlalchemy import (
     Column,
     Index,
     MetaData,
-    String,
     Table,
     Text,
     UniqueConstraint,
@@ -42,6 +41,7 @@ from powercontext.builtin.handoff_report.repository import (
     StoredActivityEventError,
 )
 from powercontext.builtin.handoff_report.workspace_store import HANDOFF_REPORT_WORKSPACE_TABLES
+from powercontext.builtin.persistence.tables import identity_string
 from powercontext.limits import MAX_SCOPE_ID_LENGTH
 
 HANDOFF_REPORT_METADATA = MetaData()
@@ -49,23 +49,23 @@ HANDOFF_REPORT_METADATA = MetaData()
 HANDOFF_REPORT_ACTIVITY_HEADS_TABLE = Table(
     "pc_handoff_report_activity_heads",
     HANDOFF_REPORT_METADATA,
-    Column("project_id", String(MAX_REPORT_ID_LENGTH), primary_key=True),
+    Column("project_id", identity_string(MAX_REPORT_ID_LENGTH), primary_key=True),
     Column("cursor", BigInteger, nullable=False),
 )
 
 HANDOFF_REPORT_ACTIVITIES_TABLE = Table(
     "pc_handoff_report_activities",
     HANDOFF_REPORT_METADATA,
-    Column("project_id", String(MAX_REPORT_ID_LENGTH), primary_key=True),
+    Column("project_id", identity_string(MAX_REPORT_ID_LENGTH), primary_key=True),
     Column("cursor", BigInteger, primary_key=True),
-    Column("event_id", String(MAX_REPORT_ID_LENGTH), nullable=False, unique=True),
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH)),
-    Column("source", String(64), nullable=False),
-    Column("source_event_id", String(MAX_REPORT_ID_LENGTH), nullable=False),
-    Column("occurred_at", String(32)),
-    Column("observed_at", String(32), nullable=False),
-    Column("period_at", String(32)),
-    Column("time_basis", String(32), nullable=False),
+    Column("event_id", identity_string(MAX_REPORT_ID_LENGTH), nullable=False, unique=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH)),
+    Column("source", identity_string(64), nullable=False),
+    Column("source_event_id", identity_string(MAX_REPORT_ID_LENGTH), nullable=False),
+    Column("occurred_at", identity_string(32)),
+    Column("observed_at", identity_string(32), nullable=False),
+    Column("period_at", identity_string(32)),
+    Column("time_basis", identity_string(32), nullable=False),
     Column("payload", Text, nullable=False),
     UniqueConstraint("source", "source_event_id", name="uq_pc_handoff_report_activities_source_event"),
 )

--- a/src/powercontext/builtin/handoff_report/workspace_store.py
+++ b/src/powercontext/builtin/handoff_report/workspace_store.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import ValidationError
-from sqlalchemy import CheckConstraint, Column, Integer, MetaData, String, Table, Text, insert, select, update
+from sqlalchemy import CheckConstraint, Column, Integer, MetaData, Table, Text, insert, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -26,20 +26,21 @@ from powercontext.builtin.handoff_report.models import (
     MAX_WORKSPACE_INSTANCE_ID_LENGTH,
     WorkspaceBinding,
 )
+from powercontext.builtin.persistence.tables import identity_string
 
 HANDOFF_REPORT_WORKSPACE_METADATA = MetaData()
 
 HANDOFF_REPORT_WORKSPACE_BINDINGS_TABLE = Table(
     "pc_handoff_report_workspace_bindings",
     HANDOFF_REPORT_WORKSPACE_METADATA,
-    Column("workspace_instance_id", String(MAX_WORKSPACE_INSTANCE_ID_LENGTH), primary_key=True),
-    Column("project_id", String(MAX_REPORT_ID_LENGTH), nullable=False),
-    Column("provider", String(32), nullable=False),
-    Column("repository_id", String(MAX_REPORT_REPOSITORY_ID_LENGTH)),
-    Column("normalized_remote", String(MAX_REPORT_NORMALIZED_REMOTE_LENGTH)),
-    Column("subpath", String(MAX_REPORT_SUBPATH_LENGTH)),
-    Column("state", String(16), nullable=False),
-    Column("confirmed_at", String(32), nullable=False),
+    Column("workspace_instance_id", identity_string(MAX_WORKSPACE_INSTANCE_ID_LENGTH), primary_key=True),
+    Column("project_id", identity_string(MAX_REPORT_ID_LENGTH), nullable=False),
+    Column("provider", identity_string(32), nullable=False),
+    Column("repository_id", identity_string(MAX_REPORT_REPOSITORY_ID_LENGTH)),
+    Column("normalized_remote", identity_string(MAX_REPORT_NORMALIZED_REMOTE_LENGTH)),
+    Column("subpath", identity_string(MAX_REPORT_SUBPATH_LENGTH)),
+    Column("state", identity_string(16), nullable=False),
+    Column("confirmed_at", identity_string(32), nullable=False),
     Column("version", Integer, nullable=False),
     Column("payload", Text, nullable=False),
     CheckConstraint("version > 0", name="ck_pc_handoff_report_workspace_bindings_version_positive"),

--- a/src/powercontext/builtin/persistence/oceanbase/memory_index.py
+++ b/src/powercontext/builtin/persistence/oceanbase/memory_index.py
@@ -7,7 +7,6 @@ from sqlalchemy import (
     BigInteger,
     Column,
     MetaData,
-    String,
     Table,
     UniqueConstraint,
     bindparam,
@@ -35,6 +34,7 @@ from powercontext.builtin.persistence.tables import (
     MAX_MEMORY_HASH_LENGTH,
     MEMORY_ENTRY_HEADS_TABLE,
     MEMORY_ENTRY_VERSIONS_TABLE,
+    identity_string,
 )
 from powercontext.limits import MAX_ARTIFACT_ID_LENGTH, MAX_SCOPE_ID_LENGTH
 
@@ -199,13 +199,13 @@ class OceanBaseMemoryVectorIndex:
             _OCEANBASE_VECTOR_TABLE_NAME,
             metadata,
             Column("vector_id", BigInteger, primary_key=True, autoincrement=True),
-            Column("scope_id", String(MAX_SCOPE_ID_LENGTH), nullable=False),
-            Column("memory_artifact_id", String(MAX_ARTIFACT_ID_LENGTH), nullable=False),
+            Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), nullable=False),
+            Column("memory_artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH), nullable=False),
             Column("head_revision", BigInteger, nullable=False),
-            Column("entry_id", String(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
-            Column("entry_version_id", String(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
-            Column("entry_content_hash", String(MAX_MEMORY_HASH_LENGTH), nullable=False),
-            Column("embedding_content_hash", String(MAX_MEMORY_HASH_LENGTH), nullable=False),
+            Column("entry_id", identity_string(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
+            Column("entry_version_id", identity_string(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
+            Column("entry_content_hash", identity_string(MAX_MEMORY_HASH_LENGTH), nullable=False),
+            Column("embedding_content_hash", identity_string(MAX_MEMORY_HASH_LENGTH), nullable=False),
             Column("embedding", VECTOR(profile.dimension), nullable=False),
             UniqueConstraint(
                 "scope_id",

--- a/src/powercontext/builtin/persistence/sqlite/memory_index.py
+++ b/src/powercontext/builtin/persistence/sqlite/memory_index.py
@@ -14,7 +14,6 @@ from sqlalchemy import (
     Column,
     ForeignKeyConstraint,
     Integer,
-    String,
     Table,
     UniqueConstraint,
     delete,
@@ -45,6 +44,7 @@ from powercontext.builtin.persistence.tables import (
     MAX_MEMORY_HASH_LENGTH,
     MEMORY_ENTRY_HEADS_TABLE,
     SHARED_METADATA,
+    identity_string,
 )
 from powercontext.limits import MAX_ARTIFACT_ID_LENGTH, MAX_SCOPE_ID_LENGTH
 
@@ -64,13 +64,13 @@ SQLITE_MEMORY_VECTOR_ENTRIES_TABLE = Table(
     "pc_memory_vector_entries",
     SHARED_METADATA,
     Column("vector_id", Integer, primary_key=True, autoincrement=True),
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), nullable=False),
-    Column("memory_artifact_id", String(MAX_ARTIFACT_ID_LENGTH), nullable=False),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), nullable=False),
+    Column("memory_artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH), nullable=False),
     Column("head_revision", Integer, nullable=False),
-    Column("entry_id", String(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
-    Column("entry_version_id", String(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
-    Column("entry_content_hash", String(MAX_MEMORY_HASH_LENGTH), nullable=False),
-    Column("embedding_content_hash", String(MAX_MEMORY_HASH_LENGTH), nullable=False),
+    Column("entry_id", identity_string(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
+    Column("entry_version_id", identity_string(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
+    Column("entry_content_hash", identity_string(MAX_MEMORY_HASH_LENGTH), nullable=False),
+    Column("embedding_content_hash", identity_string(MAX_MEMORY_HASH_LENGTH), nullable=False),
     UniqueConstraint(
         "scope_id",
         "memory_artifact_id",

--- a/src/powercontext/builtin/persistence/tables.py
+++ b/src/powercontext/builtin/persistence/tables.py
@@ -15,7 +15,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.mysql import MEDIUMBLOB, MEDIUMTEXT
+from sqlalchemy.dialects.mysql import MEDIUMBLOB, MEDIUMTEXT, VARCHAR
 
 from powercontext.limits import (
     MAX_ARTIFACT_FAMILY_LENGTH,
@@ -32,6 +32,26 @@ from powercontext.limits import (
 
 SHARED_METADATA = MetaData()
 
+_MYSQL_IDENTITY_COLLATION = "utf8mb4_bin"
+
+
+def identity_string(length: int):
+    """Opaque identity text compared byte-exactly on every backend.
+
+    SQLite compares ``String`` values with BINARY semantics. MySQL/OceanBase
+    otherwise inherit the server default ``utf8mb4_general_ci``, which would
+    collapse case-variant and accent-variant ``scope_id`` / ``source_id`` keys.
+
+    ``create_all(checkfirst=True)`` does not rewrite existing column collations,
+    and OceanBase rejects ``ALTER COLUMN ... COLLATE`` when foreign keys exist.
+    Existing MySQL/OceanBase schemas must be recreated to pick up this type.
+    """
+
+    return String(length).with_variant(
+        VARCHAR(length, charset="utf8mb4", collation=_MYSQL_IDENTITY_COLLATION),
+        "mysql",
+    )
+
 
 def _canonical_payload_type():
     return LargeBinary().with_variant(MEDIUMBLOB(), "mysql")
@@ -44,9 +64,9 @@ def _entry_text_type():
 SOURCES_TABLE = Table(
     "pc_sources",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("source_type", String(MAX_SOURCE_TYPE_LENGTH), primary_key=True),
-    Column("source_id", String(MAX_SOURCE_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("source_type", identity_string(MAX_SOURCE_TYPE_LENGTH), primary_key=True),
+    Column("source_id", identity_string(MAX_SOURCE_ID_LENGTH), primary_key=True),
     Column("payload", _canonical_payload_type(), nullable=False),
     Column("journal_position", BigInteger, nullable=False),
     UniqueConstraint("scope_id", "journal_position", name="uq_pc_sources_scope_journal_position"),
@@ -55,7 +75,7 @@ SOURCES_TABLE = Table(
 SOURCE_JOURNAL_HEADS_TABLE = Table(
     "pc_source_journal_heads",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
     Column("position", BigInteger, nullable=False),
     CheckConstraint("position >= 0", name="ck_pc_source_journal_heads_position_nonnegative"),
 )
@@ -63,9 +83,9 @@ SOURCE_JOURNAL_HEADS_TABLE = Table(
 ARTIFACTS_TABLE = Table(
     "pc_artifacts",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("family", String(MAX_ARTIFACT_FAMILY_LENGTH), primary_key=True),
-    Column("artifact_id", String(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH), primary_key=True),
+    Column("artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
     Column("revision", Integer, primary_key=True),
     Column("content", _canonical_payload_type(), nullable=False),
 )
@@ -73,9 +93,9 @@ ARTIFACTS_TABLE = Table(
 ARTIFACT_HEADS_TABLE = Table(
     "pc_artifact_heads",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("family", String(MAX_ARTIFACT_FAMILY_LENGTH), primary_key=True),
-    Column("artifact_id", String(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH), primary_key=True),
+    Column("artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
     Column("revision", Integer, nullable=False),
     Column("searchable_text", _entry_text_type()),
     ForeignKeyConstraint(
@@ -95,13 +115,13 @@ ARTIFACT_HEADS_TABLE = Table(
 ARTIFACT_LINEAGE_SOURCES_TABLE = Table(
     "pc_artifact_lineage_sources",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("family", String(MAX_ARTIFACT_FAMILY_LENGTH), primary_key=True),
-    Column("artifact_id", String(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH), primary_key=True),
+    Column("artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
     Column("revision", Integer, primary_key=True),
     Column("ordinal", Integer, primary_key=True),
-    Column("source_type", String(MAX_SOURCE_TYPE_LENGTH), nullable=False),
-    Column("source_id", String(MAX_SOURCE_ID_LENGTH), nullable=False),
+    Column("source_type", identity_string(MAX_SOURCE_TYPE_LENGTH), nullable=False),
+    Column("source_id", identity_string(MAX_SOURCE_ID_LENGTH), nullable=False),
     ForeignKeyConstraint(
         ("scope_id", "family", "artifact_id", "revision"),
         (
@@ -122,13 +142,13 @@ ARTIFACT_LINEAGE_SOURCES_TABLE = Table(
 ARTIFACT_LINEAGE_ARTIFACTS_TABLE = Table(
     "pc_artifact_lineage_artifacts",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("family", String(MAX_ARTIFACT_FAMILY_LENGTH), primary_key=True),
-    Column("artifact_id", String(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH), primary_key=True),
+    Column("artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
     Column("revision", Integer, primary_key=True),
     Column("ordinal", Integer, primary_key=True),
-    Column("upstream_family", String(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
-    Column("upstream_artifact_id", String(MAX_ARTIFACT_ID_LENGTH), nullable=False),
+    Column("upstream_family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
+    Column("upstream_artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH), nullable=False),
     Column("upstream_revision", Integer, nullable=False),
     ForeignKeyConstraint(
         ("scope_id", "family", "artifact_id", "revision"),
@@ -155,15 +175,15 @@ ARTIFACT_LINEAGE_ARTIFACTS_TABLE = Table(
 ARTIFACT_CANDIDATE_VERSIONS_TABLE = Table(
     "pc_artifact_candidate_versions",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("candidate_id", String(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("candidate_id", identity_string(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
     Column("version", Integer, primary_key=True),
-    Column("family", String(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
+    Column("family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
     Column("proposal", _canonical_payload_type(), nullable=False),
     Column("source_refs", _canonical_payload_type(), nullable=False),
     Column("artifact_refs", _canonical_payload_type(), nullable=False),
-    Column("target_family", String(MAX_ARTIFACT_FAMILY_LENGTH)),
-    Column("target_artifact_id", String(MAX_ARTIFACT_ID_LENGTH)),
+    Column("target_family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH)),
+    Column("target_artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH)),
     Column("target_revision", Integer),
     Column("reason", _entry_text_type()),
     ForeignKeyConstraint(
@@ -187,13 +207,13 @@ ARTIFACT_CANDIDATE_VERSIONS_TABLE = Table(
 ARTIFACT_CANDIDATE_HEADS_TABLE = Table(
     "pc_artifact_candidate_heads",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("candidate_id", String(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
-    Column("family", String(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("candidate_id", identity_string(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
+    Column("family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
     Column("version", Integer, nullable=False),
-    Column("status", String(16), nullable=False),
-    Column("result_family", String(MAX_ARTIFACT_FAMILY_LENGTH)),
-    Column("result_artifact_id", String(MAX_ARTIFACT_ID_LENGTH)),
+    Column("status", identity_string(16), nullable=False),
+    Column("result_family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH)),
+    Column("result_artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH)),
     Column("result_revision", Integer),
     Column("decision_reason", _entry_text_type()),
     ForeignKeyConstraint(
@@ -233,8 +253,8 @@ ARTIFACT_CANDIDATE_HEADS_TABLE = Table(
 SOURCE_CURSORS_TABLE = Table(
     "pc_source_cursors",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("binding_name", String(MAX_BINDING_NAME_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("binding_name", identity_string(MAX_BINDING_NAME_LENGTH), primary_key=True),
     Column("cursor", _canonical_payload_type(), nullable=False),
     Column("generation", BigInteger, nullable=False),
     CheckConstraint("generation >= 0", name="ck_pc_source_cursors_generation_nonnegative"),
@@ -243,17 +263,17 @@ SOURCE_CURSORS_TABLE = Table(
 EXTERNAL_SKILL_REGISTRATIONS_TABLE = Table(
     "pc_external_skill_registrations",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("external_skill_id", String(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
-    Column("provider", String(MAX_SOURCE_TYPE_LENGTH), nullable=False),
-    Column("agent_kind", String(MAX_SOURCE_TYPE_LENGTH), nullable=False),
-    Column("host_id", String(MAX_EXTERNAL_SKILL_HOST_ID_LENGTH), nullable=False),
-    Column("installation_scope", String(16), nullable=False),
-    Column("locator", String(MAX_EXTERNAL_SKILL_LOCATOR_LENGTH), nullable=False),
-    Column("locator_hash", String(64), nullable=False),
-    Column("fingerprint", String(64), nullable=False),
-    Column("name", String(MAX_EXTERNAL_SKILL_NAME_LENGTH), nullable=False),
-    Column("description", String(MAX_EXTERNAL_SKILL_DESCRIPTION_LENGTH), nullable=False),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("external_skill_id", identity_string(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
+    Column("provider", identity_string(MAX_SOURCE_TYPE_LENGTH), nullable=False),
+    Column("agent_kind", identity_string(MAX_SOURCE_TYPE_LENGTH), nullable=False),
+    Column("host_id", identity_string(MAX_EXTERNAL_SKILL_HOST_ID_LENGTH), nullable=False),
+    Column("installation_scope", identity_string(16), nullable=False),
+    Column("locator", identity_string(MAX_EXTERNAL_SKILL_LOCATOR_LENGTH), nullable=False),
+    Column("locator_hash", identity_string(64), nullable=False),
+    Column("fingerprint", identity_string(64), nullable=False),
+    Column("name", identity_string(MAX_EXTERNAL_SKILL_NAME_LENGTH), nullable=False),
+    Column("description", identity_string(MAX_EXTERNAL_SKILL_DESCRIPTION_LENGTH), nullable=False),
     UniqueConstraint(
         "scope_id",
         "provider",
@@ -271,10 +291,10 @@ EXTERNAL_SKILL_REGISTRATIONS_TABLE = Table(
 MODEL_USAGE_DAILY_TABLE = Table(
     "pc_model_usage_daily",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
     Column("usage_date", Date, primary_key=True),
-    Column("purpose", String(64), primary_key=True),
-    Column("operation", String(16), primary_key=True),
+    Column("purpose", identity_string(64), primary_key=True),
+    Column("operation", identity_string(16), primary_key=True),
     Column("requests", BigInteger, nullable=False),
     Column("input_tokens", BigInteger, nullable=False),
     Column("output_tokens", BigInteger, nullable=False),
@@ -292,10 +312,10 @@ MODEL_USAGE_DAILY_TABLE = Table(
 RECALL_TOKEN_DAILY_TABLE = Table(
     "pc_recall_token_daily",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
     Column("usage_date", Date, primary_key=True),
-    Column("estimator_id", String(128), primary_key=True),
-    Column("estimator_version", String(64), primary_key=True),
+    Column("estimator_id", identity_string(128), primary_key=True),
+    Column("estimator_version", identity_string(64), primary_key=True),
     Column("preparations", BigInteger, nullable=False),
     Column("ready_preparations", BigInteger, nullable=False),
     Column("comparable_preparations", BigInteger, nullable=False),
@@ -335,18 +355,18 @@ MAX_MEMORY_HASH_LENGTH = 64
 MEMORY_ENTRY_VERSIONS_TABLE = Table(
     "pc_memory_entry_versions",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("family", String(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
-    Column("memory_artifact_id", String(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
-    Column("entry_id", String(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
-    Column("entry_version_id", String(MAX_MEMORY_ENTRY_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
+    Column("memory_artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
+    Column("entry_id", identity_string(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
+    Column("entry_version_id", identity_string(MAX_MEMORY_ENTRY_ID_LENGTH), primary_key=True),
     Column("version", Integer, nullable=False),
-    Column("previous_version_id", String(MAX_MEMORY_ENTRY_ID_LENGTH)),
-    Column("kind", String(MAX_MEMORY_ENTRY_KIND_LENGTH), nullable=False),
+    Column("previous_version_id", identity_string(MAX_MEMORY_ENTRY_ID_LENGTH)),
+    Column("kind", identity_string(MAX_MEMORY_ENTRY_KIND_LENGTH), nullable=False),
     Column("text", _entry_text_type(), nullable=False),
     Column("source_refs", _canonical_payload_type(), nullable=False),
     Column("artifact_refs", _canonical_payload_type(), nullable=False),
-    Column("entry_content_hash", String(MAX_MEMORY_HASH_LENGTH), nullable=False),
+    Column("entry_content_hash", identity_string(MAX_MEMORY_HASH_LENGTH), nullable=False),
     Column("created_in_revision", Integer, nullable=False),
     UniqueConstraint(
         "scope_id",
@@ -382,13 +402,13 @@ MEMORY_ENTRY_VERSIONS_TABLE = Table(
 MEMORY_ENTRY_HEADS_TABLE = Table(
     "pc_memory_entry_heads",
     SHARED_METADATA,
-    Column("scope_id", String(MAX_SCOPE_ID_LENGTH), primary_key=True),
-    Column("family", String(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
-    Column("memory_artifact_id", String(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
+    Column("scope_id", identity_string(MAX_SCOPE_ID_LENGTH), primary_key=True),
+    Column("family", identity_string(MAX_ARTIFACT_FAMILY_LENGTH), nullable=False),
+    Column("memory_artifact_id", identity_string(MAX_ARTIFACT_ID_LENGTH), primary_key=True),
     Column("head_revision", Integer, nullable=False),
-    Column("entry_id", String(MAX_MEMORY_ENTRY_ID_LENGTH), primary_key=True),
-    Column("entry_version_id", String(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
-    Column("entry_content_hash", String(MAX_MEMORY_HASH_LENGTH), nullable=False),
+    Column("entry_id", identity_string(MAX_MEMORY_ENTRY_ID_LENGTH), primary_key=True),
+    Column("entry_version_id", identity_string(MAX_MEMORY_ENTRY_ID_LENGTH), nullable=False),
+    Column("entry_content_hash", identity_string(MAX_MEMORY_HASH_LENGTH), nullable=False),
     Column("searchable_text", _entry_text_type(), nullable=False),
     ForeignKeyConstraint(
         ("scope_id", "family", "memory_artifact_id", "head_revision"),

--- a/tests/builtin/persistence/test_memory.py
+++ b/tests/builtin/persistence/test_memory.py
@@ -41,6 +41,7 @@ def test_memory_schema_is_mysql_compilable_and_respects_key_and_payload_limits()
     versions = str(CreateTable(MEMORY_ENTRY_VERSIONS_TABLE).compile(dialect=dialect))
     heads = str(CreateTable(MEMORY_ENTRY_HEADS_TABLE).compile(dialect=dialect))
 
+    assert "scope_id VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL" in versions
     assert "text MEDIUMTEXT NOT NULL" in versions
     assert "source_refs MEDIUMBLOB NOT NULL" in versions
     assert "artifact_refs MEDIUMBLOB NOT NULL" in versions

--- a/tests/builtin/persistence/test_mysql_schema.py
+++ b/tests/builtin/persistence/test_mysql_schema.py
@@ -31,6 +31,14 @@ def _column_budget(column) -> int:
     raise _UnbudgetedColumnTypeError(column.type)
 
 
+def test_mysql_ddl_uses_utf8mb4_bin_for_identity_keys() -> None:
+    dialect = mysql.dialect()
+    ddl = str(CreateTable(SOURCES_TABLE).compile(dialect=dialect))
+    assert "scope_id VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL" in ddl
+    assert "source_id VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL" in ddl
+    assert "source_type VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL" in ddl
+
+
 def test_mysql_ddl_uses_mediumblob_for_every_canonical_payload() -> None:
     dialect = mysql.dialect()
     expected = {

--- a/tests/e2e/test_runtime_server.py
+++ b/tests/e2e/test_runtime_server.py
@@ -205,6 +205,58 @@ def test_server_databases_share_source_to_memory_search_behavior(
     asyncio.run(scenario())
 
 
+@pytest.mark.parametrize("database_kind", ["sqlite", "oceanbase"])
+def test_server_databases_keep_case_and_accent_variant_identities_distinct(
+    database_kind: str,
+    tmp_path: Path,
+) -> None:
+    if database_kind == "oceanbase":
+        if OCEANBASE_URL is None:
+            pytest.skip("set POWERCONTEXT_TEST_OCEANBASE_URL to a dedicated OceanBase MySQL-mode test database")
+        database = OceanBaseConfig(url=SecretStr(OCEANBASE_URL))
+    else:
+        database = SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'identity.db'}")
+    marker = uuid4().hex[:12]
+    writer_scope = f"PC-{marker}-Alpha"
+    reader_scope = writer_scope.lower()
+    accent_scope = f"{marker}-café"
+    plain_scope = f"{marker}-cafe"
+    memory_text = "Rotate the production signing key every ninety days."
+    app = create_server_app(
+        settings=ServerSettings(database=database, mcp=McpConfig(enabled=False)),
+    )
+
+    async def scenario() -> None:
+        async with (
+            app.router.lifespan_context(app),
+            httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+            ) as transport,
+        ):
+            client = PowerContextClient("http://testserver", http_client=transport)
+            await client.remember_memory(RememberMemoryRequest(scope_id=writer_scope, kind="fact", text=memory_text))
+            leaked = await client.list_memory_entries(ListMemoryEntriesRequest(scope_id=reader_scope))
+            await client.remember_memory(
+                RememberMemoryRequest(scope_id=accent_scope, kind="fact", text="Espresso is on the third floor.")
+            )
+            accent_leaked = await client.list_memory_entries(ListMemoryEntriesRequest(scope_id=plain_scope))
+            source_scope = f"{marker}-src"
+            await client.capture_content_source(
+                CaptureContentSourceRequest(scope_id=source_scope, source_id="Turn-1", content="uppercase turn")
+            )
+            second = await client.capture_content_source(
+                CaptureContentSourceRequest(scope_id=source_scope, source_id="turn-1", content="lowercase turn")
+            )
+
+        assert not leaked.entries
+        assert leaked.memory is None
+        assert not accent_leaked.entries
+        assert second.position == 2
+
+    asyncio.run(scenario())
+
+
 def test_inference_failure_degrades_readiness_without_blocking_database_operations(tmp_path: Path) -> None:
     app = create_server_app(
         settings=_server_settings(tmp_path / "degraded.db"),


### PR DESCRIPTION
# Which issue or RFC does this PR close?

<!--
Link the related issue or RFC using GitHub syntax.
For example, `Closes #123` indicates that this PR will close issue #123.
If this PR implements an RFC, link the RFC and any existing tracking issue.
-->

Closes #1276.

# Rationale for this change

<!--
Explain why this change is needed. If the linked issue or RFC already explains the rationale clearly, a short summary is enough.
-->

`scope_id` and `source_id` are opaque, byte-exact identities. Shared schema columns were declared as dialect-neutral `String(...)` with no collation, so MySQL/OceanBase inherited the server default `utf8mb4_general_ci`. SQLite compares the same columns with BINARY semantics, which is why the SQLite test matrix never caught this.

On OceanBase that collation collapses case-variant and accent-variant keys:

- `scope_id="Alpha"` and `"alpha"` are one Scope, so listing the second returns the first Scope's Memory.
- `source_id="Turn-1"` and `"turn-1"` are one Source, so a legitimate second capture is rejected as `409 source_conflict` and that turn never enters the Source journal.

# What changes are included in this PR?

<!--
Summarize the important changes. Focus on behavior, API, docs, tests, and migration impact.
-->

- Add `identity_string(length)` in `tables.py`. SQLite keeps `String`; MySQL/OceanBase emit `VARCHAR(..., charset="utf8mb4", collation="utf8mb4_bin")`.
- Use that type for identity columns in the shared persistence schema, Memory search indexes, and Handoff Report catalog / activity / workspace tables.
- Assert compiled MySQL DDL includes `CHARACTER SET utf8mb4 COLLATE utf8mb4_bin` for `scope_id`, `source_id`, and `source_type`.
- Add a SQLite and OceanBase parametrized e2e test that writes Memory under a case-variant and an accent-variant `scope_id`, asserts the other variant lists no entries, and captures both `Turn-1` and `turn-1`.

`create_all(checkfirst=True)` does not rewrite existing column collations, and OceanBase rejects `ALTER COLUMN ... COLLATE` when foreign keys exist. Existing MySQL/OceanBase schemas must be recreated on a new database (or by dropping and recreating the tables). Startup does not run an in-place ALTER.

# Are there any user-facing changes?

<!--
If there are user-facing changes, documentation may need to be updated before approval.
If there are breaking changes to public APIs or persisted formats, call them out explicitly.
-->

Public HTTP and SDK APIs are unchanged. On a fresh MySQL/OceanBase schema, identity comparison now matches SQLite and the Runtime: case-variant and accent-variant `scope_id` / `source_id` values are distinct.

This is a persisted-schema break for existing OceanBase/MySQL deployments. Databases created before this change keep `utf8mb4_general_ci` on identity columns and will still leak or reject those variants until the schema is recreated. SQLite files are unaffected.

# How was this change tested?

<!--
List commands run, tests added or updated, and any manual validation performed.
-->

- `uv run pytest -q tests/builtin/persistence/test_mysql_schema.py tests/builtin/persistence/test_memory.py tests/test_handoff_report_catalog.py tests/test_handoff_report_workspace.py tests/test_handoff_report_repository.py`
- `POWERCONTEXT_TEST_OCEANBASE_URL=... uv run pytest -q tests/e2e/test_runtime_server.py::test_server_databases_keep_case_and_accent_variant_identities_distinct` (sqlite + oceanbase)
- Live OceanBase `SHOW CREATE TABLE pc_sources` on a newly created database: `scope_id`, `source_id`, and `source_type` are `varchar(...) COLLATE utf8mb4_bin`
- Re-ran the #1276 reproduction against that new schema: listing `alpha` after writing `Alpha` returned 0 entries; capturing `turn-1` after `Turn-1` was accepted

The OceanBase checks used a dedicated empty database. An older schema on the same instance still showed `utf8mb4_general_ci` on `source_id` and would still reproduce #1276.

# AI usage statement

<!--
If AI tools were used to build this PR, describe the tool and model where possible.
If not applicable, write `Not used`.
-->
