### PR TITLE
fix(server): preserve SQLite persistence for partial settings

### DIFF
--- a/docs/en/docs/reference/configuration.md
+++ b/docs/en/docs/reference/configuration.md
@@ -183,6 +183,7 @@ set its path together with the complete embedding profile:
 export POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_MODEL=provider:embedding-model
 export POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_PROFILE_ID=embedding-model-v1
 export POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_DIMENSION=1024
+export POWERCONTEXT_SERVER_DATABASE_URL=sqlite+aiosqlite:////srv/powercontext/powercontext.db
 export POWERCONTEXT_SERVER_DATABASE_VEC1_EXTENSION=/opt/sqlite-extensions/vec1
 powercontext server run
 ```

--- a/docs/zh/docs/reference/configuration.md
+++ b/docs/zh/docs/reference/configuration.md
@@ -178,6 +178,7 @@ embedding profile：
 export POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_MODEL=provider:embedding-model
 export POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_PROFILE_ID=embedding-model-v1
 export POWERCONTEXT_SERVER_INFERENCE_EMBEDDING_DIMENSION=1024
+export POWERCONTEXT_SERVER_DATABASE_URL=sqlite+aiosqlite:////srv/powercontext/powercontext.db
 export POWERCONTEXT_SERVER_DATABASE_VEC1_EXTENSION=/opt/sqlite-extensions/vec1
 powercontext server run
 ```

--- a/src/powercontext/builtin/persistence/sqlite/profile.py
+++ b/src/powercontext/builtin/persistence/sqlite/profile.py
@@ -62,6 +62,12 @@ class SQLiteConfig(BaseModel):
             raise ValueError("SQLite profile URL must use sqlite+aiosqlite")  # noqa: TRY003
         return value
 
+    @property
+    def is_in_memory(self) -> bool:
+        """Return whether this profile stores its database only in process memory."""
+
+        return _is_memory_url(self.url)
+
 
 class SQLiteProfile:
     """An initialized SQLite database profile."""
@@ -82,7 +88,7 @@ class SQLiteProfile:
 
         _create_database_directory(config.url)
         engine_options: dict[str, object] = {"echo": config.echo}
-        if _is_memory_url(config.url):
+        if config.is_in_memory:
             engine_options["poolclass"] = StaticPool
         engine = create_async_engine(config.url, **engine_options)
         _configure_sqlite(engine, config)

--- a/src/powercontext/server/factory.py
+++ b/src/powercontext/server/factory.py
@@ -32,6 +32,7 @@ from powercontext.builtin.artifacts.handoff import HandoffGenerationPipeline
 from powercontext.builtin.artifacts.memory import CandidatePipeline
 from powercontext.builtin.artifacts.skill import ExternalSkillProvider, SkillGenerator
 from powercontext.builtin.inference import EmbeddingModel
+from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.builtin.runtime import BuiltinRuntime
 from powercontext.builtin.runtime.composition import open_builtin_runtime
 from powercontext.builtin.runtime.config import BuiltinConfig
@@ -83,6 +84,8 @@ def create_server_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         _log_lifecycle("server.starting", "PowerContext Server is starting")
+        if isinstance(config.database, SQLiteConfig) and config.database.is_in_memory:
+            _log_in_memory_database_warning()
         async with open_builtin_runtime(
             config,
             scheduler_path=default_scheduler_path() if scheduler_path is None else scheduler_path,
@@ -241,6 +244,16 @@ def _log_lifecycle(event: str, message: str) -> None:
         logging.INFO,
         message,
         extra={"event": event, "unit": "server"},
+    )
+
+
+def _log_in_memory_database_warning() -> None:
+    log_safely(
+        logger,
+        logging.WARNING,
+        "PowerContext Server is using an in-memory SQLite database; "
+        "all main database data will be lost when the process stops",
+        extra={"event": "server.database.in_memory", "unit": "server"},
     )
 
 

--- a/src/powercontext/server/settings.py
+++ b/src/powercontext/server/settings.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Literal
 
 from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
@@ -28,7 +29,6 @@ from powercontext.builtin.runtime.config import (
     HandoffReportConfig,
     InferenceConfig,
     RuntimeConfig,
-    normalize_database_discriminator,
 )
 from powercontext.paths import default_database_path, sqlite_url
 
@@ -154,10 +154,12 @@ class ServerSettings(BaseSettings):
     inference: InferenceConfig = Field(default_factory=InferenceConfig)
     external_skills: ExternalSkillsConfig = Field(default_factory=ExternalSkillsConfig)
 
-    @model_validator(mode="before")
+    @field_validator("database", mode="before")
     @classmethod
     def default_database_to_sqlite(cls, value: object) -> object:
-        return normalize_database_discriminator(value)
+        if not isinstance(value, Mapping) or value.get("kind", "sqlite") != "sqlite":
+            return value
+        return {"kind": "sqlite", "url": _default_database().url, **value}
 
     @model_validator(mode="after")
     def require_authentication_for_dashboard(self) -> ServerSettings:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -127,6 +127,16 @@ def test_settings_load_server_environment(monkeypatch) -> None:
     assert settings.external_skills.codex_roots[0].path.as_posix() == "/srv/project/.agents/skills"
 
 
+def test_server_settings_vec1_preserves_file_database(tmp_path, monkeypatch) -> None:
+    data_dir = tmp_path / "powercontext-data"
+    monkeypatch.setenv("POWERCONTEXT_HOME", str(data_dir))
+    monkeypatch.setenv("POWERCONTEXT_SERVER_DATABASE_VEC1_EXTENSION", str(tmp_path / "vec1"))
+
+    settings = ServerSettings()
+
+    assert settings.database.url == f"sqlite+aiosqlite:///{data_dir / 'powercontext.db'}"
+
+
 def test_server_settings_select_oceanbase(monkeypatch) -> None:
     url = "mysql+aoceanbase://root:test@127.0.0.1:2881/powercontext?charset=utf8mb4"
     monkeypatch.setenv("POWERCONTEXT_SERVER_DATABASE_KIND", "oceanbase")

--- a/tests/test_server_logging.py
+++ b/tests/test_server_logging.py
@@ -72,6 +72,26 @@ def test_server_access_log_uses_operation_id_and_skips_health(caplog, tmp_path) 
     assert records[0].transport == "http"
 
 
+def test_server_warns_when_using_an_in_memory_database(caplog, tmp_path) -> None:
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(),
+            mcp=McpConfig(enabled=False),
+        ),
+        scheduler_path=tmp_path / "scheduler.db",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="powercontext.server.factory"), TestClient(app) as client:
+        response = client.get("/health/live")
+
+    assert response.status_code == 200
+    assert any(
+        record.levelno == logging.WARNING
+        and "all main database data will be lost when the process stops" in record.getMessage()
+        for record in caplog.records
+    )
+
+
 def test_server_logging_settings_normalize_the_level(monkeypatch) -> None:
     monkeypatch.setenv("POWERCONTEXT_SERVER_LOGGING_LEVEL", "warning")
     monkeypatch.setenv("POWERCONTEXT_SERVER_LOGGING_FORMAT", "json")


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A

# Rationale for this change

Partial SQLite settings such as `POWERCONTEXT_SERVER_DATABASE_VEC1_EXTENSION` could replace the Server's file database default with `:memory:`, causing data loss after restart.

# What changes are included in this PR?

Partial SQLite settings now retain the default file URL. Explicit in-memory databases still work, with a startup warning. The Vec1 documentation now includes a persistent database URL.

# Are there any user-facing changes?

SQLite data remains persistent when Vec1 is configured without an explicit database URL. No breaking API or storage format changes.

# How was this change tested?

- `make check`
- `make docs-test`
- `make test` (580 passed, 12 skipped)

# AI usage statement

OpenAI Codex assisted with investigation, implementation, tests, and documentation.