### PR TITLE
fix(website): redirect root to English site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 title: PowerContext
 description: PowerContext turns human-agent work into handoff-ready context.
+template: redirect.html
 hide:
   - navigation
   - toc

--- a/theme/powercontext/redirect.html
+++ b/theme/powercontext/redirect.html
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (c) 2026 OceanBase.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+{% extends "main.html" %}
+
+{% set destination = "en/" | url %}
+
+{% block htmltitle %}<title>Redirecting to PowerContext</title>{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  <meta http-equiv="refresh" content="0; url={{ destination }}">
+  <script>window.location.replace("{{ destination }}");</script>
+{% endblock %}
+
+{% block container %}
+  <main class="md-content" data-md-component="content">
+    <article class="md-content__inner md-typeset">
+      <p>Redirecting to the <a href="{{ destination }}">PowerContext English site</a>…</p>
+    </article>
+  </main>
+{% endblock %}


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A.

# Rationale for this change

The documentation root currently shows an empty page. It should open the English site by default.

# What changes are included in this PR?

The root page now redirects to `en/`, with fallbacks for browsers that do not run JavaScript.

# Are there any user-facing changes?

Yes. Visiting `https://oceanbase.github.io/powercontext/` now opens `/powercontext/en/`. There are no API or persisted format changes.

# How was this change tested?

- `make docs-test`
- Opened `/powercontext/` locally and confirmed the redirect to `/powercontext/en/`

# AI usage statement

Codex (GPT-5) was used to implement and review this change.