### PR TITLE
fix(persistence): report concurrent artifact create as revision conflict

### DIFF
--- a/src/powercontext/builtin/persistence/artifacts.py
+++ b/src/powercontext/builtin/persistence/artifacts.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from pydantic import BaseModel
 from sqlalchemy import insert, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from powercontext.artifacts import (
@@ -75,30 +76,34 @@ class ArtifactRepository:
         artifact_type = self._artifact_type(draft.family)
         self._require_content(draft.family, draft.content)
         ref = ArtifactRef(family=draft.family, artifact_id=artifact_id, revision=1)
-        existing = await self._find_head(connection, scope_id, ref.family, ref.artifact_id)
-        if existing is not None:
-            current = await self.get(
+        conflict = await self._head_conflict(connection, scope_id, ref, draft)
+        if conflict is not None:
+            raise conflict
+        try:
+            artifact = await self._insert_revision(
                 connection,
                 scope_id,
-                ArtifactRef(family=ref.family, artifact_id=ref.artifact_id, revision=int(existing)),
+                artifact_type,
+                ref,
+                draft.content,
+                ArtifactLineage(sources=draft.sources, artifacts=draft.artifacts),
             )
-            raise RevisionConflictError(draft, current)
-        artifact = await self._insert_revision(
-            connection,
-            scope_id,
-            artifact_type,
-            ref,
-            draft.content,
-            ArtifactLineage(sources=draft.sources, artifacts=draft.artifacts),
-        )
-        await connection.execute(
-            insert(ARTIFACT_HEADS_TABLE).values(
-                scope_id=scope_id,
-                family=ref.family,
-                artifact_id=ref.artifact_id,
-                revision=ref.revision,
+            await connection.execute(
+                insert(ARTIFACT_HEADS_TABLE).values(
+                    scope_id=scope_id,
+                    family=ref.family,
+                    artifact_id=ref.artifact_id,
+                    revision=ref.revision,
+                )
             )
-        )
+        except IntegrityError:
+            # Another writer may have committed this lifecycle after the head
+            # read above. Only a committed head proves the draft is stale; any
+            # other constraint violation stays an integrity failure.
+            conflict = await self._head_conflict(connection, scope_id, ref, draft)
+            if conflict is None:
+                raise
+            raise conflict from None
         return artifact
 
     async def revise(
@@ -376,6 +381,25 @@ class ArtifactRepository:
                 for row in artifacts
             ),
         )
+
+    async def _head_conflict(
+        self,
+        connection: AsyncConnection,
+        scope_id: str,
+        ref: ArtifactRef,
+        draft: ArtifactDraft[Any],
+    ) -> RevisionConflictError | None:
+        """Return the conflict raised by an already committed lifecycle."""
+
+        head = await self._find_head(connection, scope_id, ref.family, ref.artifact_id)
+        if head is None:
+            return None
+        current = await self.get(
+            connection,
+            scope_id,
+            ArtifactRef(family=ref.family, artifact_id=ref.artifact_id, revision=head),
+        )
+        return RevisionConflictError(draft, current)
 
     async def _find_head(
         self,

--- a/tests/builtin/persistence/test_artifacts.py
+++ b/tests/builtin/persistence/test_artifacts.py
@@ -19,8 +19,10 @@ import asyncio
 import pytest
 from sqlalchemy import insert
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncConnection
 
 from powercontext.artifacts import ArtifactRef
+from powercontext.builtin.persistence.artifacts import ArtifactRepository
 from powercontext.builtin.persistence.tables import (
     ARTIFACT_HEADS_TABLE,
 )
@@ -124,6 +126,46 @@ def test_stale_artifact_revision_fails_optimistic_head_cas() -> None:
 
             assert error.value.artifact == original
             assert error.value.current == current
+
+    asyncio.run(scenario())
+
+
+def test_lifecycle_committed_after_the_head_read_conflicts(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def scenario() -> None:
+        async with (
+            repository_profile() as (profile, repositories),
+            profile.database.transaction() as connection,
+        ):
+            winner = await repositories.artifacts.create(
+                connection,
+                "scope-a",
+                "handoff-1",
+                HandoffDraft(content=HandoffContent(summary="winner")),
+            )
+            committed_head = ArtifactRepository._find_head
+            reads = 0
+
+            async def stale_first_read(
+                repository: ArtifactRepository,
+                connection: AsyncConnection,
+                scope_id: str,
+                family: str,
+                artifact_id: str,
+            ) -> int | None:
+                nonlocal reads
+                reads += 1
+                # The first read models the window before the winner committed.
+                if reads == 1:
+                    return None
+                return await committed_head(repository, connection, scope_id, family, artifact_id)
+
+            monkeypatch.setattr(ArtifactRepository, "_find_head", stale_first_read)
+            draft = HandoffDraft(content=HandoffContent(summary="loser"))
+            with pytest.raises(RevisionConflictError) as error:
+                await repositories.artifacts.create(connection, "scope-a", "handoff-1", draft)
+
+            assert error.value.artifact == draft
+            assert error.value.current == winner
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Closes #1294.

# Rationale for this change

`revise` is not the culprit. Its compare-and-swap detects conflicts through
`UPDATE ... WHERE revision = N` and a rowcount — a write, which cannot be raced.

`create` decides "this lifecycle already exists" from a `SELECT`, and a read cannot
exclude a writer that commits before the insert. Both instances see no head, both
insert revision 1, and the loser's `IntegrityError` matches no domain error, falling
through to the HTTP 500 default.

Only Memory reaches this, because its Artifact id is a per-scope constant. Candidate
and approved Artifact ids are uuid4 and never collide.

# What changes are included in this PR?

`ArtifactRepository.create` now takes the unique-constraint violation as the
authoritative conflict signal. The inserts are wrapped in `try/except IntegrityError`;
a committed head turns the failure into `RevisionConflictError`. With no committed
head the error is re-raised, so foreign key violations and other genuine integrity
failures are unchanged.

# Are there any user-facing changes?

The losing concurrent create returns `409 revision_conflict` instead of
`500 internal_error`. No API, schema, or persisted format changes.

# How was this change tested?

- Added `test_lifecycle_committed_after_the_head_read_conflicts`, covering the window
  where a lifecycle is committed between the head read and the insert.
- The reproduction script from #1294, five runs each way. Before:
  `{'ok': 8, 'HTTP 409 revision_conflict': 7, 'HTTP 500 internal_error': 1}`, exit 1.
  After: `{'ok': 8, 'HTTP 409 revision_conflict': 8}`, exit 0.
- `pytest --doctest-modules --ignore=tests/e2e`: 563 passed, 1 skipped. `ty check` and
  ruff clean. E2E not run.