### PR TITLE
docs: visualize benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ collaboration. It turns shared work into project context that can be understood,
 
 ### [LoCoMo](https://github.com/snap-research/locomo)
 
+![LOCOMO benchmark comparison showing PowerContext accuracy, search latency, and answer token usage against PowerMem and a full-context baseline](docs/assets/locomo-benchmark-comparison.svg)
+
 | Metric | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | Full-context baseline |
 | --- | ---: | ---: | ---: |
 | Accuracy | **90.78%** (1,398/1,540) | 87.79% | 52.9% |
@@ -44,6 +46,8 @@ resolution rate from **82.35%** to **86.73%**, an improvement of **4.38 percenta
 
 The evaluation ran in a Codex environment, with both the PowerContext OFF and ON groups using the `gpt-5.6-sol`
 model.
+
+![SWE-bench Pro public v2 comparison showing an increase from 82.35% with PowerContext off to 86.73% with PowerContext on](docs/assets/swe-bench-pro-public-v2-comparison.svg)
 
 | Result | PowerContext OFF | PowerContext ON | Change |
 | --- | ---: | ---: | ---: |

--- a/docs/assets/locomo-benchmark-comparison.svg
+++ b/docs/assets/locomo-benchmark-comparison.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="820" viewBox="0 0 1200 820" role="img" aria-labelledby="title description">
+  <title id="title">PowerContext LOCOMO benchmark comparison</title>
+  <desc id="description">Three horizontal bar charts compare PowerContext, PowerMem, and a full-context baseline on accuracy, search p95 latency, and answer tokens per question.</desc>
+
+  <rect width="1200" height="820" rx="24" fill="#ffffff"/>
+
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="64" y="66" fill="#172033" font-size="32" font-weight="700">LOCOMO benchmark</text>
+    <text x="64" y="98" fill="#667085" font-size="17">Long-conversation question answering · 1,540 scored questions</text>
+
+    <g font-size="15" fill="#344054">
+      <rect x="64" y="122" width="15" height="15" rx="4" fill="#1677ff"/>
+      <text x="88" y="135">PowerContext</text>
+      <rect x="222" y="122" width="15" height="15" rx="4" fill="#55a6a6"/>
+      <text x="246" y="135">PowerMem</text>
+      <rect x="350" y="122" width="15" height="15" rx="4" fill="#98a2b3"/>
+      <text x="374" y="135">Full-context baseline</text>
+    </g>
+
+    <!-- Accuracy -->
+    <text x="64" y="190" fill="#172033" font-size="20" font-weight="700">Accuracy</text>
+    <text x="1136" y="190" fill="#1677ff" font-size="14" text-anchor="end">Higher is better ↑</text>
+    <g stroke="#e4e7ec" stroke-width="1">
+      <line x1="270" y1="212" x2="270" y2="324"/>
+      <line x1="480" y1="212" x2="480" y2="324"/>
+      <line x1="690" y1="212" x2="690" y2="324"/>
+      <line x1="900" y1="212" x2="900" y2="324"/>
+      <line x1="1110" y1="212" x2="1110" y2="324"/>
+    </g>
+    <g fill="#667085" font-size="13" text-anchor="middle">
+      <text x="270" y="340">0%</text>
+      <text x="480" y="340">25%</text>
+      <text x="690" y="340">50%</text>
+      <text x="900" y="340">75%</text>
+      <text x="1110" y="340">100%</text>
+    </g>
+    <g fill="#344054" font-size="15" text-anchor="end">
+      <text x="250" y="235">PowerContext</text>
+      <text x="250" y="274">PowerMem</text>
+      <text x="250" y="313">Full context</text>
+    </g>
+    <rect x="270" y="216" width="762.6" height="24" rx="6" fill="#1677ff"/>
+    <rect x="270" y="255" width="737.4" height="24" rx="6" fill="#55a6a6"/>
+    <rect x="270" y="294" width="444.4" height="24" rx="6" fill="#98a2b3"/>
+    <g fill="#344054" font-size="15" font-weight="600">
+      <text x="1042" y="234">90.78%</text>
+      <text x="1017" y="273">87.79%</text>
+      <text x="724" y="312">52.9%</text>
+    </g>
+
+    <!-- Latency -->
+    <line x1="64" y1="374" x2="1136" y2="374" stroke="#eaecf0"/>
+    <text x="64" y="420" fill="#172033" font-size="20" font-weight="700">Search p95 latency</text>
+    <text x="1136" y="420" fill="#1677ff" font-size="14" text-anchor="end">Lower is better ↓</text>
+    <g stroke="#e4e7ec" stroke-width="1">
+      <line x1="270" y1="442" x2="270" y2="554"/>
+      <line x1="480" y1="442" x2="480" y2="554"/>
+      <line x1="690" y1="442" x2="690" y2="554"/>
+      <line x1="900" y1="442" x2="900" y2="554"/>
+      <line x1="1110" y1="442" x2="1110" y2="554"/>
+    </g>
+    <g fill="#667085" font-size="13" text-anchor="middle">
+      <text x="270" y="570">0 s</text>
+      <text x="480" y="570">4.5 s</text>
+      <text x="690" y="570">9 s</text>
+      <text x="900" y="570">13.5 s</text>
+      <text x="1110" y="570">18 s</text>
+    </g>
+    <g fill="#344054" font-size="15" text-anchor="end">
+      <text x="250" y="465">PowerContext</text>
+      <text x="250" y="504">PowerMem</text>
+      <text x="250" y="543">Full context</text>
+    </g>
+    <rect x="270" y="446" width="64.4" height="24" rx="6" fill="#1677ff"/>
+    <rect x="270" y="485" width="67.2" height="24" rx="6" fill="#55a6a6"/>
+    <rect x="270" y="524" width="798.9" height="24" rx="6" fill="#98a2b3"/>
+    <g fill="#344054" font-size="15" font-weight="600">
+      <text x="344" y="464">1.38 s</text>
+      <text x="347" y="503">1.44 s</text>
+      <text x="1079" y="542">17.12 s</text>
+    </g>
+
+    <!-- Tokens -->
+    <line x1="64" y1="604" x2="1136" y2="604" stroke="#eaecf0"/>
+    <text x="64" y="650" fill="#172033" font-size="20" font-weight="700">Answer tokens per question</text>
+    <text x="1136" y="650" fill="#1677ff" font-size="14" text-anchor="end">Lower is better ↓</text>
+    <g stroke="#e4e7ec" stroke-width="1">
+      <line x1="270" y1="672" x2="270" y2="784"/>
+      <line x1="480" y1="672" x2="480" y2="784"/>
+      <line x1="690" y1="672" x2="690" y2="784"/>
+      <line x1="900" y1="672" x2="900" y2="784"/>
+      <line x1="1110" y1="672" x2="1110" y2="784"/>
+    </g>
+    <g fill="#667085" font-size="13" text-anchor="middle">
+      <text x="270" y="800">0</text>
+      <text x="480" y="800">6.5k</text>
+      <text x="690" y="800">13k</text>
+      <text x="900" y="800">19.5k</text>
+      <text x="1110" y="800">26k</text>
+    </g>
+    <g fill="#344054" font-size="15" text-anchor="end">
+      <text x="250" y="695">PowerContext</text>
+      <text x="250" y="734">PowerMem</text>
+      <text x="250" y="773">Full context</text>
+    </g>
+    <rect x="270" y="676" width="53.3" height="24" rx="6" fill="#1677ff"/>
+    <rect x="270" y="715" width="29.1" height="24" rx="6" fill="#55a6a6"/>
+    <rect x="270" y="754" width="840" height="24" rx="6" fill="#98a2b3"/>
+    <g fill="#344054" font-size="15" font-weight="600">
+      <text x="333" y="694">~1.65k</text>
+      <text x="309" y="733">~0.9k</text>
+      <text x="1120" y="772">26k</text>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/swe-bench-pro-public-v2-comparison.svg
+++ b/docs/assets/swe-bench-pro-public-v2-comparison.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="430" viewBox="0 0 1200 430" role="img" aria-labelledby="title description">
+  <title id="title">PowerContext SWE-bench Pro public v2 comparison</title>
+  <desc id="description">A horizontal bar chart compares an 82.35 percent task resolution rate with PowerContext off and an 86.73 percent rate with PowerContext on.</desc>
+
+  <rect width="1200" height="430" rx="24" fill="#ffffff"/>
+
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="64" y="66" fill="#172033" font-size="32" font-weight="700">SWE-bench Pro public v2</text>
+    <text x="64" y="98" fill="#667085" font-size="17">Paired Codex evaluation · 731 tasks · gpt-5.6-sol</text>
+
+    <g font-size="15" fill="#344054">
+      <rect x="64" y="122" width="15" height="15" rx="4" fill="#98a2b3"/>
+      <text x="88" y="135">PowerContext OFF</text>
+      <rect x="240" y="122" width="15" height="15" rx="4" fill="#1677ff"/>
+      <text x="264" y="135">PowerContext ON</text>
+    </g>
+
+    <text x="64" y="190" fill="#172033" font-size="20" font-weight="700">Task resolution rate</text>
+    <text x="1136" y="190" fill="#1677ff" font-size="14" text-anchor="end">Higher is better ↑</text>
+
+    <g stroke="#e4e7ec" stroke-width="1">
+      <line x1="270" y1="216" x2="270" y2="332"/>
+      <line x1="480" y1="216" x2="480" y2="332"/>
+      <line x1="690" y1="216" x2="690" y2="332"/>
+      <line x1="900" y1="216" x2="900" y2="332"/>
+      <line x1="1110" y1="216" x2="1110" y2="332"/>
+    </g>
+    <g fill="#667085" font-size="13" text-anchor="middle">
+      <text x="270" y="352">0%</text>
+      <text x="480" y="352">25%</text>
+      <text x="690" y="352">50%</text>
+      <text x="900" y="352">75%</text>
+      <text x="1110" y="352">100%</text>
+    </g>
+
+    <g fill="#344054" font-size="15" text-anchor="end">
+      <text x="250" y="252">PowerContext OFF</text>
+      <text x="250" y="307">PowerContext ON</text>
+    </g>
+    <rect x="270" y="232" width="691.7" height="30" rx="7" fill="#98a2b3"/>
+    <rect x="270" y="287" width="728.5" height="30" rx="7" fill="#1677ff"/>
+
+    <g fill="#344054" font-size="16" font-weight="600">
+      <text x="973" y="253">82.35% · 602 / 731</text>
+      <text x="1010" y="308">86.73% · 634 / 731</text>
+    </g>
+
+    <rect x="806" y="378" width="330" height="34" rx="17" fill="#eaf2ff"/>
+    <text x="971" y="400" fill="#0969da" font-size="15" font-weight="700" text-anchor="middle">+4.38 percentage points · +32 tasks</text>
+  </g>
+</svg>


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A.

# Rationale for this change

The benchmark tables are precise but make relative performance difficult to scan. Visual comparisons make the LoCoMo quality, latency, and token tradeoffs and the SWE-bench Pro treatment improvement immediately visible on the repository homepage.

# What changes are included in this PR?

- Add an accessible SVG chart for the LoCoMo accuracy, search p95 latency, and answer-token results.
- Add an accessible SVG chart for the SWE-bench Pro public v2 PowerContext OFF/ON resolution rates.
- Embed both charts beside their corresponding benchmark details in README.md.

This is documentation-only and does not change runtime behavior, APIs, dependencies, or persisted formats.

# Are there any user-facing changes?

Yes. The GitHub repository homepage now presents both benchmark comparisons as horizontal bar charts while retaining the existing tables with exact values. There are no breaking changes.

# How was this change tested?

- git diff --check
- xmllint --noout docs/assets/locomo-benchmark-comparison.svg docs/assets/swe-bench-pro-public-v2-comparison.svg
- .venv/bin/prek run --files README.md docs/assets/locomo-benchmark-comparison.svg docs/assets/swe-bench-pro-public-v2-comparison.svg
- Rendered both SVGs to PNG and manually checked layout, labels, values, and clipping.

# AI usage statement

OpenAI Codex was used to inspect the repository, design and implement the SVG charts, update README.md, and run validation.