### PR TITLE
docs: update v0.0.2 quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,46 @@
 PowerContext is the upgraded version of [PowerMem](https://www.powermem.ai/) and a context runtime for human-agent
 collaboration. It turns shared work into project context that can be understood, handed off, and continued.
 
+## Quick start
+
+You need macOS or Linux, Python 3.11 or newer, [`uv`](https://docs.astral.sh/uv/), and at least one supported agent
+host.
+
+### 1. Install PowerContext and the plugins
+
+```bash
+uv tool install "powercontext[cli,server]==0.0.2"
+
+# Choose one or more integrations.
+powercontext setup codex --source oceanbase/powercontext --ref v0.0.2
+powercontext setup claude-code --source oceanbase/powercontext --ref v0.0.2
+powercontext setup dsh --source oceanbase/powercontext --ref v0.0.2
+powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
+```
+
+The first command installs the CLI and local Server in an isolated environment. The subsequent setup commands
+install the corresponding plugins from the matching repository tag. Run setup again to refresh an existing
+installation. Hermes integration requires Hermes Agent v0.20.4 or newer; see the
+[Hermes integration guide](integrations/hermes/README.md) for configuration and project-local installation.
+
+### 2. Start and verify the local Server
+
+Keep the Server running in one terminal:
+
+```bash
+powercontext server run
+```
+
+In another terminal, verify the service and plugin:
+
+```bash
+powercontext doctor
+powercontext doctor codex  # or: claude-code / dsh / hermes
+```
+
+By default, the Server listens on `127.0.0.1:8000`, exposes Streamable HTTP MCP at `/mcp`, and persists data in a
+local SQLite database. Explicit Memory operations work without configuring an inference provider.
+
 ## Core capabilities
 
 | Capability | Core value |
@@ -28,41 +68,20 @@ collaboration. It turns shared work into project context that can be understood,
 
 ![LOCOMO benchmark comparison showing PowerContext accuracy, search latency, and answer token usage against PowerMem and a full-context baseline](docs/assets/locomo-benchmark-comparison.svg)
 
-| Metric | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | Full-context baseline |
-| --- | ---: | ---: | ---: |
-| Accuracy | **90.78%** (1,398/1,540) | 87.79% | 52.9% |
-| Search p95 latency | **1.38 s** | 1.44 s | 17.12 s |
-| Answer tokens per question | **~1.65k** | ~0.9k | 26k |
-
-The PowerContext result covers all 1,540 scored questions across the benchmark's 10 conversations. See the
-[LoCoMo evaluation details](benchmark/locomo/README.md) for dataset selection, retrieval, judging, latency, token, and
-Artifact boundaries.
-
 ### [SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os)
-
-In a paired evaluation over all **731 tasks** in
-[SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os), enabling PowerContext increased the task
-resolution rate from **82.35%** to **86.73%**, an improvement of **4.38 percentage points**.
-
-The evaluation ran in a Codex environment, with both the PowerContext OFF and ON groups using the `gpt-5.6-sol`
-model.
 
 ![SWE-bench Pro public v2 comparison showing an increase from 82.35% with PowerContext off to 86.73% with PowerContext on](docs/assets/swe-bench-pro-public-v2-comparison.svg)
 
-| Result | PowerContext OFF | PowerContext ON | Change |
-| --- | ---: | ---: | ---: |
-| Resolved tasks | 602 / 731 | **634 / 731** | **+32** |
-| Resolution rate | 82.35% | **86.73%** | **+4.38 percentage points** |
-
-[SWE-bench Pro public v2 evaluation details](evaluation/README.md).
+The evaluation ran in a Codex environment, with both the PowerContext OFF and ON groups using the `gpt-5.6-sol`
+model.
 
 ---
 
 ## Plugins
 
-PowerContext provides official plugins and installation guides for Codex, Claude Code, and DeepSeek Harness. All
-three integrations use the same scoped data and history-preserving contracts through PowerContext Server; the
-plugins do not start or embed the Server.
+PowerContext provides official plugins and installation guides for Codex, Claude Code, DeepSeek Harness, and Hermes
+Agent. All four integrations use the same scoped data and history-preserving contracts through PowerContext Server;
+the plugins do not start or embed the Server.
 
 ### Official integrations
 
@@ -74,43 +93,6 @@ plugins do not start or embed the Server.
 <td align="center" width="120"><a href="integrations/hermes/README.md"><img src="https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/logo.png?raw=true&size=120" alt="Hermes Agent" width="48" height="48" /><br /><sub><b>Hermes Agent</b></sub></a></td>
 </tr>
 </table>
-
-## Quick start
-
-You need macOS or Linux, Python 3.11 or newer, [`uv`](https://docs.astral.sh/uv/), and Codex CLI.
-
-### 1. Install PowerContext and the plugins
-
-```bash
-uv tool install "powercontext[cli,server]==0.0.2"
-
-# Choose one or more integrations.
-powercontext setup codex --source oceanbase/powercontext --ref v0.0.2
-powercontext setup claude-code --source oceanbase/powercontext --ref v0.0.2
-powercontext setup dsh --source oceanbase/powercontext --ref v0.0.2
-```
-
-The first command installs the CLI and local Server in an isolated environment. The subsequent setup commands
-install the corresponding plugins from the matching repository tag. Run setup again to refresh an existing
-installation.
-
-### 2. Start and verify the local Server
-
-Keep the Server running in one terminal:
-
-```bash
-powercontext server run
-```
-
-In another terminal, verify the service and plugin:
-
-```bash
-powercontext doctor
-powercontext doctor codex  # or: claude-code / dsh
-```
-
-By default, the Server listens on `127.0.0.1:8000`, exposes Streamable HTTP MCP at `/mcp`, and persists data in a
-local SQLite database. Explicit Memory operations work without configuring an inference provider.
 
 ## Development
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,6 +10,44 @@
 
 PowerContext 是 [PowerMem](https://www.powermem.ai/) 的升级版本，也是面向人机协作的上下文运行层。它将共同推进的工作沉淀为可理解、可交接、可延续的项目上下文。
 
+## 快速开始
+
+你需要 macOS 或 Linux、Python 3.11 或更高版本、[`uv`](https://docs.astral.sh/uv/)，以及至少一个支持的 Agent Host。
+
+### 1. 安装 PowerContext 和 Plugin
+
+```bash
+uv tool install "powercontext[cli,server]==0.0.2"
+
+# 选择一个或多个集成。
+powercontext setup codex --source oceanbase/powercontext --ref v0.0.2
+powercontext setup claude-code --source oceanbase/powercontext --ref v0.0.2
+powercontext setup dsh --source oceanbase/powercontext --ref v0.0.2
+powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
+```
+
+第一条命令会在隔离环境中安装 CLI 和本地 Server。后续 setup 命令会从匹配的仓库 tag 安装对应的
+Plugin。如需刷新现有安装，请再次运行 setup。Hermes 集成需要 Hermes Agent v0.20.4 或更高版本；配置和项目本地
+安装方式详见 [Hermes 集成指南](integrations/hermes/README.md)。
+
+### 2. 启动并验证本地 Server
+
+在一个终端中保持 Server 运行：
+
+```bash
+powercontext server run
+```
+
+在另一个终端中验证服务和 Plugin：
+
+```bash
+powercontext doctor
+powercontext doctor codex  # or: claude-code / dsh / hermes
+```
+
+默认情况下，Server 监听 `127.0.0.1:8000`，在 `/mcp` 提供 Streamable HTTP MCP，并将数据持久化到本地
+SQLite 数据库。显式 Memory 操作无需配置 inference provider 即可使用。
+
 ## 核心能力
 
 | 能力 | 核心价值 |
@@ -25,34 +63,19 @@ PowerContext 是 [PowerMem](https://www.powermem.ai/) 的升级版本，也是�
 
 ### [LoCoMo](https://github.com/snap-research/locomo)
 
-| 指标 | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | 全上下文基线 |
-| --- | ---: | ---: | ---: |
-| 准确率 | **90.78%**（1,398/1,540） | 87.79% | 52.9% |
-| 搜索 p95 延迟 | **1.38 秒** | 1.44 秒 | 17.12 秒 |
-| 每个问题的回答 token 数 | **约 1.65k** | 约 0.9k | 26k |
-
-PowerContext 的结果覆盖了该 benchmark 全部 10 个对话中的 1,540 道计分题。数据集选择、检索、judge、延迟、token 和 Artifact 边界详见
-[LoCoMo 评估详情](benchmark/locomo/README.md)。
+![LOCOMO benchmark comparison showing PowerContext accuracy, search latency, and answer token usage against PowerMem and a full-context baseline](docs/assets/locomo-benchmark-comparison.svg)
 
 ### [SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os)
 
-在 [SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os) 全部 **731 项任务**的配对评估中，
-启用 PowerContext 后，任务解决率从 **82.35%** 提升至 **86.73%**，提高了 **4.38 个百分点**。
+![SWE-bench Pro public v2 comparison showing an increase from 82.35% with PowerContext off to 86.73% with PowerContext on](docs/assets/swe-bench-pro-public-v2-comparison.svg)
 
 本次评估在 Codex 环境中运行，PowerContext OFF 与 ON 两组均使用 `gpt-5.6-sol` 模型。
-
-| 结果 | PowerContext OFF | PowerContext ON | 变化 |
-| --- | ---: | ---: | ---: |
-| 已解决任务 | 602 / 731 | **634 / 731** | **+32** |
-| 任务解决率 | 82.35% | **86.73%** | **+4.38 个百分点** |
-
-[SWE-bench Pro public v2 评估详情](evaluation/README.md)。
 
 ---
 
 ## 插件
 
-PowerContext 为 Codex、Claude Code 和 DeepSeek Harness 提供官方插件与安装指南。三个集成都通过
+PowerContext 为 Codex、Claude Code、DeepSeek Harness 和 Hermes Agent 提供官方插件与安装指南。四个集成都通过
 PowerContext Server 使用同一套作用域数据和保留历史的契约；插件不会自行启动或内嵌 Server。
 
 ### 官方集成
@@ -62,45 +85,9 @@ PowerContext Server 使用同一套作用域数据和保留历史的契约；插
 <td align="center" width="120"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></td>
 <td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
 <td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
+<td align="center" width="120"><a href="integrations/hermes/README.md"><img src="https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/logo.png?raw=true&size=120" alt="Hermes Agent" width="48" height="48" /><br /><sub><b>Hermes Agent</b></sub></a></td>
 </tr>
 </table>
-
-
-## 快速开始
-
-你需要 macOS 或 Linux、Python 3.11 或更高版本、[`uv`](https://docs.astral.sh/uv/) 和 Codex CLI。
-
-### 1. 安装 PowerContext 和 Plugin
-
-```bash
-uv tool install "powercontext[cli,server]==0.0.2"
-
-# Choose one or more integrations.
-powercontext setup codex --source oceanbase/powercontext --ref v0.0.2
-powercontext setup claude-code --source oceanbase/powercontext --ref v0.0.2
-powercontext setup dsh --source oceanbase/powercontext --ref v0.0.2
-```
-
-第一条命令会在隔离环境中安装 CLI 和本地 Server。第二条命令会从匹配的仓库 tag 安装对应的 Plugin。如需刷新现有安装，
-请再次运行 setup。
-
-### 2. 启动并验证本地 Server
-
-在一个终端中保持 Server 运行：
-
-```bash
-powercontext server run
-```
-
-在另一个终端中验证服务和 Plugin：
-
-```bash
-powercontext doctor
-powercontext doctor codex  # or: claude-code / dsh
-```
-
-默认情况下，Server 监听 `127.0.0.1:8000`，在 `/mcp` 提供 Streamable HTTP MCP，并将数据持久化到本地
-SQLite 数据库。显式 Memory 操作无需配置 inference provider 即可使用。
 
 ## 开发
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -12,6 +12,46 @@ PowerContext は [PowerMem](https://www.powermem.ai/) のアップグレード�
 コンテキストランタイムです。共同で進めた作業を、理解・引き継ぎ・継続が可能なプロジェクトコンテキストとして
 蓄積します。
 
+## クイックスタート
+
+macOS または Linux、Python 3.11 以降、[`uv`](https://docs.astral.sh/uv/)、および少なくとも 1 つの対応 Agent Host が必要です。
+
+### 1. PowerContext とプラグインをインストールする
+
+```bash
+uv tool install "powercontext[cli,server]==0.0.2"
+
+# 1 つ以上のインテグレーションを選択します。
+powercontext setup codex --source oceanbase/powercontext --ref v0.0.2
+powercontext setup claude-code --source oceanbase/powercontext --ref v0.0.2
+powercontext setup dsh --source oceanbase/powercontext --ref v0.0.2
+powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
+```
+
+最初のコマンドは、隔離された環境に CLI とローカル Server をインストールします。以降の setup コマンドは、
+対応するリポジトリの tag から各プラグインをインストールします。既存のインストールを更新するには、setup を
+再実行してください。Hermes インテグレーションには Hermes Agent v0.20.4 以降が必要です。設定とプロジェクトローカルの
+インストール方法については、[Hermes インテグレーションガイド](integrations/hermes/README.md)を参照してください。
+
+### 2. ローカル Server を起動して検証する
+
+1 つのターミナルで Server を起動したままにします。
+
+```bash
+powercontext server run
+```
+
+別のターミナルでサービスとプラグインを検証します。
+
+```bash
+powercontext doctor
+powercontext doctor codex  # または: claude-code / dsh / hermes
+```
+
+デフォルトでは、Server は `127.0.0.1:8000` で待ち受け、`/mcp` で Streamable HTTP MCP を公開し、
+ローカルの SQLite データベースにデータを永続化します。明示的な Memory 操作には inference provider の設定は
+不要です。
+
 ## 主な機能
 
 | 機能 | 提供する価値 |
@@ -27,36 +67,20 @@ PowerContext は [PowerMem](https://www.powermem.ai/) のアップグレード�
 
 ### [LoCoMo](https://github.com/snap-research/locomo)
 
-| 指標 | PowerContext | [PowerMem](https://www.powermem.ai/benchmark) | フルコンテキストのベースライン |
-| --- | ---: | ---: | ---: |
-| 精度 | **90.78%**（1,398/1,540） | 87.79% | 52.9% |
-| 検索 p95 レイテンシ | **1.38 秒** | 1.44 秒 | 17.12 秒 |
-| 質問ごとの回答 token 数 | **約 1.65k** | 約 0.9k | 26k |
-
-PowerContext の結果は、このベンチマークの全 10 会話に含まれる 1,540 問の採点対象すべてを網羅しています。
-データセットの選択、検索、judge、レイテンシ、token、Artifact の境界については、
-[LoCoMo 評価の詳細](benchmark/locomo/README.md)を参照してください。
+![LOCOMO benchmark comparison showing PowerContext accuracy, search latency, and answer token usage against PowerMem and a full-context baseline](docs/assets/locomo-benchmark-comparison.svg)
 
 ### [SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os)
 
-[SWE-bench Pro public v2](https://github.com/scaleapi/SWE-bench_Pro-os) の全 **731 タスク**を対象としたペア評価では、
-PowerContext を有効にすると、タスク解決率が **82.35%** から **86.73%** へと **4.38 ポイント**向上しました。
+![SWE-bench Pro public v2 comparison showing an increase from 82.35% with PowerContext off to 86.73% with PowerContext on](docs/assets/swe-bench-pro-public-v2-comparison.svg)
 
 この評価は Codex 環境で実行し、PowerContext OFF と ON の両グループで `gpt-5.6-sol` モデルを使用しました。
-
-| 結果 | PowerContext OFF | PowerContext ON | 変化 |
-| --- | ---: | ---: | ---: |
-| 解決済みタスク | 602 / 731 | **634 / 731** | **+32** |
-| タスク解決率 | 82.35% | **86.73%** | **+4.38 ポイント** |
-
-[SWE-bench Pro public v2 評価の詳細](evaluation/README.md)。
 
 ---
 
 ## プラグイン
 
-PowerContext は Codex、Claude Code、DeepSeek Harness 向けの公式プラグインとインストールガイドを提供します。
-3 つのインテグレーションはすべて、PowerContext Server を通じて同じスコープ付きデータと履歴を保持する契約を
+PowerContext は Codex、Claude Code、DeepSeek Harness、Hermes Agent 向けの公式プラグインとインストールガイドを提供します。
+4 つのインテグレーションはすべて、PowerContext Server を通じて同じスコープ付きデータと履歴を保持する契約を
 使用します。プラグインが Server を自動的に起動したり、組み込んだりすることはありません。
 
 ### 公式インテグレーション
@@ -66,46 +90,9 @@ PowerContext は Codex、Claude Code、DeepSeek Harness 向けの公式プラグ
 <td align="center" width="120"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></td>
 <td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
 <td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
+<td align="center" width="120"><a href="integrations/hermes/README.md"><img src="https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/logo.png?raw=true&size=120" alt="Hermes Agent" width="48" height="48" /><br /><sub><b>Hermes Agent</b></sub></a></td>
 </tr>
 </table>
-
-## クイックスタート
-
-macOS または Linux、Python 3.11 以降、[`uv`](https://docs.astral.sh/uv/)、Codex CLI が必要です。
-
-### 1. PowerContext とプラグインをインストールする
-
-```bash
-uv tool install "powercontext[cli,server]==0.0.2"
-
-# 1 つ以上のインテグレーションを選択します。
-powercontext setup codex --source oceanbase/powercontext --ref v0.0.2
-powercontext setup claude-code --source oceanbase/powercontext --ref v0.0.2
-powercontext setup dsh --source oceanbase/powercontext --ref v0.0.2
-```
-
-最初のコマンドは、隔離された環境に CLI とローカル Server をインストールします。以降の setup コマンドは、
-対応するリポジトリの tag から各プラグインをインストールします。既存のインストールを更新するには、setup を
-再実行してください。
-
-### 2. ローカル Server を起動して検証する
-
-1 つのターミナルで Server を起動したままにします。
-
-```bash
-powercontext server run
-```
-
-別のターミナルでサービスとプラグインを検証します。
-
-```bash
-powercontext doctor
-powercontext doctor codex  # または: claude-code / dsh
-```
-
-デフォルトでは、Server は `127.0.0.1:8000` で待ち受け、`/mcp` で Streamable HTTP MCP を公開し、
-ローカルの SQLite データベースにデータを永続化します。明示的な Memory 操作には inference provider の設定は
-不要です。
 
 ## 開発
 


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A.

# Rationale for this change

The v0.0.2 README should lead new users directly to a concise installation path and present Hermes Agent alongside the other supported agent hosts. The localized READMEs should expose the same release instructions and product overview.

# What changes are included in this PR?

- Move Quick start before the capability and benchmark sections in the English, Chinese, and Japanese READMEs.
- Add the v0.0.2 Hermes setup and doctor commands, the minimum Hermes Agent version, and the integration guide link.
- Present all four official integrations consistently across locales.
- Replace dense benchmark tables with the maintained comparison visualizations and keep the evaluation model context aligned.

# Are there any user-facing changes?

Yes. New users see the installation workflow earlier, and Hermes Agent is documented as an official v0.0.2 integration. This PR changes documentation only; it does not change public APIs or persisted formats.

# How was this change tested?

- `uv run prek run --files README.md README_CN.md README_JP.md`
- `make docs-test`
- `git diff --check -- README.md README_CN.md README_JP.md`

# AI usage statement

OpenAI Codex was used to edit the documentation, check cross-locale consistency, and run repository validation.
