### PR TITLE
chore(release): prepare v0.0.2

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -59,9 +59,14 @@ jobs:
           import urllib.request
 
           tag = os.environ["RELEASE_TAG"]
-          version = tag.removeprefix("v")
+          if tag.startswith("powercontext-v"):
+              version = tag.removeprefix("powercontext-v")
+          else:
+              version = tag.removeprefix("v")
           if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", version):
-              raise SystemExit("release_tag must use vX.Y.Z or X.Y.Z semantic versioning")
+              raise SystemExit(
+                  "release_tag must use vX.Y.Z, powercontext-vX.Y.Z, or X.Y.Z semantic versioning"
+              )
 
           package = os.environ["RELEASE_PACKAGE"]
           if package not in {"auto", "powercontext", "powermem"}:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,14 @@ jobs:
           from pathlib import Path
 
           release_tag = os.environ["RELEASE_TAG"]
-          release_version = release_tag.removeprefix("v")
+          if release_tag.startswith("powercontext-v"):
+              release_version = release_tag.removeprefix("powercontext-v")
+          else:
+              release_version = release_tag.removeprefix("v")
           if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?", release_version):
-              raise SystemExit("Release tag must use vX.Y.Z or X.Y.Z semantic versioning")
+              raise SystemExit(
+                  "Release tag must use vX.Y.Z, powercontext-vX.Y.Z, or X.Y.Z semantic versioning"
+              )
 
           pyproject_path = Path("pyproject.toml")
           pyproject_text = pyproject_path.read_text()

--- a/README.md
+++ b/README.md
@@ -1,65 +1,136 @@
 # PowerContext
 
-**PowerContext is PowerMem 2.0, the upgraded version of [PowerMem](https://www.powermem.ai/).**
+**Beyond memory**
 
 [![PyPI version](https://img.shields.io/pypi/v/powercontext)](https://pypi.org/project/powercontext/)
 [![License Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/74cF8vbNEs)
 
-PowerContext gives agents durable, project-scoped context. A later session can recover a decision, outcome, current state, or next step without relying on chat history. PowerContext includes a local Server, SQLite storage, an async Python client, a Core SDK, a CLI, a Codex plugin, and a DeepSeek Harness plugin.
+*[English](README.md) · [中文](README_CN.md) · [日本語](README_JP.md)*
 
-## Get started
+PowerContext is the upgraded version of [PowerMem](https://www.powermem.ai/) and a context runtime for human-agent
+collaboration. It turns shared work into project context that can be understood, handed off, and continued.
 
-Use [Install and run](docs/en/docs/how-to/install-and-run.md) for prerequisites, installation, Server startup, and
-verification. Then choose a host integration:
+## Core capabilities
 
-- [Codex quickstart](docs/en/docs/tutorials/codex-quickstart.md) provides a first cross-session Memory workflow.
-- [Configure Codex](docs/en/docs/how-to/configure-codex.md) and
-  [Configure DeepSeek Harness](docs/en/docs/how-to/configure-dsh.md) cover host-specific setup.
-
-For other tasks, start from the [documentation overview](docs/en/docs/index.md).
-
-## Choose an interface
-
-| Interface | Use it for |
+| Capability | Core value |
 | --- | --- |
-| Codex plugin | Restore relevant project memory and explicitly remember, revise, or retire entries while coding |
-| DeepSeek Harness plugin | Restore relevant project memory and explicitly remember, revise, or retire entries in DeepSeek Harness |
-| CLI | Install the plugin, run or connect to the Server, inspect content, and diagnose an installation |
-| Python client | Call the Server's Source and Memory API from an application |
-| Core SDK | Embed PowerContext contracts or supply custom adapters in a Python system |
-| HTTP and MCP | Integrate a non-Python process or an agent host with the running Server |
-
-The [interface reference](docs/en/docs/reference/interfaces.md) explains the ownership boundary between these
-surfaces. Installation, configuration, and troubleshooting live under [`docs/en/docs/`](docs/en/docs/index.md).
-
-## Python projects
-
-Add only the role the project imports:
-
-```bash
-uv add "powercontext[client]==0.0.1"
-```
-
-Available extras are `builtin`, `client`, `server`, `cli`, and `tracing-otlp`. The CLI always includes Server-backed content commands; installing the `server` role also makes local Server process management available.
+| Memory extraction and management | Explicitly record decisions, constraints, outcomes, state, and next steps worth reusing over time; with a generation model configured, Memory can also be extracted from Sources. Revisions and retirements preserve history |
+| Bounded request-time recall | Before an agent handles a request, generate one schema-validated, cited `PreparedContext` based on project scope, relevance, and a byte budget; recall failures do not block the original task |
+| Handoff | Organize the objective, verified progress, blockers, next step, and evidence into an inspectable work package so another session, task, model, or agent host can continue from a clear state |
+| Sources and evidence lineage | Preserve the original sources of knowledge and link Memory and Artifacts with exact citations; capturing a prompt creates only a Source and does not directly turn it into Memory |
+| Experience and Skill governance | A model or caller can only submit a Candidate; an immutable revision is created only after Review, and a Skill must still be exported explicitly—it cannot approve, install, or execute itself |
+| Local and service deployment | Use SQLite directly for local development, choose OceanBase for team deployments, and integrate with existing systems through HTTP/OpenAPI, MCP, authentication, and OpenTelemetry |
 
 ## Benchmarks
 
-### [LOCOMO](https://github.com/snap-research/locomo)
+### [LoCoMo](https://github.com/snap-research/locomo)
 
 | Metric | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | Full-context baseline |
 | --- | ---: | ---: | ---: |
 | Accuracy | **90.78%** (1,398/1,540) | 87.79% | 52.9% |
 | Search p95 latency | **1.38 s** | 1.44 s | 17.12 s |
-| Answer tokens / question | **~1.65 k** | ~0.9 k | 26 k |
+| Answer tokens per question | **~1.65k** | ~0.9k | 26k |
 
-The PowerContext results come from a full 1,540-question run across all 10 LOCOMO conversations.
+The PowerContext result covers all 1,540 scored questions across the benchmark's 10 conversations. See the
+[LoCoMo evaluation details](benchmark/locomo/README.md) for dataset selection, retrieval, judging, latency, token, and
+Artifact boundaries.
+
+### [SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os)
+
+In a paired evaluation over all **731 tasks** in
+[SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os), enabling PowerContext increased the task
+resolution rate from **82.35%** to **86.73%**, an improvement of **4.38 percentage points**.
+
+The evaluation ran in a Codex environment, with both the PowerContext OFF and ON groups using the `gpt-5.6-sol`
+model.
+
+| Result | PowerContext OFF | PowerContext ON | Change |
+| --- | ---: | ---: | ---: |
+| Resolved tasks | 602 / 731 | **634 / 731** | **+32** |
+| Resolution rate | 82.35% | **86.73%** | **+4.38 percentage points** |
+
+[SWE-bench Pro public v2 evaluation details](evaluation/README.md).
+
+---
+
+## Plugins
+
+PowerContext provides official plugins and installation guides for Codex, Claude Code, and DeepSeek Harness. All
+three integrations use the same scoped data and history-preserving contracts through PowerContext Server; the
+plugins do not start or embed the Server.
+
+### Official integrations
+
+<table>
+<tr>
+<td align="center" width="120"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></td>
+<td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
+<td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
+</tr>
+</table>
+
+## Quick start
+
+You need macOS or Linux, Python 3.11 or newer, [`uv`](https://docs.astral.sh/uv/), and Codex CLI.
+
+### 1. Install PowerContext and the plugins
+
+```bash
+uv tool install "powercontext[cli,server]==0.0.2"
+
+# Choose one or more integrations.
+powercontext setup codex --source oceanbase/powercontext --ref v0.0.2
+powercontext setup claude-code --source oceanbase/powercontext --ref v0.0.2
+powercontext setup dsh --source oceanbase/powercontext --ref v0.0.2
+```
+
+The first command installs the CLI and local Server in an isolated environment. The subsequent setup commands
+install the corresponding plugins from the matching repository tag. Run setup again to refresh an existing
+installation.
+
+### 2. Start and verify the local Server
+
+Keep the Server running in one terminal:
+
+```bash
+powercontext server run
+```
+
+In another terminal, verify the service and plugin:
+
+```bash
+powercontext doctor
+powercontext doctor codex  # or: claude-code / dsh
+```
+
+By default, the Server listens on `127.0.0.1:8000`, exposes Streamable HTTP MCP at `/mcp`, and persists data in a
+local SQLite database. Explicit Memory operations work without configuring an inference provider.
 
 ## Development
 
-Repository contributors can install the locked environment and hooks with `make install`. Use `make test`,
-`make check`, and `make docs-test` before opening a pull request. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full
-workflow and [`docs/en/development/`](docs/en/development/core-protocol.md) for implementation guides.
+Install the locked development environment and hooks:
+
+```bash
+make install
+```
+
+Run the main validation commands before opening a pull request:
+
+```bash
+make check
+make test
+make docs-test
+```
+
+After changing `openapi/powercontext.yaml`, run `make contract-test`. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+complete workflow and [`docs/en/development/`](docs/en/development/core-protocol.md) for implementation guides.
+
+## Community
+
+Questions and feedback are welcome in [Discord](https://discord.com/invite/74cF8vbNEs). Use
+[GitHub Issues](https://github.com/oceanbase/powercontext/issues) for reproducible defects and focused feature
+requests.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PowerContext
 
-**Beyond memory**
+**Not only memory**
 
 [![PyPI version](https://img.shields.io/pypi/v/powercontext)](https://pypi.org/project/powercontext/)
 [![License Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,0 +1,132 @@
+# PowerContext
+
+**不止于记忆**
+
+[![PyPI version](https://img.shields.io/pypi/v/powercontext)](https://pypi.org/project/powercontext/)
+[![License Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/74cF8vbNEs)
+
+*[English](README.md) · [中文](README_CN.md) · [日本語](README_JP.md)*
+
+PowerContext 是 [PowerMem](https://www.powermem.ai/) 的升级版本，也是面向人机协作的上下文运行层。它将共同推进的工作沉淀为可理解、可交接、可延续的项目上下文。
+
+## 核心能力
+
+| 能力 | 核心价值 |
+| --- | --- |
+| Memory 抽取与管理 | 显式记录值得长期复用的决策、约束、结果、状态和下一步；配置生成模型后，也可以从 Source 中提取 Memory。修订和停用均保留历史 |
+| 请求时有界召回 | 在 Agent 处理请求前，按项目 scope、相关性和字节预算生成一份通过 schema 验证、带有 citation 的 `PreparedContext`；召回失败不会阻断原任务 |
+| Handoff 任务交接 | 将目标、已验证进度、阻塞项、下一步和证据整理为可检查的工作包，让另一个会话、任务、模型或 Agent Host 从明确状态继续工作 |
+| Source 与证据链 | 保存知识的原始来源，并用精确 citation 关联 Memory 和 Artifact；采集 prompt 只会生成 Source，不会直接将其变成 Memory |
+| Experience 和 Skill 治理 | 模型或调用方只能提交 Candidate；Review 通过后才会形成不可变的 revision，Skill 还需显式导出，不会自行批准、安装或执行 |
+| 本地与服务化部署 | 本地开发可直接使用 SQLite，团队部署可选 OceanBase，并通过 HTTP/OpenAPI、MCP、身份验证和 OpenTelemetry 接入现有系统 |
+
+## Benchmarks
+
+### [LoCoMo](https://github.com/snap-research/locomo)
+
+| 指标 | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | 全上下文基线 |
+| --- | ---: | ---: | ---: |
+| 准确率 | **90.78%**（1,398/1,540） | 87.79% | 52.9% |
+| 搜索 p95 延迟 | **1.38 秒** | 1.44 秒 | 17.12 秒 |
+| 每个问题的回答 token 数 | **约 1.65k** | 约 0.9k | 26k |
+
+PowerContext 的结果覆盖了该 benchmark 全部 10 个对话中的 1,540 道计分题。数据集选择、检索、judge、延迟、token 和 Artifact 边界详见
+[LoCoMo 评估详情](benchmark/locomo/README.md)。
+
+### [SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os)
+
+在 [SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os) 全部 **731 项任务**的配对评估中，
+启用 PowerContext 后，任务解决率从 **82.35%** 提升至 **86.73%**，提高了 **4.38 个百分点**。
+
+本次评估在 Codex 环境中运行，PowerContext OFF 与 ON 两组均使用 `gpt-5.6-sol` 模型。
+
+| 结果 | PowerContext OFF | PowerContext ON | 变化 |
+| --- | ---: | ---: | ---: |
+| 已解决任务 | 602 / 731 | **634 / 731** | **+32** |
+| 任务解决率 | 82.35% | **86.73%** | **+4.38 个百分点** |
+
+[SWE-bench Pro public v2 评估详情](evaluation/README.md)。
+
+---
+
+## 插件
+
+PowerContext 为 Codex、Claude Code 和 DeepSeek Harness 提供官方插件与安装指南。三个集成都通过
+PowerContext Server 使用同一套作用域数据和保留历史的契约；插件不会自行启动或内嵌 Server。
+
+### 官方集成
+
+<table>
+<tr>
+<td align="center" width="120"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></td>
+<td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
+<td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
+</tr>
+</table>
+
+
+## 快速开始
+
+你需要 macOS 或 Linux、Python 3.11 或更高版本、[`uv`](https://docs.astral.sh/uv/) 和 Codex CLI。
+
+### 1. 安装 PowerContext 和 Plugin
+
+```bash
+uv tool install "powercontext[cli,server]==0.0.2"
+
+# Choose one or more integrations.
+powercontext setup codex --source oceanbase/powercontext --ref v0.0.2
+powercontext setup claude-code --source oceanbase/powercontext --ref v0.0.2
+powercontext setup dsh --source oceanbase/powercontext --ref v0.0.2
+```
+
+第一条命令会在隔离环境中安装 CLI 和本地 Server。第二条命令会从匹配的仓库 tag 安装对应的 Plugin。如需刷新现有安装，
+请再次运行 setup。
+
+### 2. 启动并验证本地 Server
+
+在一个终端中保持 Server 运行：
+
+```bash
+powercontext server run
+```
+
+在另一个终端中验证服务和 Plugin：
+
+```bash
+powercontext doctor
+powercontext doctor codex  # or: claude-code / dsh
+```
+
+默认情况下，Server 监听 `127.0.0.1:8000`，在 `/mcp` 提供 Streamable HTTP MCP，并将数据持久化到本地
+SQLite 数据库。显式 Memory 操作无需配置 inference provider 即可使用。
+
+## 开发
+
+安装锁定的开发环境和 Hook：
+
+```bash
+make install
+```
+
+提交 Pull Request 前，请运行主要验证命令：
+
+```bash
+make check
+make test
+make docs-test
+```
+
+修改 `openapi/powercontext.yaml` 后，请运行 `make contract-test`。完整工作流程参见
+[CONTRIBUTING.md](CONTRIBUTING.md)，实现指南参见
+[`docs/zh/development/`](docs/zh/development/core-protocol.md)。
+
+## 社区
+
+欢迎在 [Discord](https://discord.com/invite/74cF8vbNEs) 中提问和反馈。如需报告可复现的缺陷或提出范围明确的功能请求，
+请使用 [GitHub Issues](https://github.com/oceanbase/powercontext/issues)。
+
+## 许可证
+
+PowerContext 使用 [Apache License 2.0](LICENSE) 许可证。

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,0 +1,137 @@
+# PowerContext
+
+**記憶を超えて**
+
+[![PyPI version](https://img.shields.io/pypi/v/powercontext)](https://pypi.org/project/powercontext/)
+[![License Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/74cF8vbNEs)
+
+*[English](README.md) · [中文](README_CN.md) · [日本語](README_JP.md)*
+
+PowerContext は [PowerMem](https://www.powermem.ai/) のアップグレード版であり、人と Agent の協働を支える
+コンテキストランタイムです。共同で進めた作業を、理解・引き継ぎ・継続が可能なプロジェクトコンテキストとして
+蓄積します。
+
+## 主な機能
+
+| 機能 | 提供する価値 |
+| --- | --- |
+| Memory の抽出と管理 | 長期的に再利用する価値のある意思決定、制約、成果、状態、次のステップを明示的に記録します。Generation model を設定すると、Source から Memory を抽出することもできます。改訂や廃止を行っても履歴は保持されます |
+| リクエスト時の範囲限定想起 | Agent がリクエストを処理する前に、プロジェクト scope、関連性、byte budget に基づいて、schema 検証済みで citation 付きの `PreparedContext` を 1 つ生成します。想起に失敗しても元のタスクは中断されません |
+| Handoff によるタスク引き継ぎ | 目標、検証済みの進捗、ブロッカー、次のステップ、エビデンスを検査可能な作業パッケージにまとめ、別のセッション、タスク、モデル、Agent Host が明確な状態から作業を継続できるようにします |
+| Source とエビデンスチェーン | 知識の出所を保存し、正確な citation で Memory と Artifact を関連付けます。Prompt の収集によって作成されるのは Source だけであり、直接 Memory に変換されることはありません |
+| Experience と Skill のガバナンス | モデルや呼び出し元が作成できるのは Candidate までです。Review を通過して初めて不変の revision が作成され、Skill にはさらに明示的な export が必要です。自動的に承認、インストール、実行されることはありません |
+| ローカルおよびサービスデプロイ | ローカル開発では SQLite をそのまま使用でき、チーム環境では OceanBase を選択できます。HTTP/OpenAPI、MCP、認証、OpenTelemetry を通じて既存システムと連携できます |
+
+## ベンチマーク
+
+### [LoCoMo](https://github.com/snap-research/locomo)
+
+| 指標 | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | フルコンテキストのベースライン |
+| --- | ---: | ---: | ---: |
+| 精度 | **90.78%**（1,398/1,540） | 87.79% | 52.9% |
+| 検索 p95 レイテンシ | **1.38 秒** | 1.44 秒 | 17.12 秒 |
+| 質問ごとの回答 token 数 | **約 1.65k** | 約 0.9k | 26k |
+
+PowerContext の結果は、このベンチマークの全 10 会話に含まれる 1,540 問の採点対象すべてを網羅しています。
+データセットの選択、検索、judge、レイテンシ、token、Artifact の境界については、
+[LoCoMo 評価の詳細](benchmark/locomo/README.md)を参照してください。
+
+### [SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os)
+
+[SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os) の全 **731 タスク**を対象としたペア評価では、
+PowerContext を有効にすると、タスク解決率が **82.35%** から **86.73%** へと **4.38 ポイント**向上しました。
+
+この評価は Codex 環境で実行し、PowerContext OFF と ON の両グループで `gpt-5.6-sol` モデルを使用しました。
+
+| 結果 | PowerContext OFF | PowerContext ON | 変化 |
+| --- | ---: | ---: | ---: |
+| 解決済みタスク | 602 / 731 | **634 / 731** | **+32** |
+| タスク解決率 | 82.35% | **86.73%** | **+4.38 ポイント** |
+
+[SWE-bench Pro public v2 評価の詳細](evaluation/README.md)。
+
+---
+
+## プラグイン
+
+PowerContext は Codex、Claude Code、DeepSeek Harness 向けの公式プラグインとインストールガイドを提供します。
+3 つのインテグレーションはすべて、PowerContext Server を通じて同じスコープ付きデータと履歴を保持する契約を
+使用します。プラグインが Server を自動的に起動したり、組み込んだりすることはありません。
+
+### 公式インテグレーション
+
+<table>
+<tr>
+<td align="center" width="120"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></td>
+<td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
+<td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
+</tr>
+</table>
+
+## クイックスタート
+
+macOS または Linux、Python 3.11 以降、[`uv`](https://docs.astral.sh/uv/)、Codex CLI が必要です。
+
+### 1. PowerContext とプラグインをインストールする
+
+```bash
+uv tool install "powercontext[cli,server]==0.0.2"
+
+# 1 つ以上のインテグレーションを選択します。
+powercontext setup codex --source oceanbase/powercontext --ref v0.0.2
+powercontext setup claude-code --source oceanbase/powercontext --ref v0.0.2
+powercontext setup dsh --source oceanbase/powercontext --ref v0.0.2
+```
+
+最初のコマンドは、隔離された環境に CLI とローカル Server をインストールします。以降の setup コマンドは、
+対応するリポジトリの tag から各プラグインをインストールします。既存のインストールを更新するには、setup を
+再実行してください。
+
+### 2. ローカル Server を起動して検証する
+
+1 つのターミナルで Server を起動したままにします。
+
+```bash
+powercontext server run
+```
+
+別のターミナルでサービスとプラグインを検証します。
+
+```bash
+powercontext doctor
+powercontext doctor codex  # または: claude-code / dsh
+```
+
+デフォルトでは、Server は `127.0.0.1:8000` で待ち受け、`/mcp` で Streamable HTTP MCP を公開し、
+ローカルの SQLite データベースにデータを永続化します。明示的な Memory 操作には inference provider の設定は
+不要です。
+
+## 開発
+
+ロックされた開発環境と Hook をインストールします。
+
+```bash
+make install
+```
+
+Pull Request を作成する前に、主要な検証コマンドを実行します。
+
+```bash
+make check
+make test
+make docs-test
+```
+
+`openapi/powercontext.yaml` を変更した後は、`make contract-test` を実行してください。完全なワークフローについては
+[CONTRIBUTING.md](CONTRIBUTING.md)、実装ガイドについては
+[`docs/en/development/`](docs/en/development/core-protocol.md)を参照してください。
+
+## コミュニティ
+
+質問やフィードバックは [Discord](https://discord.com/invite/74cF8vbNEs) で歓迎しています。再現可能な不具合や、
+範囲を明確にした機能リクエストには [GitHub Issues](https://github.com/oceanbase/powercontext/issues) を利用してください。
+
+## ライセンス
+
+PowerContext は [Apache License 2.0](LICENSE) の下でライセンスされています。

--- a/e2e/bub/uv.lock
+++ b/e2e/bub/uv.lock
@@ -1599,7 +1599,7 @@ wheels = [
 
 [[package]]
 name = "powercontext"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "pydantic" },
@@ -1631,7 +1631,7 @@ requires-dist = [
     { name = "powercontext", extras = ["client"], marker = "extra == 'cli'" },
     { name = "prometheus-client", marker = "extra == 'server'", specifier = ">=0.21,<1" },
     { name = "pydantic", specifier = ">=2.10,<3" },
-    { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'builtin'", specifier = ">=2.14.1,<3" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'builtin'", specifier = ">=2.27.1,<3" },
     { name = "pydantic-settings", marker = "extra == 'builtin'", specifier = ">=2.7,<3" },
     { name = "pydantic-settings", marker = "extra == 'client'", specifier = ">=2.7,<3" },
     { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.7,<3" },

--- a/integrations/dsh/plugins/powercontext/openapi/powercontext.yaml
+++ b/integrations/dsh/plugins/powercontext/openapi/powercontext.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 0.0.1
+  version: 0.0.2
 security:
   - BearerAuth: []
   - {}
@@ -369,6 +369,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SearchMemoryResponse"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "422":

--- a/openapi/powercontext.yaml
+++ b/openapi/powercontext.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: PowerContext API
   description: Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.
-  version: 0.0.1
+  version: 0.0.2
 security:
   - BearerAuth: []
   - {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powercontext"
-version = "0.0.1"
+version = "0.0.2"
 description = "PowerContext turns human-agent work into handoff-ready context."
 authors = [{ name = "PowerContext Team", email = "open_oceanbase@oceanbase.com" }]
 readme = "README.md"
@@ -95,7 +95,10 @@ packages = ["src/powercontext"]
 [tool.ty.environment]
 python = "./.venv"
 python-version = "3.11"
-extra-paths = ["./integrations/codex/plugins/powercontext"]
+extra-paths = [
+    "./integrations/claude-code/plugins/powercontext",
+    "./integrations/codex/plugins/powercontext",
+]
 
 [tool.ty.src]
 exclude = ["e2e/bub", "integrations/bub", "evaluation"]

--- a/src/powercontext/http/_generated/operations.py
+++ b/src/powercontext/http/_generated/operations.py
@@ -91,7 +91,7 @@ from powercontext.http._generated.models import (
 OPENAPI_VERSION = "3.0.3"
 API_TITLE = "PowerContext API"
 API_DESCRIPTION = "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities."
-API_VERSION = "0.0.1"
+API_VERSION = "0.0.2"
 
 RequestT = TypeVar("RequestT")
 ResponseT = TypeVar("ResponseT")

--- a/src/powercontext/http/_generated/schema.py
+++ b/src/powercontext/http/_generated/schema.py
@@ -7,7 +7,7 @@ OPENAPI_SCHEMA: dict[str, JsonValue] = {
     "info": {
         "title": "PowerContext API",
         "description": "Remote PowerContext transport. Runtime behavior is reported by /v1/capabilities.",
-        "version": "0.0.1",
+        "version": "0.0.2",
     },
     "paths": {
         "/health/live": {

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -600,7 +600,7 @@ def test_default_doctor_preserves_degraded_checks_in_human_and_json_output(monke
             "package": {
                 "ok": True,
                 "status": "ok",
-                "detail": "powercontext 0.0.1",
+                "detail": "powercontext 0.0.2",
             },
             "server_liveness": {
                 "ok": True,

--- a/uv.lock
+++ b/uv.lock
@@ -1793,7 +1793,7 @@ wheels = [
 
 [[package]]
 name = "powercontext"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
# Which issue or RFC does this PR close?

No linked issue or RFC.

# Rationale for this change

Prepare the repository for the PowerContext 0.0.2 release with consistent package, API, integration, workflow, and documentation versions.

# What changes are included in this PR?

- Bump the Python package, OpenAPI contract, generated HTTP metadata, tests, and lockfiles to 0.0.2.
- Accept `powercontext-vX.Y.Z` release tags in the verification and publishing workflows while retaining the existing tag formats.
- Synchronize the root OpenAPI contract with the DeepSeek Harness plugin snapshot.
- Include both the Claude Code and Codex plugin paths in static type checking.
- Rewrite the English README and add aligned Chinese and Japanese READMEs with current installation commands, core capabilities, benchmark results, and official plugin guidance.

# Are there any user-facing changes?

Yes. Installation examples now pin 0.0.2, the published API metadata reports 0.0.2, release workflows accept the `powercontext-vX.Y.Z` tag form, and project documentation is available in English, Chinese, and Japanese. No persisted-format or breaking API change is introduced.

# How was this change tested?

- Sensitive-information scan across all staged files and added lines: no credentials, private keys, tokens, absolute user paths, or non-loopback host IPs found.
- `make check`
- `make test` (`551 passed, 12 skipped`)
- `make contract-test` (`28 passed`)
- `make docs-test`
- `uv run --project e2e/bub --frozen pytest e2e/bub/tests` (`5 passed`)
- `uv build`
- `uvx --from 'twine>=6.2' twine check dist/powercontext-0.0.2.tar.gz dist/powercontext-0.0.2-py3-none-any.whl`

# AI usage statement

OpenAI Codex using GPT-5.6-Sol was used to review the release changes, synchronize the multilingual READMEs, run validation, and prepare this pull request.
