### PR TITLE
ci(docs): add manual documentation deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,39 @@
+name: Deploy documentation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy-docs:
+    if: github.ref == 'refs/heads/master'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+
+      - name: Build documentation
+        run: uv run zensical build --clean
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A.

# Rationale for this change

Documentation can only be deployed as part of a release.

# What changes are included in this PR?

Add a manual Pages workflow that only deploys from `master`.

# Are there any user-facing changes?

No product behavior changes. Maintainers can deploy the site without publishing a release.

# How was this change tested?

- `uv run prek run --files .github/workflows/deploy-docs.yml`
- `make docs-test`

# AI usage statement

Codex (GPT-5) was used to implement and review this change.