### PR TITLE
feat: enable Dashboard by default without blocking Server startup

### DIFF
--- a/docs/en/docs/how-to/install-and-run.md
+++ b/docs/en/docs/how-to/install-and-run.md
@@ -37,8 +37,14 @@ With no environment variables, the Server:
 
 - binds to `127.0.0.1:8000`;
 - enables Streamable HTTP MCP at `/mcp`;
+- enables the Dashboard at `/`; when no scopes are configured, the page shows an explicit empty state;
 - creates a persistent SQLite database in the operating system's user data directory;
 - supports explicit Memory operations without an inference provider.
+
+After startup, the terminal prints the Dashboard URL, such as `http://127.0.0.1:8000/`. The Dashboard shares the
+Server listener and port with the HTTP API and MCP. If Dashboard initialization fails, the Server logs a warning with
+the direct cause and continues serving the other interfaces. Set `POWERCONTEXT_SERVER_DASHBOARD_ENABLED=false` to
+disable the Dashboard explicitly.
 
 `Ctrl-C` performs a clean shutdown. Restarting the command reopens the same database.
 

--- a/docs/en/docs/reference/configuration.md
+++ b/docs/en/docs/reference/configuration.md
@@ -35,6 +35,8 @@ Server settings use the `POWERCONTEXT_SERVER_` prefix.
 | `POWERCONTEXT_SERVER_MCP_PATH` | `/mcp` | MCP path |
 | `POWERCONTEXT_SERVER_AUTH_ENABLED` | `false` | Require one static bearer token for HTTP and MCP |
 | `POWERCONTEXT_SERVER_AUTH_TOKEN` | unset | Static bearer token; required when authentication is enabled |
+| `POWERCONTEXT_SERVER_DASHBOARD_ENABLED` | `true` | Enable the Dashboard at the Server root path `/` |
+| `POWERCONTEXT_SERVER_DASHBOARD_SCOPES` | `[]` | JSON array of selectable Dashboard scopes |
 | `POWERCONTEXT_SERVER_LOGGING_LEVEL` | `INFO` | Operational log level |
 | `POWERCONTEXT_SERVER_LOGGING_FORMAT` | `console` | `console` or structured `json` output |
 | `POWERCONTEXT_SERVER_LOGGING_ACCESS` | `true` | Log external HTTP and logical MCP request completion |
@@ -55,6 +57,10 @@ Server settings use the `POWERCONTEXT_SERVER_` prefix.
 Static bearer authentication is disabled by default. When enabled, API and MCP requests must include
 `Authorization: Bearer <token>`; the liveness and readiness endpoints remain public. Plain HTTP should remain on a
 loopback address. Use TLS before exposing an authenticated Server over a network.
+
+The Dashboard is enabled by default and shares the Server listener and port with the HTTP API and MCP. With no scopes
+configured, the page shows an empty state. Dashboard initialization failures are logged with their direct cause and do
+not prevent the Server HTTP API, MCP, or health checks from starting.
 
 Example with a controlled SQLite path and scheduled extraction:
 

--- a/docs/zh/docs/how-to/install-and-run.md
+++ b/docs/zh/docs/how-to/install-and-run.md
@@ -35,8 +35,13 @@ powercontext server run
 
 - 监听 `127.0.0.1:8000`；
 - 在 `/mcp` 启用 Streamable HTTP MCP；
+- 在 `/` 启用 Dashboard；尚未配置 scope 时，页面会显示明确的空状态；
 - 在操作系统的用户数据目录中创建持久化 SQLite 数据库；
 - 无需推理服务即可支持显式 Memory 操作。
+
+启动成功后，终端会输出 Dashboard 地址，例如 `http://127.0.0.1:8000/`。Dashboard 与 HTTP API、MCP 共用 Server
+的监听地址和端口。Dashboard 初始化失败时，Server 会记录包含直接原因的 warning，并继续提供其他接口；可通过
+`POWERCONTEXT_SERVER_DASHBOARD_ENABLED=false` 显式关闭 Dashboard。
 
 按 `Ctrl-C` 可正常关闭。再次运行该命令会打开同一个数据库。
 

--- a/docs/zh/docs/reference/configuration.md
+++ b/docs/zh/docs/reference/configuration.md
@@ -35,6 +35,8 @@ Server 配置使用 `POWERCONTEXT_SERVER_` 前缀。
 | `POWERCONTEXT_SERVER_MCP_PATH` | `/mcp` | MCP 路径 |
 | `POWERCONTEXT_SERVER_AUTH_ENABLED` | `false` | HTTP 和 MCP 是否要求一个静态 Bearer token |
 | `POWERCONTEXT_SERVER_AUTH_TOKEN` | 未设置 | 静态 Bearer token；启用鉴权时必须设置 |
+| `POWERCONTEXT_SERVER_DASHBOARD_ENABLED` | `true` | 在 Server 根路径 `/` 启用 Dashboard |
+| `POWERCONTEXT_SERVER_DASHBOARD_SCOPES` | `[]` | Dashboard 可选择的 scope JSON 数组 |
 | `POWERCONTEXT_SERVER_LOGGING_LEVEL` | `INFO` | operational log 级别 |
 | `POWERCONTEXT_SERVER_LOGGING_FORMAT` | `console` | `console` 或结构化 `json` 输出 |
 | `POWERCONTEXT_SERVER_LOGGING_ACCESS` | `true` | 记录外部 HTTP 和逻辑 MCP request completion |
@@ -54,6 +56,9 @@ Server 配置使用 `POWERCONTEXT_SERVER_` 前缀。
 
 静态 Bearer 鉴权默认关闭。启用后，API 和 MCP 请求必须携带 `Authorization: Bearer <token>`；liveness 和
 readiness endpoint 仍然公开。明文 HTTP 应只用于 loopback 地址；通过网络暴露启用鉴权的 Server 前必须配置 TLS。
+
+Dashboard 默认启用，并与 HTTP API、MCP 共用监听地址和端口。默认未配置 scope，页面会显示空状态；Dashboard
+初始化失败只记录包含直接原因的 warning，不影响 Server 的 HTTP API、MCP 和健康检查启动。
 
 指定 SQLite 路径并启用定时提取的示例：
 

--- a/src/powercontext/server/cli.py
+++ b/src/powercontext/server/cli.py
@@ -56,8 +56,17 @@ def run(
     configure_server_logging(settings.logging)
     tracing = configure_server_tracing(settings.tracing)
     try:
+        application = create_server_app(settings=settings, tracing=tracing)
+        if settings.dashboard.enabled:
+            if application.state.dashboard_started:
+                typer.echo(f"PowerContext Dashboard: http://{settings.http.host}:{settings.http.port}/")
+            else:
+                typer.echo(
+                    f"PowerContext Dashboard failed to start: {application.state.dashboard_startup_error}",
+                    err=True,
+                )
         _run_server(
-            create_server_app(settings=settings, tracing=tracing),
+            application,
             host=settings.http.host,
             port=settings.http.port,
         )

--- a/src/powercontext/server/factory.py
+++ b/src/powercontext/server/factory.py
@@ -138,13 +138,7 @@ def create_server_app(
         tracing=resolved_tracing,
         handoff_report_enabled=resolved.handoff_report.enabled,
     )
-    if resolved.dashboard.enabled or resolved.handoff_report.enabled:
-        mount_web_ui(
-            app,
-            scopes={scope.scope_id: scope.display_name for scope in resolved.dashboard.scopes},
-            dashboard_enabled=resolved.dashboard.enabled,
-            handoff_report_enabled=resolved.handoff_report.enabled,
-        )
+    _mount_optional_web_ui(app, resolved)
     if metrics is not None:
         app.add_api_route(
             "/metrics",
@@ -178,6 +172,33 @@ def create_server_app(
             tracing=resolved_tracing,
         )
     return app
+
+
+def _mount_optional_web_ui(app: FastAPI, settings: ServerSettings) -> None:
+    app.state.dashboard_started = False
+    app.state.dashboard_startup_error = None
+    if not (settings.dashboard.enabled or settings.handoff_report.enabled):
+        return
+    try:
+        mount_web_ui(
+            app,
+            scopes={scope.scope_id: scope.display_name for scope in settings.dashboard.scopes},
+            dashboard_enabled=settings.dashboard.enabled,
+            handoff_report_enabled=settings.handoff_report.enabled,
+            authentication_required=settings.auth.enabled,
+        )
+        if settings.dashboard.enabled:
+            app.state.dashboard_started = True
+    except Exception as error:
+        app.state.dashboard_startup_error = str(error)
+        unit = "Dashboard" if settings.dashboard.enabled else "Handoff Report"
+        log_safely(
+            logger,
+            logging.WARNING,
+            f"PowerContext {unit} failed to start: {error}",
+            exc_info=error,
+            extra={"event": "web_ui.start_failed", "unit": "web_ui"},
+        )
 
 
 class _ServerReadinessProbe:

--- a/src/powercontext/server/settings.py
+++ b/src/powercontext/server/settings.py
@@ -88,15 +88,13 @@ class DashboardScopeConfig(BaseModel):
 
 
 class DashboardConfig(BaseModel):
-    """Optional personal Dashboard served by the local Server."""
+    """Personal Dashboard served by the local Server."""
 
-    enabled: bool = False
+    enabled: bool = True
     scopes: list[DashboardScopeConfig] = Field(default_factory=list, max_length=100)
 
     @model_validator(mode="after")
     def validate_scopes(self) -> DashboardConfig:
-        if self.enabled and not self.scopes:
-            raise ValueError("Enabled Dashboard requires at least one scope")  # noqa: TRY003
         scope_ids = [scope.scope_id for scope in self.scopes]
         if len(scope_ids) != len(set(scope_ids)):
             raise ValueError("Dashboard scope IDs must be unique")  # noqa: TRY003
@@ -160,12 +158,6 @@ class ServerSettings(BaseSettings):
         if not isinstance(value, Mapping) or value.get("kind", "sqlite") != "sqlite":
             return value
         return {"kind": "sqlite", "url": _default_database().url, **value}
-
-    @model_validator(mode="after")
-    def require_authentication_for_dashboard(self) -> ServerSettings:
-        if self.dashboard.enabled and not self.auth.enabled:
-            raise ValueError("Dashboard requires Server bearer authentication")  # noqa: TRY003
-        return self
 
 
 __all__ = [

--- a/src/powercontext/server/static/auth.js
+++ b/src/powercontext/server/static/auth.js
@@ -48,6 +48,8 @@ export function clearServerToken() {
 
 export function fetchWithBearer(resource, token, options = {}) {
   const headers = new Headers(options.headers);
-  headers.set("Authorization", `Bearer ${token}`);
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
   return fetch(resource, {...options, headers, cache: options.cache || "no-store"});
 }

--- a/src/powercontext/server/static/dashboard.js
+++ b/src/powercontext/server/static/dashboard.js
@@ -21,7 +21,7 @@ import {
   fetchWithBearer,
   readServerToken,
   storeServerToken
-} from "./auth.js?v=session-shell";
+} from "./auth.js?v=optional-auth";
 import {createPageUi, createRequestGate} from "./page-ui.js?v=locale-complete";
 
 const translations = {
@@ -154,6 +154,7 @@ const pageStatusRetry = document.getElementById("page-status-retry");
 const dashboard = document.getElementById("dashboard");
 const signOut = document.getElementById("sign-out");
 const scopeSelect = document.getElementById("scope-select");
+const authenticationRequired = document.documentElement.dataset.serverAuthRequired === "true";
 const svgNamespace = "http://www.w3.org/2000/svg";
 let currentView = null;
 let currentScopes = [];
@@ -191,12 +192,14 @@ signOut.addEventListener("click", () => {
 });
 
 async function authenticate(token, scopeId = "") {
-  if (!token) {
+  if (authenticationRequired && !token) {
     showLogin();
     return;
   }
 
-  storeServerToken(token);
+  if (authenticationRequired) {
+    storeServerToken(token);
+  }
   tokenInput.value = "";
   currentAuthError = null;
   const request = dashboardRequests.start();
@@ -240,7 +243,7 @@ async function authenticate(token, scopeId = "") {
 }
 
 async function loadStatistics(token, scopeId, request = null) {
-  if (!token) {
+  if (authenticationRequired && !token) {
     showLogin();
     return;
   }
@@ -309,7 +312,7 @@ function showPageStatus(messageKey, values = {}, retryable = false) {
   authShell.hidden = true;
   pageStatus.hidden = false;
   dashboard.hidden = true;
-  signOut.hidden = false;
+  signOut.hidden = !authenticationRequired;
 }
 
 function renderPageStatus() {
@@ -340,7 +343,7 @@ function renderDashboard(view) {
   authShell.hidden = true;
   pageStatus.hidden = true;
   dashboard.hidden = false;
-  signOut.hidden = false;
+  signOut.hidden = !authenticationRequired;
 
   renderScopes(view.scopes, statistics.scope_id);
   setText("dashboard-name", view.selectedScope.display_name);

--- a/src/powercontext/server/static/handoff-report.js
+++ b/src/powercontext/server/static/handoff-report.js
@@ -21,7 +21,7 @@ import {
   fetchWithBearer,
   readServerToken,
   storeServerToken
-} from "./auth.js?v=session-shell";
+} from "./auth.js?v=optional-auth";
 import {formatDateRange, resolvePeriodSelection, validateDateRange} from "./handoff-period.js";
 import {createPageUi, createRequestGate} from "./page-ui.js?v=locale-complete";
 
@@ -31,6 +31,7 @@ const autoRefreshIntervalMilliseconds = 5_000;
 const continuityTimelineRecentLimit = 6;
 const workstreamSearchThreshold = 8;
 const projectOptionRenderLimit = 50;
+const authenticationRequired = document.documentElement.dataset.serverAuthRequired === "true";
 const translations = {
   en: {
     pageTitle: "PowerContext Handoff Report",
@@ -633,11 +634,13 @@ document.addEventListener("visibilitychange", () => {
 });
 
 async function authenticate(token) {
-  if (!token) {
+  if (authenticationRequired && !token) {
     showLogin();
     return;
   }
-  storeServerToken(token);
+  if (authenticationRequired) {
+    storeServerToken(token);
+  }
   tokenInput.value = "";
   currentAuthError = null;
   const request = beginReportRequest();
@@ -720,7 +723,7 @@ async function loadReport(token, projectId, {background = false, selectedScopeId
   if (reportLoading) {
     return false;
   }
-  if (!token) {
+  if (authenticationRequired && !token) {
     showLogin();
     return false;
   }
@@ -878,7 +881,7 @@ function showReportFailure(key, values = {}) {
   currentPageStatus = null;
   pageStatus.hidden = true;
   reportShell.hidden = false;
-  signOut.hidden = false;
+  signOut.hidden = !authenticationRequired;
   showReportError(key, values);
 }
 
@@ -919,7 +922,7 @@ function showPageStatus(messageKey, values = {}, retryable = false) {
   authShell.hidden = true;
   pageStatus.hidden = false;
   reportShell.hidden = true;
-  signOut.hidden = false;
+  signOut.hidden = !authenticationRequired;
 }
 
 function renderPageStatus() {
@@ -1094,7 +1097,7 @@ function renderReport(report) {
   authShell.hidden = true;
   pageStatus.hidden = true;
   reportShell.hidden = false;
-  signOut.hidden = false;
+  signOut.hidden = !authenticationRequired;
   clearReportError();
   setText("project-name", report.project.title);
   setText("report-updated", translate("updated", {value: formatDateTime(report.generated_at)}));

--- a/src/powercontext/server/templates/base.html
+++ b/src/powercontext/server/templates/base.html
@@ -15,7 +15,7 @@
 -->
 
 <!doctype html>
-<html lang="en" data-server-session="missing">
+<html lang="en" data-server-session="{{ 'missing' if authentication_required else 'active' }}" data-server-auth-required="{{ 'true' if authentication_required else 'false' }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -23,7 +23,8 @@
   <link rel="icon" href="{{ url_for('web_static', path='/oceanbase-logo.svg') }}" type="image/svg+xml">
   <script>
     try {
-      document.documentElement.dataset.serverSession = sessionStorage.getItem("powercontext.server.token")
+      const authenticationRequired = document.documentElement.dataset.serverAuthRequired === "true";
+      document.documentElement.dataset.serverSession = !authenticationRequired || sessionStorage.getItem("powercontext.server.token")
         ? "active"
         : "missing";
     } catch (error) {

--- a/src/powercontext/server/templates/pages/dashboard.html
+++ b/src/powercontext/server/templates/pages/dashboard.html
@@ -94,5 +94,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script type="module" src="{{ url_for('web_static', path='/dashboard.js') }}?v=locale-complete-v1"></script>
+<script type="module" src="{{ url_for('web_static', path='/dashboard.js') }}?v=default-startup-locale-v1"></script>
 {% endblock %}

--- a/src/powercontext/server/templates/pages/handoff_report.html
+++ b/src/powercontext/server/templates/pages/handoff_report.html
@@ -287,5 +287,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script type="module" src="{{ url_for('web_static', path='/handoff-report.js') }}?v=unified-editor-v1"></script>
+<script type="module" src="{{ url_for('web_static', path='/handoff-report.js') }}?v=default-startup-unified-editor-v1"></script>
 {% endblock %}

--- a/src/powercontext/server/web.py
+++ b/src/powercontext/server/web.py
@@ -50,17 +50,22 @@ def mount_web_ui(
     scopes: Mapping[str, str],
     dashboard_enabled: bool = False,
     handoff_report_enabled: bool = False,
+    authentication_required: bool = False,
 ) -> None:
     """Mount Server-owned pages, static assets, and UI support endpoints."""
 
     dashboard_scopes = tuple(DashboardScope(scope_id=scope_id, display_name=name) for scope_id, name in scopes.items())
-    if dashboard_enabled and not dashboard_scopes:
-        raise ValueError("Dashboard requires at least one scope")  # noqa: TRY003
+    templates = _templates()
+    if dashboard_enabled:
+        templates.env.get_template("pages/dashboard.html")
+    if handoff_report_enabled:
+        templates.env.get_template("pages/handoff_report.html")
+    static_files = StaticFiles(packages=[("powercontext.server", "static")])
 
     router = APIRouter(include_in_schema=False)
 
     async def dashboard_page(request: Request) -> Response:
-        return _templates().TemplateResponse(
+        return templates.TemplateResponse(
             request=request,
             name="pages/dashboard.html",
             context={
@@ -68,12 +73,13 @@ def mount_web_ui(
                 "dashboard_enabled": True,
                 "handoff_report_enabled": handoff_report_enabled,
                 "home_route": "dashboard_home",
+                "authentication_required": authentication_required,
             },
             headers=_PAGE_HEADERS,
         )
 
     async def handoff_report_page(request: Request) -> Response:
-        return _templates().TemplateResponse(
+        return templates.TemplateResponse(
             request=request,
             name="pages/handoff_report.html",
             context={
@@ -81,6 +87,7 @@ def mount_web_ui(
                 "dashboard_enabled": dashboard_enabled,
                 "handoff_report_enabled": True,
                 "home_route": "dashboard_home" if dashboard_enabled else "handoff_report_dashboard",
+                "authentication_required": authentication_required,
             },
             headers=_PAGE_HEADERS,
         )
@@ -113,12 +120,12 @@ def mount_web_ui(
             name="handoff_report_dashboard",
         )
 
-    app.include_router(router)
     app.mount(
         "/static",
-        StaticFiles(packages=[("powercontext.server", "static")]),
+        static_files,
         name="web_static",
     )
+    app.include_router(router)
 
 
 @cache

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,6 +231,8 @@ def test_server_command_does_not_load_client_settings(monkeypatch: pytest.Monkey
     run_server = Mock()
     tracing = Mock()
     monkeypatch.setenv("POWERCONTEXT_CLIENT_SERVER_URL", "not-a-url")
+    monkeypatch.setenv("POWERCONTEXT_SERVER_AUTH_ENABLED", "false")
+    monkeypatch.setenv("POWERCONTEXT_SERVER_DASHBOARD_ENABLED", "true")
     monkeypatch.setattr("powercontext.server.cli._run_server", run_server)
     monkeypatch.setattr("powercontext.server.cli.configure_server_logging", lambda _config: None)
     monkeypatch.setattr("powercontext.server.cli.configure_server_tracing", lambda _config: tracing)
@@ -238,6 +240,7 @@ def test_server_command_does_not_load_client_settings(monkeypatch: pytest.Monkey
     result = CliRunner().invoke(create_cli([server_app]), ["server", "run"])
 
     assert result.exit_code == 0
+    assert "PowerContext Dashboard: http://127.0.0.1:8000/" in result.stdout
 
 
 def test_cli_reports_server_errors_with_request_context_without_a_traceback(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -14,11 +14,11 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
-import pytest
 from fastapi.testclient import TestClient
-from pydantic import SecretStr, ValidationError
+from pydantic import SecretStr
 
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.builtin.runtime.config import HandoffReportConfig
@@ -34,14 +34,70 @@ from powercontext.server.settings import (
 _AUTH_HEADERS = {"Authorization": "Bearer dashboard-secret"}
 
 
-def test_dashboard_cannot_run_without_server_authentication() -> None:
-    dashboard = DashboardConfig(
-        enabled=True,
-        scopes=[DashboardScopeConfig(scope_id="person:psiace", display_name="PsiACE")],
+def test_dashboard_is_enabled_by_default_without_authentication_or_scopes(tmp_path, monkeypatch) -> None:
+    for name in (
+        "POWERCONTEXT_SERVER_AUTH_ENABLED",
+        "POWERCONTEXT_SERVER_AUTH_TOKEN",
+        "POWERCONTEXT_SERVER_DASHBOARD_ENABLED",
+        "POWERCONTEXT_SERVER_DASHBOARD_SCOPES",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    settings = ServerSettings(
+        database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'dashboard-default.db'}"),
+        mcp=McpConfig(enabled=False),
+    )
+    app = create_server_app(settings=settings)
+
+    with TestClient(app) as client:
+        home = client.get("/")
+        scopes = client.get("/dashboard/scopes")
+
+    assert settings.dashboard.enabled is True
+    assert settings.dashboard.scopes == []
+    assert home.status_code == 200
+    assert 'data-server-session="active"' in home.text
+    assert 'data-server-auth-required="false"' in home.text
+    assert scopes.status_code == 200
+    assert scopes.json() == []
+
+
+def test_dashboard_can_be_disabled_explicitly(tmp_path) -> None:
+    app = create_server_app(
+        settings=ServerSettings(
+            dashboard=DashboardConfig(enabled=False),
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'dashboard-disabled.db'}"),
+            mcp=McpConfig(enabled=False),
+        )
     )
 
-    with pytest.raises(ValidationError, match="Dashboard requires Server bearer authentication"):
-        ServerSettings(dashboard=dashboard)
+    with TestClient(app) as client:
+        home = client.get("/")
+        health = client.get("/health/live")
+
+    assert home.status_code == 404
+    assert health.status_code == 200
+
+
+def test_dashboard_mount_failure_does_not_prevent_server_startup(tmp_path, monkeypatch, caplog) -> None:
+    def fail_to_mount(*_args, **_kwargs) -> None:
+        raise RuntimeError("static assets are unavailable")  # noqa: TRY003 - verifies direct failure reporting
+
+    monkeypatch.setattr("powercontext.server.factory.mount_web_ui", fail_to_mount)
+    caplog.set_level(logging.WARNING, logger="powercontext.server.factory")
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'dashboard-fallback.db'}"),
+            mcp=McpConfig(enabled=False),
+        )
+    )
+
+    with TestClient(app) as client:
+        health = client.get("/health/live")
+        dashboard = client.get("/")
+
+    assert health.status_code == 200
+    assert dashboard.status_code == 404
+    assert "PowerContext Dashboard failed to start: static assets are unavailable" in caplog.text
 
 
 def test_dashboard_is_the_authenticated_server_ui_entry(tmp_path) -> None:
@@ -79,11 +135,12 @@ def test_dashboard_is_the_authenticated_server_ui_entry(tmp_path) -> None:
     assert 'id="page-status" hidden' in home.text
     assert 'class="server-content" id="dashboard"' in home.text
     assert 'id="dashboard" hidden' not in home.text
+    assert 'data-server-auth-required="true"' in home.text
     assert 'data-i18n-aria-label="brandHomeLabel"' in home.text
     assert 'data-i18n-aria-label="primaryNavigation"' in home.text
     assert 'data-i18n-aria-label="scopeOverview"' in home.text
     assert 'data-i18n-aria-label="activityAria"' in home.text
-    assert "dashboard.js?v=locale-complete-v1" in home.text
+    assert "dashboard.js?v=default-startup-locale-v1" in home.text
     assert scopes.json() == [
         {"scope_id": "person:psiace", "display_name": "PsiACE"},
         {"scope_id": "project:powercontext", "display_name": "PowerContext"},
@@ -178,13 +235,14 @@ def test_handoff_report_page_is_available_without_the_statistics_dashboard(tmp_p
     assert enabled_page.text.index('class="data-section activity-section"') < enabled_page.text.index(
         '<details class="report-metadata">'
     )
-    assert "handoff-report.js?v=unified-editor-v1" in enabled_page.text
+    assert "handoff-report.js?v=default-startup-unified-editor-v1" in enabled_page.text
     assert protected_projects.status_code == 401
 
 
 def _handoff_report_settings(database_path: Path, *, enabled: bool) -> ServerSettings:
     return ServerSettings(
         auth=BearerAuthConfig(enabled=True, token=SecretStr("dashboard-secret")),
+        dashboard=DashboardConfig(enabled=False),
         database=SQLiteConfig(url=f"sqlite+aiosqlite:///{database_path}"),
         mcp=McpConfig(enabled=False),
         handoff_report=HandoffReportConfig(enabled=enabled),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -83,6 +83,8 @@ class _SequencedEmbeddingModel:
 
 
 def test_settings_load_server_environment(monkeypatch) -> None:
+    monkeypatch.delenv("POWERCONTEXT_SERVER_DASHBOARD_ENABLED", raising=False)
+    monkeypatch.delenv("POWERCONTEXT_SERVER_DASHBOARD_SCOPES", raising=False)
     monkeypatch.setenv("POWERCONTEXT_SERVER_HTTP_HOST", "127.0.0.2")
     monkeypatch.setenv("POWERCONTEXT_SERVER_HTTP_PORT", "9000")
     monkeypatch.setenv(
@@ -122,6 +124,8 @@ def test_settings_load_server_environment(monkeypatch) -> None:
     assert settings.inference.generation_max_requests == 4
     assert settings.mcp.enabled is False
     assert settings.mcp.path == "/context"
+    assert settings.dashboard.enabled is True
+    assert settings.dashboard.scopes == []
     assert settings.external_skills.host_id == "workstation-1"
     assert settings.external_skills.codex_roots[0].root_id == "repository"
     assert settings.external_skills.codex_roots[0].path.as_posix() == "/srv/project/.agents/skills"


### PR DESCRIPTION
Closes #1290

# Rationale for this change

PowerContext Server did not enable Dashboard by default, and Dashboard initialization could make startup failures affect core Server availability. Users also lacked a clear startup URL.

# What changes are included in this PR?

- Enable Dashboard by default when Server starts.
- Print the Dashboard URL (/) on startup.
- Allow Dashboard to run without configured scopes and without bearer auth when Server auth is disabled.
- Make Dashboard initialization fail open: print/log the direct reason and continue HTTP API, MCP, and health endpoints.
- Add an explicit environment switch: `POWERCONTEXT_SERVER_DASHBOARD_ENABLED=false`.
- Update English and Chinese documentation and regression tests.
- Dashboard, HTTP API, and MCP share the same listener and port; automatic port fallback is out of scope.

# Are there any user-facing changes?

Yes. Dashboard is available by default at `http://127.0.0.1:8000/` (assuming the default host and port), and startup prints the URL. Dashboard can be disabled with the environment variable above. A Dashboard startup failure no longer prevents the core Server from starting. No breaking API changes.

# How was this change tested?

- `env POWERCONTEXT_SERVER_AUTH_ENABLED=false POWERCONTEXT_SERVER_DASHBOARD_ENABLED=true .venv/bin/pytest tests/test_dashboard.py tests/test_server.py tests/test_cli.py -q` (50 passed)
- `.venv/bin/ty check src/powercontext/server src/powercontext/cli` passed
- `.venv/bin/zensical build -s` passed
- Ruff lint and format checks passed.
- JavaScript syntax checks passed.
- `git diff --check` passed.

# AI usage statement

Built with OpenAI Codex (GPT-5-based coding agent), used for implementation, tests, and documentation updates.