### PR TITLE
feat(hermes): add Hermes memory provider setup and diagnostics of powercontext cli

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -7,7 +7,33 @@ preparation, and memory lifecycle operations.
 
 The integration requires Hermes Agent v0.20.4 or newer.
 
-## Install as a directory provider
+## Install with the PowerContext CLI
+
+With Hermes installed and available on `PATH`, install or refresh the provider
+from the matching PowerContext release tag:
+
+```bash
+powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
+```
+
+The command copies the provider to `$HERMES_HOME/plugins/powercontext`. Verify
+the installation with:
+
+```bash
+powercontext doctor hermes
+```
+
+Then run `hermes memory setup` and select `PowerContext` to configure the
+provider. Hermes v0.20.4 or newer is required.
+
+<details>
+<summary>Manual directory installation (alternative)</summary>
+
+### Manual directory installation
+
+`powercontext setup hermes` performs this copy automatically for a user-level
+installation. Use the manual method only for a project-local provider or when
+the PowerContext CLI is not available.
 
 Copy `plugins/powercontext` into one of the Hermes provider locations:
 
@@ -18,6 +44,8 @@ cp -R integrations/hermes/plugins/powercontext \
 
 For project-local installation, copy it to `.hermes/plugins/powercontext` and
 enable project plugins with `HERMES_ENABLE_PROJECT_PLUGINS=1`.
+
+</details>
 
 Start PowerContext separately:
 

--- a/integrations/hermes/plugins/powercontext/README.md
+++ b/integrations/hermes/plugins/powercontext/README.md
@@ -10,6 +10,16 @@ The plugin deliberately uses only the Python standard library for HTTP, so it
 can be copied into Hermes without adding an HTTP client dependency. Its
 provider configuration is read from `$HERMES_HOME/powercontext/config.json`.
 
+To install or refresh the provider from a matching PowerContext release tag:
+
+```bash
+powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
+powercontext doctor hermes
+```
+
+The setup command copies this directory to `$HERMES_HOME/plugins/powercontext`.
+It requires the Hermes CLI to be installed and available on `PATH`.
+
 The provider participates in Hermes' generic memory setup wizard. Run the
 command below and select `PowerContext` from the provider list:
 

--- a/src/powercontext/cli/hermes.py
+++ b/src/powercontext/cli/hermes.py
@@ -16,9 +16,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
+import re
 import shutil
 import subprocess
+import tempfile
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import which
@@ -29,6 +33,8 @@ from powercontext.paths import powercontext_data_dir
 HERMES_HOME_ENV = "HERMES_HOME"
 HERMES_PLUGIN_RELATIVE = Path("integrations") / "hermes" / "plugins" / "powercontext"
 HERMES_PLUGIN_NAME = "powercontext"
+HERMES_MIN_VERSION = (0, 20, 4)
+_HERMES_VERSION_PATTERN = re.compile(r"Hermes Agent v?(\d+)\.(\d+)\.(\d+)")
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,7 +48,8 @@ class HermesSetupResult:
 def install_hermes_plugin(*, source: str, ref: str) -> HermesSetupResult:
     """Install the PowerContext provider into Hermes' user plugin directory."""
 
-    hermes_executable()
+    executable = hermes_executable()
+    get_hermes_version(executable)
     data_dir = powercontext_data_dir()
     try:
         data_dir.mkdir(parents=True, exist_ok=True)
@@ -54,7 +61,15 @@ def install_hermes_plugin(*, source: str, ref: str) -> HermesSetupResult:
     target = home / "plugins" / HERMES_PLUGIN_NAME
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(plugin_dir, target, dirs_exist_ok=True)
+        staging = _new_staging_directory(target)
+        try:
+            shutil.rmtree(staging)
+            shutil.copytree(plugin_dir, staging)
+            _run_plugin_doctor(executable, staging)
+            _replace_directory(staging, target)
+        except BaseException:
+            _remove_path(staging)
+            raise
     except OSError as error:
         raise SetupError.hermes_plugin_write(target, error) from error
 
@@ -102,16 +117,40 @@ def run_hermes_diagnostics() -> dict[str, Diagnostic]:
             ),
         }
 
-    plugin = hermes_home() / "plugins" / HERMES_PLUGIN_NAME
-    installed = _is_hermes_plugin(plugin)
-    return {
-        "hermes": Diagnostic(status=DiagnosticStatus.OK, detail=executable),
-        "plugin": Diagnostic(
-            status=DiagnosticStatus.OK if installed else DiagnosticStatus.FAILED,
-            detail=(
-                f"{HERMES_PLUGIN_NAME} is installed" if installed else "PowerContext Hermes plugin is not installed"
+    try:
+        hermes_version = get_hermes_version(executable)
+    except SetupError as error:
+        return {
+            "hermes": Diagnostic(status=DiagnosticStatus.FAILED, detail=str(error)),
+            "plugin": Diagnostic(
+                status=DiagnosticStatus.SKIPPED,
+                detail="not checked because Hermes version validation failed",
             ),
-        ),
+        }
+
+    plugin = hermes_home() / "plugins" / HERMES_PLUGIN_NAME
+    if not _is_hermes_plugin(plugin):
+        return {
+            "hermes": Diagnostic(status=DiagnosticStatus.OK, detail=f"{executable} (Hermes Agent v{hermes_version})"),
+            "plugin": Diagnostic(
+                status=DiagnosticStatus.FAILED,
+                detail="PowerContext Hermes plugin is not installed",
+            ),
+        }
+
+    try:
+        _run_plugin_doctor(executable, plugin)
+    except SetupError as error:
+        plugin_diagnostic = Diagnostic(status=DiagnosticStatus.FAILED, detail=str(error))
+    else:
+        plugin_diagnostic = Diagnostic(
+            status=DiagnosticStatus.OK,
+            detail="powercontext passed Hermes plugin doctor",
+        )
+
+    return {
+        "hermes": Diagnostic(status=DiagnosticStatus.OK, detail=f"{executable} (Hermes Agent v{hermes_version})"),
+        "plugin": plugin_diagnostic,
     }
 
 
@@ -131,13 +170,14 @@ def hermes_executable() -> str:
     return executable
 
 
-def checkout_target(ref: str) -> Path:
-    """Resolve a Git ref to a directory under PowerContext's Hermes cache."""
+def checkout_target(source: str, ref: str) -> Path:
+    """Resolve a source and Git ref to a directory under the Hermes cache."""
 
     root = (powercontext_data_dir() / "checkouts" / "hermes").resolve()
     if not ref or ref in {".", ".."} or "\x00" in ref:
         raise SetupError.invalid_hermes_ref(ref)
-    target = (root / ref).resolve()
+    source_key = _source_cache_key(source)
+    target = (root / source_key / ref).resolve()
     try:
         target.relative_to(root)
     except ValueError as error:
@@ -174,13 +214,16 @@ def _usable_checkout(target: Path) -> bool:
 
 
 def _materialize_remote_checkout(source: str, ref: str) -> Path:
-    target = checkout_target(ref)
-    if _usable_checkout(target):
-        return target
-    if target.exists():
-        shutil.rmtree(target)
+    target = checkout_target(source, ref)
     target.parent.mkdir(parents=True, exist_ok=True)
-    _clone_github_source(source, ref, target)
+    staging = _new_staging_directory(target)
+    shutil.rmtree(staging)
+    try:
+        _clone_github_source(source, ref, staging)
+        _replace_directory(staging, target)
+    except BaseException:
+        _remove_path(staging)
+        raise
     return target
 
 
@@ -201,10 +244,87 @@ def _clone_github_source(source: str, ref: str, target: Path) -> None:
         raise SetupError.command_failed(command, detail)
 
 
+def get_hermes_version(executable: str | None = None) -> str:
+    """Return the Hermes version and reject versions below the supported minimum."""
+
+    executable = executable or hermes_executable()
+    command = [executable, "--version"]
+    completed = _run_hermes_command(command)
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit code {completed.returncode}"
+        raise SetupError.command_failed(command, detail)
+    match = _HERMES_VERSION_PATTERN.search(f"{completed.stdout}\n{completed.stderr}")
+    if match is None:
+        raise SetupError.invalid_command_output(command, "an unrecognized Hermes version")
+    parsed = tuple(int(part) for part in match.groups())
+    if parsed < HERMES_MIN_VERSION:
+        actual = ".".join(str(part) for part in parsed)
+        minimum = ".".join(str(part) for part in HERMES_MIN_VERSION)
+        raise SetupError.unsupported_hermes_version(actual, minimum)
+    return ".".join(str(part) for part in parsed)
+
+
+def _run_plugin_doctor(executable: str, plugin: Path) -> None:
+    command = [executable, "plugins", "doctor", "--ci", str(plugin)]
+    completed = _run_hermes_command(command)
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit code {completed.returncode}"
+        raise SetupError.command_failed(command, detail)
+
+
+def _run_hermes_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(  # noqa: S603 - the executable and arguments are controlled by this CLI.
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise SetupError.command_unavailable(command, error) from error
+
+
+def _source_cache_key(source: str) -> str:
+    normalized = github_clone_url(source)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _new_staging_directory(target: Path) -> Path:
+    return Path(tempfile.mkdtemp(prefix=f".{target.name}-", dir=target.parent))
+
+
+def _replace_directory(staging: Path, target: Path) -> None:
+    backup = target.with_name(f".{target.name}.backup-{uuid.uuid4().hex}")
+    moved_old = False
+    try:
+        if target.exists() or target.is_symlink():
+            os.replace(target, backup)
+            moved_old = True
+        os.replace(staging, target)
+    except BaseException:
+        if moved_old and not (target.exists() or target.is_symlink()) and backup.exists():
+            os.replace(backup, target)
+        raise
+    finally:
+        _remove_path(staging)
+        _remove_path(backup)
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
 __all__ = [
     "HERMES_PLUGIN_NAME",
     "HermesSetupResult",
     "checkout_target",
+    "get_hermes_version",
     "github_clone_url",
     "hermes_executable",
     "hermes_home",

--- a/src/powercontext/cli/hermes.py
+++ b/src/powercontext/cli/hermes.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Install and diagnose the Hermes PowerContext memory provider."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from shutil import which
+
+from powercontext.cli.system import Diagnostic, DiagnosticStatus, SetupError
+from powercontext.paths import powercontext_data_dir
+
+HERMES_HOME_ENV = "HERMES_HOME"
+HERMES_PLUGIN_RELATIVE = Path("integrations") / "hermes" / "plugins" / "powercontext"
+HERMES_PLUGIN_NAME = "powercontext"
+
+
+@dataclass(frozen=True, slots=True)
+class HermesSetupResult:
+    plugin: str
+    plugin_path: str
+    hermes_home: str
+    data_dir: str
+
+
+def install_hermes_plugin(*, source: str, ref: str) -> HermesSetupResult:
+    """Install the PowerContext provider into Hermes' user plugin directory."""
+
+    hermes_executable()
+    data_dir = powercontext_data_dir()
+    try:
+        data_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise SetupError.data_directory(data_dir, error) from error
+
+    plugin_dir = resolve_hermes_plugin_dir(source=source, ref=ref)
+    home = hermes_home()
+    target = home / "plugins" / HERMES_PLUGIN_NAME
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(plugin_dir, target, dirs_exist_ok=True)
+    except OSError as error:
+        raise SetupError.hermes_plugin_write(target, error) from error
+
+    return HermesSetupResult(
+        plugin=HERMES_PLUGIN_NAME,
+        plugin_path=str(target),
+        hermes_home=str(home),
+        data_dir=str(data_dir),
+    )
+
+
+def resolve_hermes_plugin_dir(*, source: str, ref: str) -> Path:
+    """Return the Hermes provider directory from a local or remote checkout."""
+
+    if _is_local_source(source):
+        return plugin_dir_from_checkout(Path(source).expanduser().resolve())
+    return plugin_dir_from_checkout(_materialize_remote_checkout(source, ref))
+
+
+def plugin_dir_from_checkout(root: Path) -> Path:
+    """Accept either the provider directory or a PowerContext repository root."""
+
+    if _is_hermes_plugin(root):
+        return root
+    plugin = root / HERMES_PLUGIN_RELATIVE
+    if _is_hermes_plugin(plugin):
+        return plugin
+    raise SetupError.missing_hermes_plugin(root)
+
+
+def run_hermes_diagnostics() -> dict[str, Diagnostic]:
+    """Collect diagnostics for the optional Hermes integration."""
+
+    try:
+        executable = hermes_executable()
+    except SetupError:
+        return {
+            "hermes": Diagnostic(
+                status=DiagnosticStatus.FAILED,
+                detail="Hermes CLI is not installed or is not on PATH",
+            ),
+            "plugin": Diagnostic(
+                status=DiagnosticStatus.SKIPPED,
+                detail="not checked because Hermes CLI is unavailable",
+            ),
+        }
+
+    plugin = hermes_home() / "plugins" / HERMES_PLUGIN_NAME
+    installed = _is_hermes_plugin(plugin)
+    return {
+        "hermes": Diagnostic(status=DiagnosticStatus.OK, detail=executable),
+        "plugin": Diagnostic(
+            status=DiagnosticStatus.OK if installed else DiagnosticStatus.FAILED,
+            detail=(
+                f"{HERMES_PLUGIN_NAME} is installed" if installed else "PowerContext Hermes plugin is not installed"
+            ),
+        ),
+    }
+
+
+def hermes_home() -> Path:
+    """Return Hermes' user home, honoring the host's environment override."""
+
+    configured = os.environ.get(HERMES_HOME_ENV, "").strip()
+    return Path(configured).expanduser().resolve() if configured else (Path.home() / ".hermes").resolve()
+
+
+def hermes_executable() -> str:
+    """Return a subprocess-launchable Hermes CLI path."""
+
+    executable = which("hermes")
+    if executable is None:
+        raise SetupError.hermes_unavailable()
+    return executable
+
+
+def checkout_target(ref: str) -> Path:
+    """Resolve a Git ref to a directory under PowerContext's Hermes cache."""
+
+    root = (powercontext_data_dir() / "checkouts" / "hermes").resolve()
+    if not ref or ref in {".", ".."} or "\x00" in ref:
+        raise SetupError.invalid_hermes_ref(ref)
+    target = (root / ref).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError as error:
+        raise SetupError.invalid_hermes_ref(ref) from error
+    if target == root:
+        raise SetupError.invalid_hermes_ref(ref)
+    return target
+
+
+def github_clone_url(source: str) -> str:
+    """Accept a GitHub slug or repository URL and return a clone URL."""
+
+    text = source.strip()
+    if text.startswith(("https://github.com/", "http://github.com/", "git@github.com:")):
+        return text if text.endswith(".git") else f"{text}.git"
+    if "://" in text or text.startswith("git@"):
+        raise SetupError.invalid_hermes_source(source)
+    if "/" in text and not text.startswith("."):
+        return f"https://github.com/{text}.git"
+    raise SetupError.invalid_hermes_source(source)
+
+
+def _is_local_source(source: str) -> bool:
+    candidate = Path(source).expanduser()
+    return source.startswith((".", "/", "~")) or (len(source) >= 2 and source[1] == ":") or candidate.exists()
+
+
+def _is_hermes_plugin(path: Path) -> bool:
+    return (path / "__init__.py").is_file() and (path / "plugin.yaml").is_file()
+
+
+def _usable_checkout(target: Path) -> bool:
+    return _is_hermes_plugin(target) or _is_hermes_plugin(target / HERMES_PLUGIN_RELATIVE)
+
+
+def _materialize_remote_checkout(source: str, ref: str) -> Path:
+    target = checkout_target(ref)
+    if _usable_checkout(target):
+        return target
+    if target.exists():
+        shutil.rmtree(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    _clone_github_source(source, ref, target)
+    return target
+
+
+def _clone_github_source(source: str, ref: str, target: Path) -> None:
+    command = ["git", "clone", "--depth", "1", "--branch", ref, github_clone_url(source), str(target)]
+    try:
+        completed = subprocess.run(  # noqa: S603 - arguments are passed directly to git.
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise SetupError.command_unavailable(command, error) from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit code {completed.returncode}"
+        raise SetupError.command_failed(command, detail)
+
+
+__all__ = [
+    "HERMES_PLUGIN_NAME",
+    "HermesSetupResult",
+    "checkout_target",
+    "github_clone_url",
+    "hermes_executable",
+    "hermes_home",
+    "install_hermes_plugin",
+    "plugin_dir_from_checkout",
+    "resolve_hermes_plugin_dir",
+    "run_hermes_diagnostics",
+]

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -111,6 +111,10 @@ class SetupError(RuntimeError):
         return cls(f"Cannot install PowerContext Hermes plugin at {path}: {error}")
 
     @classmethod
+    def unsupported_hermes_version(cls, actual: str, minimum: str) -> SetupError:
+        return cls(f"Hermes Agent v{actual} is unsupported; PowerContext requires Hermes Agent v{minimum} or newer.")
+
+    @classmethod
     def data_directory(cls, path: Path, error: OSError) -> SetupError:
         return cls(f"Cannot create PowerContext data directory {path}: {error}")
 

--- a/src/powercontext/cli/system.py
+++ b/src/powercontext/cli/system.py
@@ -75,6 +75,10 @@ class SetupError(RuntimeError):
         return cls("DeepSeek Harness CLI is not installed or is not on PATH.")
 
     @classmethod
+    def hermes_unavailable(cls) -> SetupError:
+        return cls("Hermes CLI is not installed or is not on PATH.")
+
+    @classmethod
     def missing_dsh_plugin(cls, path: Path) -> SetupError:
         return cls(f"PowerContext DSH plugin was not found under {path}.")
 
@@ -89,6 +93,22 @@ class SetupError(RuntimeError):
     @classmethod
     def invalid_dsh_source(cls, source: str) -> SetupError:
         return cls(f"invalid DeepSeek Harness source: {source}")
+
+    @classmethod
+    def invalid_hermes_ref(cls, ref: str) -> SetupError:
+        return cls(f"invalid Hermes ref: {ref}")
+
+    @classmethod
+    def invalid_hermes_source(cls, source: str) -> SetupError:
+        return cls(f"invalid Hermes source: {source}")
+
+    @classmethod
+    def missing_hermes_plugin(cls, path: Path) -> SetupError:
+        return cls(f"PowerContext Hermes plugin was not found under {path}.")
+
+    @classmethod
+    def hermes_plugin_write(cls, path: Path, error: OSError) -> SetupError:
+        return cls(f"Cannot install PowerContext Hermes plugin at {path}: {error}")
 
     @classmethod
     def data_directory(cls, path: Path, error: OSError) -> SetupError:
@@ -322,6 +342,46 @@ def setup_dsh(
     typer.echo("Next: run `powercontext server run`, then start `dsh web`.")
 
 
+@setup_app.command("hermes")
+def setup_hermes(
+    source: Annotated[
+        str,
+        typer.Option(help="PowerContext Git source or local checkout path."),
+    ] = DEFAULT_MARKETPLACE_SOURCE,
+    ref: Annotated[
+        str,
+        typer.Option(help="Git ref used for a remote source."),
+    ] = DEFAULT_MARKETPLACE_REF,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Write the result as JSON."),
+    ] = False,
+) -> None:
+    """Install the PowerContext Hermes memory provider."""
+
+    from powercontext.cli.hermes import install_hermes_plugin, run_hermes_diagnostics
+
+    try:
+        result = install_hermes_plugin(source=source, ref=ref)
+    except SetupError as error:
+        typer.echo(str(error), err=True)
+        raise typer.Exit(code=1) from error
+
+    diagnostics = run_hermes_diagnostics()
+    if not _diagnostics_ok(diagnostics):
+        _write_diagnostics(diagnostics, json_output=json_output)
+        raise typer.Exit(code=1)
+
+    if json_output:
+        typer.echo(json.dumps(asdict(result), indent=2))
+        return
+    typer.echo("PowerContext Hermes setup complete.")
+    typer.echo(f"Plugin: {result.plugin} ({result.plugin_path})")
+    typer.echo(f"Hermes home: {result.hermes_home}")
+    typer.echo(f"Data directory: {result.data_dir}")
+    typer.echo("Next: run `hermes memory setup`, select PowerContext, then start Hermes.")
+
+
 @doctor_app.callback()
 def doctor(
     context: typer.Context,
@@ -386,6 +446,23 @@ def doctor_dsh(
     from powercontext.cli.dsh import run_dsh_diagnostics
 
     diagnostics = run_dsh_diagnostics()
+    _write_diagnostics(diagnostics, json_output=json_output)
+    if not _diagnostics_ok(diagnostics):
+        raise typer.Exit(code=1)
+
+
+@doctor_app.command("hermes")
+def doctor_hermes(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Write the result as JSON."),
+    ] = False,
+) -> None:
+    """Check the optional Hermes CLI and PowerContext memory provider."""
+
+    from powercontext.cli.hermes import run_hermes_diagnostics
+
+    diagnostics = run_hermes_diagnostics()
     _write_diagnostics(diagnostics, json_output=json_output)
     if not _diagnostics_ok(diagnostics):
         raise typer.Exit(code=1)

--- a/tests/test_hermes_cli.py
+++ b/tests/test_hermes_cli.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+from typer.testing import CliRunner
+
+import powercontext.cli.hermes as hermes_cli
+from powercontext.cli.app import create_cli
+from powercontext.cli.system import doctor_app, setup_app
+
+
+def _write_plugin(root: Path) -> Path:
+    plugin = root / "integrations" / "hermes" / "plugins" / "powercontext"
+    plugin.mkdir(parents=True)
+    (plugin / "__init__.py").write_text("def register(): pass\n", encoding="utf-8")
+    (plugin / "plugin.yaml").write_text("name: powercontext\n", encoding="utf-8")
+    return plugin
+
+
+def test_setup_hermes_copies_provider_from_a_local_checkout(tmp_path: Path, monkeypatch) -> None:
+    checkout = tmp_path / "powercontext"
+    _write_plugin(checkout)
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("POWERCONTEXT_HOME", str(tmp_path / "data"))
+    monkeypatch.setattr(hermes_cli, "which", lambda _name: "/usr/bin/hermes")
+
+    result = CliRunner().invoke(
+        create_cli([setup_app]),
+        ["setup", "hermes", "--source", str(checkout), "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "plugin": "powercontext",
+        "plugin_path": str(hermes_home / "plugins" / "powercontext"),
+        "hermes_home": str(hermes_home),
+        "data_dir": str(tmp_path / "data"),
+    }
+    assert (hermes_home / "plugins" / "powercontext" / "plugin.yaml").is_file()
+
+
+def test_setup_hermes_reports_missing_cli(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(hermes_cli, "which", lambda _name: None)
+
+    result = CliRunner().invoke(
+        create_cli([setup_app]),
+        ["setup", "hermes", "--source", str(tmp_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "Hermes CLI is not installed" in result.output
+
+
+def test_doctor_hermes_reports_an_installed_provider(tmp_path: Path, monkeypatch) -> None:
+    hermes_home = tmp_path / "hermes"
+    plugin = hermes_home / "plugins" / "powercontext"
+    plugin.mkdir(parents=True)
+    (plugin / "__init__.py").write_text("def register(): pass\n", encoding="utf-8")
+    (plugin / "plugin.yaml").write_text("name: powercontext\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(hermes_cli, "which", lambda _name: "/usr/bin/hermes")
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "hermes", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["checks"]["hermes"] == {
+        "ok": True,
+        "status": "ok",
+        "detail": "/usr/bin/hermes",
+    }
+    assert payload["checks"]["plugin"] == {
+        "ok": True,
+        "status": "ok",
+        "detail": "powercontext is installed",
+    }
+
+
+def test_doctor_hermes_reports_missing_provider(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(hermes_cli, "which", lambda _name: "/usr/bin/hermes")
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "hermes"])
+
+    assert result.exit_code == 1
+    assert "hermes: ok - /usr/bin/hermes" in result.output
+    assert "plugin: failed - PowerContext Hermes plugin is not installed" in result.output
+
+
+def test_setup_hermes_remote_checkout_uses_the_requested_ref(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("POWERCONTEXT_HOME", str(tmp_path / "data"))
+    captured: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        captured.append(command)
+        _write_plugin(Path(command[-1]))
+        return Mock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_cli.subprocess, "run", fake_run)
+
+    plugin = hermes_cli.resolve_hermes_plugin_dir(source="oceanbase/powercontext", ref="v0.0.2")
+
+    assert (
+        plugin
+        == tmp_path
+        / "data"
+        / "checkouts"
+        / "hermes"
+        / "v0.0.2"
+        / "integrations"
+        / "hermes"
+        / "plugins"
+        / "powercontext"
+    )
+    assert captured[0][:6] == ["git", "clone", "--depth", "1", "--branch", "v0.0.2"]
+    assert captured[0][6] == "https://github.com/oceanbase/powercontext.git"

--- a/tests/test_hermes_cli.py
+++ b/tests/test_hermes_cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from subprocess import CompletedProcess
 from unittest.mock import Mock
 
 from typer.testing import CliRunner
@@ -33,6 +34,14 @@ def _write_plugin(root: Path) -> Path:
     return plugin
 
 
+def _successful_hermes_run(command: list[str], **_kwargs) -> CompletedProcess[str]:
+    if command[1:] == ["--version"]:
+        return CompletedProcess(command, 0, stdout="Hermes Agent v0.20.4 (2026.8.18)\n", stderr="")
+    if command[1:3] == ["plugins", "doctor"]:
+        return CompletedProcess(command, 0, stdout="Plugin Doctor: OK\n", stderr="")
+    raise AssertionError(command)
+
+
 def test_setup_hermes_copies_provider_from_a_local_checkout(tmp_path: Path, monkeypatch) -> None:
     checkout = tmp_path / "powercontext"
     _write_plugin(checkout)
@@ -40,6 +49,10 @@ def test_setup_hermes_copies_provider_from_a_local_checkout(tmp_path: Path, monk
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("POWERCONTEXT_HOME", str(tmp_path / "data"))
     monkeypatch.setattr(hermes_cli, "which", lambda _name: "/usr/bin/hermes")
+    old_plugin = hermes_home / "plugins" / "powercontext"
+    old_plugin.mkdir(parents=True)
+    (old_plugin / "removed_module.py").write_text("stale\n", encoding="utf-8")
+    monkeypatch.setattr(hermes_cli.subprocess, "run", _successful_hermes_run)
 
     result = CliRunner().invoke(
         create_cli([setup_app]),
@@ -54,6 +67,7 @@ def test_setup_hermes_copies_provider_from_a_local_checkout(tmp_path: Path, monk
         "data_dir": str(tmp_path / "data"),
     }
     assert (hermes_home / "plugins" / "powercontext" / "plugin.yaml").is_file()
+    assert not (hermes_home / "plugins" / "powercontext" / "removed_module.py").exists()
 
 
 def test_setup_hermes_reports_missing_cli(tmp_path: Path, monkeypatch) -> None:
@@ -76,6 +90,7 @@ def test_doctor_hermes_reports_an_installed_provider(tmp_path: Path, monkeypatch
     (plugin / "plugin.yaml").write_text("name: powercontext\n", encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setattr(hermes_cli, "which", lambda _name: "/usr/bin/hermes")
+    monkeypatch.setattr(hermes_cli.subprocess, "run", _successful_hermes_run)
 
     result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "hermes", "--json"])
 
@@ -85,24 +100,70 @@ def test_doctor_hermes_reports_an_installed_provider(tmp_path: Path, monkeypatch
     assert payload["checks"]["hermes"] == {
         "ok": True,
         "status": "ok",
-        "detail": "/usr/bin/hermes",
+        "detail": "/usr/bin/hermes (Hermes Agent v0.20.4)",
     }
     assert payload["checks"]["plugin"] == {
         "ok": True,
         "status": "ok",
-        "detail": "powercontext is installed",
+        "detail": "powercontext passed Hermes plugin doctor",
     }
 
 
 def test_doctor_hermes_reports_missing_provider(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setattr(hermes_cli, "which", lambda _name: "/usr/bin/hermes")
+    monkeypatch.setattr(hermes_cli.subprocess, "run", _successful_hermes_run)
 
     result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "hermes"])
 
     assert result.exit_code == 1
-    assert "hermes: ok - /usr/bin/hermes" in result.output
+    assert "hermes: ok - /usr/bin/hermes (Hermes Agent v0.20.4)" in result.output
     assert "plugin: failed - PowerContext Hermes plugin is not installed" in result.output
+
+
+def test_doctor_hermes_rejects_a_broken_provider(tmp_path: Path, monkeypatch) -> None:
+    hermes_home = tmp_path / "hermes"
+    plugin = hermes_home / "plugins" / "powercontext"
+    plugin.mkdir(parents=True)
+    (plugin / "__init__.py").write_text("def register(): pass\n", encoding="utf-8")
+    (plugin / "plugin.yaml").write_text("name: powercontext\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(hermes_cli, "which", lambda _name: "/usr/bin/hermes")
+
+    def failed_plugin_doctor(command: list[str], **_kwargs) -> CompletedProcess[str]:
+        if command[1:] == ["--version"]:
+            return CompletedProcess(command, 0, stdout="Hermes Agent v0.20.4\n", stderr="")
+        return CompletedProcess(command, 1, stdout="", stderr="ImportError: cannot import client\n")
+
+    monkeypatch.setattr(hermes_cli.subprocess, "run", failed_plugin_doctor)
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "hermes", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert payload["checks"]["plugin"]["status"] == "failed"
+    assert "ImportError" in payload["checks"]["plugin"]["detail"]
+
+
+def test_doctor_hermes_rejects_an_unsupported_version(monkeypatch) -> None:
+    monkeypatch.setattr(hermes_cli, "which", lambda _name: "/usr/bin/hermes")
+    calls: list[list[str]] = []
+
+    def old_hermes_run(command: list[str], **_kwargs) -> CompletedProcess[str]:
+        calls.append(command)
+        return CompletedProcess(command, 0, stdout="Hermes Agent v0.20.3\n", stderr="")
+
+    monkeypatch.setattr(hermes_cli.subprocess, "run", old_hermes_run)
+
+    result = CliRunner().invoke(create_cli([doctor_app]), ["doctor", "hermes", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["checks"]["hermes"]["status"] == "failed"
+    assert "requires Hermes Agent v0.20.4 or newer" in payload["checks"]["hermes"]["detail"]
+    assert payload["checks"]["plugin"]["status"] == "skipped"
+    assert len(calls) == 1
 
 
 def test_setup_hermes_remote_checkout_uses_the_requested_ref(tmp_path: Path, monkeypatch) -> None:
@@ -116,19 +177,30 @@ def test_setup_hermes_remote_checkout_uses_the_requested_ref(tmp_path: Path, mon
 
     monkeypatch.setattr(hermes_cli.subprocess, "run", fake_run)
 
-    plugin = hermes_cli.resolve_hermes_plugin_dir(source="oceanbase/powercontext", ref="v0.0.2")
+    source = "oceanbase/powercontext"
+    ref = "v0.0.2"
+    plugin = hermes_cli.resolve_hermes_plugin_dir(source=source, ref=ref)
 
-    assert (
-        plugin
-        == tmp_path
-        / "data"
-        / "checkouts"
-        / "hermes"
-        / "v0.0.2"
-        / "integrations"
-        / "hermes"
-        / "plugins"
-        / "powercontext"
-    )
+    assert plugin == hermes_cli.checkout_target(source, ref) / "integrations" / "hermes" / "plugins" / "powercontext"
     assert captured[0][:6] == ["git", "clone", "--depth", "1", "--branch", "v0.0.2"]
     assert captured[0][6] == "https://github.com/oceanbase/powercontext.git"
+
+
+def test_remote_checkout_is_source_scoped_and_refreshes_mutable_refs(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("POWERCONTEXT_HOME", str(tmp_path / "data"))
+    captured: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        captured.append(command)
+        _write_plugin(Path(command[-1]))
+        return CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(hermes_cli.subprocess, "run", fake_run)
+
+    first = hermes_cli.resolve_hermes_plugin_dir(source="oceanbase/powercontext", ref="master")
+    refreshed = hermes_cli.resolve_hermes_plugin_dir(source="oceanbase/powercontext", ref="master")
+    other_source = hermes_cli.resolve_hermes_plugin_dir(source="other/project", ref="master")
+
+    assert first == refreshed
+    assert first != other_source
+    assert len(captured) == 3


### PR DESCRIPTION
# Which issue or RFC does this PR close?


# Rationale for this change

add support for Hermes CLI:
```
powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
powercontext doctor hermes
```

including 

install plugin of powercontext hermes
cp to $HERMES_HOME/plugins/powercontext
check Hermes CLI installed or not
check PowerContext Hermes pligin exists or not
suppport --json


# Are there any user-facing changes?

yes, powercontext cli support for hermes

# AI usage statement

coworked with codex
