### PR TITLE
build: derive package version from vcs

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -72,10 +72,12 @@ jobs:
           import os
           import re
           import subprocess
-          import tomllib
           from pathlib import Path
 
-          version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          version = subprocess.check_output(
+              ["uvx", "--from", "hatchling", "--with", "hatch-vcs", "hatchling", "version"],
+              text=True,
+          ).strip()
           source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
           label = os.environ.get("ARTIFACT_LABEL") or os.environ.get("SOURCE_REF") or "source"
           slug = re.sub(r"[^A-Za-z0-9._-]+", "-", label).strip("-.").lower() or "source"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,6 +22,14 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v10.0.0
+        with:
+          version: "0.10.12"
+          enable-cache: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -36,11 +44,12 @@ jobs:
           import os
           import re
           import subprocess
-          import tomllib
           from pathlib import Path
 
-          project = tomllib.loads(Path("pyproject.toml").read_text())
-          package_version = project["project"]["version"]
+          package_version = subprocess.check_output(
+              ["uvx", "--from", "hatchling", "--with", "hatch-vcs", "hatchling", "version"],
+              text=True,
+          ).strip()
           source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
 
           safe_version = re.sub(r"[^A-Za-z0-9_.-]+", "-", package_version).strip("-.")
@@ -69,6 +78,7 @@ jobs:
               --file docker/Dockerfile \
               --platform "$platform" \
               --tag "${IMAGE_NAME}:${IMAGE_TAG}" \
+              --build-arg "POWERCONTEXT_VERSION=${{ steps.metadata.outputs.package_version }}" \
               --cache-from "type=gha,scope=docker-${platform_suffix}" \
               --cache-to "type=gha,mode=max,scope=docker-${platform_suffix}" \
               --output "type=docker,dest=${output_file}" \

--- a/.github/workflows/e2e-harness.yml
+++ b/.github/workflows/e2e-harness.yml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   TRUFFLEHOG_IMAGE: ghcr.io/trufflesecurity/trufflehog:3.96.0
+  UV_VERSION: "0.10.12"
 
 concurrency:
   group: e2e-harness-${{ github.event.pull_request.number || github.ref }}-${{ github.sha }}
@@ -24,9 +25,13 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - name: Validate harness and Compose definitions
         run: |
@@ -46,6 +51,13 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - name: Run deterministic scenarios
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,18 +13,20 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
 
-      - name: Set package version from Release tag
+      - name: Verify package version from Release tag
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           python - <<'PY'
           import os
           import re
-          from pathlib import Path
+          import subprocess
 
           release_tag = os.environ["RELEASE_TAG"]
           if release_tag.startswith("powercontext-v"):
@@ -36,18 +38,14 @@ jobs:
                   "Release tag must use vX.Y.Z, powercontext-vX.Y.Z, or X.Y.Z semantic versioning"
               )
 
-          pyproject_path = Path("pyproject.toml")
-          pyproject_text = pyproject_path.read_text()
-          updated, replacements = re.subn(
-              r'^version = ".*"$',
-              f'version = "{release_version}"',
-              pyproject_text,
-              count=1,
-              flags=re.MULTILINE,
-          )
-          if replacements != 1:
-              raise SystemExit("Could not update the project version for the Release package")
-          pyproject_path.write_text(updated)
+          package_version = subprocess.check_output(
+              ["uvx", "--from", "hatchling", "--with", "hatch-vcs", "hatchling", "version"],
+              text=True,
+          ).strip()
+          if package_version != release_version:
+              raise SystemExit(
+                  f"Release tag version {release_version!r} does not match VCS version {package_version!r}"
+              )
           PY
 
       - name: Build release distributions

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ real-e2e-test: ## Run opt-in real Codex Experience/Skill tests; REAL_E2E_MODE de
 
 .PHONY: harness-sync
 harness-sync: ## Install the Bub replay harness environment.
-	@uv sync --project e2e/bub
+	@uv sync --project e2e/bub --locked
 
 .PHONY: harness-check
 harness-check: ## Validate the Bub replay harness and committed scenarios.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ ./src/
 
-ARG POWERCONTEXT_VERSION=0.0.0
+ARG POWERCONTEXT_VERSION
 
 RUN --mount=type=cache,id=powercontext-uv,target=/root/.cache/uv \
     test -n "${POWERCONTEXT_VERSION}" \
@@ -27,7 +27,10 @@ RUN --mount=type=cache,id=powercontext-uv,target=/root/.cache/uv \
     --no-dev \
     --no-editable \
     --extra cli \
-    --extra server
+    --extra server \
+    --refresh-package powercontext \
+    && test "$(.venv/bin/python -c 'from importlib.metadata import version; print(version("powercontext"))')" \
+    = "${POWERCONTEXT_VERSION}"
 
 
 FROM python:3.11-slim-bookworm AS runtime

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ ./src/
 
-ARG POWERCONTEXT_VERSION
+ARG POWERCONTEXT_VERSION=0.0.0
 
 RUN --mount=type=cache,id=powercontext-uv,target=/root/.cache/uv \
     test -n "${POWERCONTEXT_VERSION}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,11 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/ ./src/
 
+ARG POWERCONTEXT_VERSION
+
 RUN --mount=type=cache,id=powercontext-uv,target=/root/.cache/uv \
-    uv sync \
+    test -n "${POWERCONTEXT_VERSION}" \
+    && SETUPTOOLS_SCM_PRETEND_VERSION="${POWERCONTEXT_VERSION}" uv sync \
     --frozen \
     --no-dev \
     --no-editable \

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,12 @@
 Build the image from the repository root:
 
 ```bash
-docker build --file docker/Dockerfile --tag powercontext-server:local .
+POWERCONTEXT_VERSION=$(uvx --from hatchling --with hatch-vcs hatchling version)
+docker build \
+  --file docker/Dockerfile \
+  --build-arg "POWERCONTEXT_VERSION=${POWERCONTEXT_VERSION}" \
+  --tag powercontext-server:local \
+  .
 ```
 
 Run the Server with persistent SQLite and scheduler data:

--- a/e2e/bub/Dockerfile
+++ b/e2e/bub/Dockerfile
@@ -40,7 +40,11 @@ WORKDIR /workspace/powercontext
 
 COPY . .
 
+ARG POWERCONTEXT_VERSION=0.0.0
+
 RUN --mount=type=cache,id=powercontext-bub-e2e-uv,target=/root/.cache/uv \
+    test -n "${POWERCONTEXT_VERSION}" \
+    && SETUPTOOLS_SCM_PRETEND_VERSION="${POWERCONTEXT_VERSION}" \
     uv sync --project e2e/bub --frozen --no-dev --no-editable
 
 COPY --chmod=0755 e2e/bub/container-entrypoint.sh /usr/local/bin/powercontext-e2e-container

--- a/e2e/bub/Dockerfile
+++ b/e2e/bub/Dockerfile
@@ -40,12 +40,14 @@ WORKDIR /workspace/powercontext
 
 COPY . .
 
-ARG POWERCONTEXT_VERSION=0.0.1
+ARG POWERCONTEXT_VERSION
 
 RUN --mount=type=cache,id=powercontext-bub-e2e-uv,target=/root/.cache/uv \
     test -n "${POWERCONTEXT_VERSION}" \
     && SETUPTOOLS_SCM_PRETEND_VERSION="${POWERCONTEXT_VERSION}" \
-    uv sync --project e2e/bub --frozen --no-dev --no-editable
+    uv sync --project e2e/bub --frozen --no-dev --no-editable --refresh-package powercontext \
+    && test "$(e2e/bub/.venv/bin/python -c 'from importlib.metadata import version; print(version("powercontext"))')" \
+    = "${POWERCONTEXT_VERSION}"
 
 COPY --chmod=0755 e2e/bub/container-entrypoint.sh /usr/local/bin/powercontext-e2e-container
 

--- a/e2e/bub/Dockerfile
+++ b/e2e/bub/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /workspace/powercontext
 
 COPY . .
 
-ARG POWERCONTEXT_VERSION=0.0.0
+ARG POWERCONTEXT_VERSION=0.0.1
 
 RUN --mount=type=cache,id=powercontext-bub-e2e-uv,target=/root/.cache/uv \
     test -n "${POWERCONTEXT_VERSION}" \

--- a/e2e/bub/compose.yaml
+++ b/e2e/bub/compose.yaml
@@ -19,6 +19,8 @@ services:
     build:
       context: ../..
       dockerfile: docker/Dockerfile
+      args:
+        POWERCONTEXT_VERSION: ${POWERCONTEXT_VERSION:-}
     environment:
       - ANTHROPIC_API_KEY
       - DEEPSEEK_API_KEY
@@ -54,6 +56,8 @@ services:
     build:
       context: ../..
       dockerfile: e2e/bub/Dockerfile
+      args:
+        POWERCONTEXT_VERSION: ${POWERCONTEXT_VERSION:-}
     depends_on:
       powercontext:
         condition: service_healthy

--- a/e2e/bub/run.sh
+++ b/e2e/bub/run.sh
@@ -60,15 +60,21 @@ else
 fi
 export POWERCONTEXT_E2E_CODEX_AUTH_MOUNT
 
-if [ "$command" = check ]; then
-    test "$#" -eq 0 || { echo "check does not accept workload arguments" >&2; exit 2; }
-    docker compose $compose_files config --quiet
-    exit
-fi
-
 if [ "$command" = down ]; then
     test "$#" -eq 0 || { echo "down does not accept workload arguments" >&2; exit 2; }
     docker compose $compose_files down --volumes --remove-orphans
+    exit
+fi
+
+if [ -z "${POWERCONTEXT_VERSION:-}" ]; then
+    POWERCONTEXT_VERSION=$(uvx --from hatchling --with hatch-vcs hatchling version)
+fi
+test -n "$POWERCONTEXT_VERSION" || { echo "POWERCONTEXT_VERSION must not be empty" >&2; exit 2; }
+export POWERCONTEXT_VERSION
+
+if [ "$command" = check ]; then
+    test "$#" -eq 0 || { echo "check does not accept workload arguments" >&2; exit 2; }
+    docker compose $compose_files config --quiet
     exit
 fi
 

--- a/e2e/bub/src/powercontext_e2e/harbor_agent.py
+++ b/e2e/bub/src/powercontext_e2e/harbor_agent.py
@@ -33,6 +33,7 @@ REMOTE_CODEX_HOME = "/installed-agent/codex"
 REMOTE_SOURCE = "/opt/powercontext/source"
 REMOTE_TOOL_DIR = "/installed-agent/tools"
 BUB_VERSION = version("bub")
+POWERCONTEXT_VERSION = version("powercontext")
 BUB_ACP_SERVER_VERSION = "0.0.2"
 
 
@@ -102,7 +103,8 @@ def _install_bub_command() -> str:
         f"cp {REMOTE_CODEX_AUTH} {REMOTE_CODEX_HOME}/auth.json; "
         f"chmod 600 {REMOTE_CODEX_HOME}/auth.json; "
         "fi; "
-        f"{_tool_environment()} {uv} tool install --force "
+        f"SETUPTOOLS_SCM_PRETEND_VERSION={shlex.quote(POWERCONTEXT_VERSION)} {_tool_environment()} "
+        f"{uv} tool install --force "
         f"--with {REMOTE_SOURCE} --with {REMOTE_SOURCE}/integrations/bub "
         f"{shlex.quote(f'bub=={BUB_VERSION}')}"
     )

--- a/e2e/bub/tests/test_harbor_agent.py
+++ b/e2e/bub/tests/test_harbor_agent.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 OceanBase.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shlex
+from importlib.metadata import version
+
+from powercontext_e2e.harbor_agent import _install_bub_command
+
+
+def test_install_bub_command_provides_powercontext_version() -> None:
+    version_assignment = f"SETUPTOOLS_SCM_PRETEND_VERSION={shlex.quote(version('powercontext'))}"
+
+    assert version_assignment in _install_bub_command().split()

--- a/e2e/bub/uv.lock
+++ b/e2e/bub/uv.lock
@@ -1599,7 +1599,6 @@ wheels = [
 
 [[package]]
 name = "powercontext"
-version = "0.0.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "pydantic" },
@@ -1616,32 +1615,38 @@ client = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'builtin'", specifier = ">=0.22,<1" },
+    { name = "aiosqlite", marker = "extra == 'server'", specifier = ">=0.22,<1" },
     { name = "apscheduler", marker = "extra == 'builtin'", specifier = ">=3.11,<4" },
+    { name = "apscheduler", marker = "extra == 'server'", specifier = ">=3.11,<4" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115,<1" },
     { name = "fastmcp", marker = "extra == 'server'", specifier = ">=3.4,<4" },
+    { name = "httpx", extras = ["socks"], marker = "extra == 'cli'", specifier = ">=0.28,<1" },
     { name = "httpx", extras = ["socks"], marker = "extra == 'client'", specifier = ">=0.28,<1" },
     { name = "jinja2", marker = "extra == 'server'", specifier = ">=3.1,<4" },
+    { name = "opentelemetry-api", marker = "extra == 'cli'", specifier = ">=1.30,<2" },
     { name = "opentelemetry-api", marker = "extra == 'client'", specifier = ">=1.30,<2" },
     { name = "opentelemetry-api", marker = "extra == 'server'", specifier = ">=1.30,<2" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'tracing-otlp'", specifier = ">=1.30,<2" },
     { name = "opentelemetry-sdk", marker = "extra == 'server'", specifier = ">=1.30,<2" },
     { name = "platformdirs", marker = "extra == 'cli'", specifier = ">=4,<5" },
     { name = "platformdirs", marker = "extra == 'server'", specifier = ">=4,<5" },
-    { name = "powercontext", extras = ["builtin"], marker = "extra == 'server'" },
-    { name = "powercontext", extras = ["client"], marker = "extra == 'cli'" },
     { name = "prometheus-client", marker = "extra == 'server'", specifier = ">=0.21,<1" },
     { name = "pydantic", specifier = ">=2.10,<3" },
     { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'builtin'", specifier = ">=2.27.1,<3" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "openai"], marker = "extra == 'server'", specifier = ">=2.27.1,<3" },
     { name = "pydantic-settings", marker = "extra == 'builtin'", specifier = ">=2.7,<3" },
+    { name = "pydantic-settings", marker = "extra == 'cli'", specifier = ">=2.7,<3" },
     { name = "pydantic-settings", marker = "extra == 'client'", specifier = ">=2.7,<3" },
     { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.7,<3" },
     { name = "pyobvector", marker = "extra == 'builtin'", specifier = ">=0.2.28,<0.3" },
+    { name = "pyobvector", marker = "extra == 'server'", specifier = ">=0.2.28,<0.3" },
     { name = "rfc8785", specifier = ">=0.1.4,<1" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'builtin'", specifier = ">=2,<3" },
+    { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'server'", specifier = ">=2,<3" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.16,<1" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.34,<1" },
 ]
-provides-extras = ["builtin", "client", "server", "tracing-otlp", "cli"]
+provides-extras = ["builtin", "cli", "client", "server", "tracing-otlp"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "powercontext"
-version = "0.0.2"
+dynamic = ["version"]
 description = "PowerContext turns human-agent work into handoff-ready context."
 authors = [{ name = "PowerContext Team", email = "open_oceanbase@oceanbase.com" }]
 readme = "README.md"
@@ -100,8 +100,11 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/powercontext"]

--- a/tests/test_system_cli.py
+++ b/tests/test_system_cli.py
@@ -638,6 +638,8 @@ def test_default_doctor_preserves_not_ready_checks_in_human_and_json_output(monk
 
 
 def test_default_doctor_preserves_degraded_checks_in_human_and_json_output(monkeypatch) -> None:
+    monkeypatch.setattr(system_cli, "version", lambda _package: "0.0.2")
+
     def responses() -> list[_Response]:
         return [
             _Response(200, {"status": "ok"}),

--- a/uv.lock
+++ b/uv.lock
@@ -1793,7 +1793,6 @@ wheels = [
 
 [[package]]
 name = "powercontext"
-version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A.

# Rationale for this change

Use Git tags as the package version source.

# What changes are included in this PR?

Adds `hatch-vcs` and uses the resolved version in release, Docker, and artifact builds.

# Are there any user-facing changes?

No API changes.

# How was this change tested?

`uv lock --check`, pre-commit hooks, and the CLI version test.

# AI usage statement

OpenAI Codex (GPT-5) was used.
