### PR TITLE
docs: announce Pi Coding Agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ collaboration. It turns shared work into project context that can be understood,
 You need macOS or Linux, Python 3.11 or newer, [`uv`](https://docs.astral.sh/uv/), and at least one supported agent
 host.
 
-### 1. Install PowerContext and the plugins
+### 1. Install PowerContext and integrations
 
 ```bash
 uv tool install "powercontext[cli,server]==0.0.2"
@@ -29,23 +29,8 @@ powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
 ```
 
 The first command installs the CLI and local Server in an isolated environment. The subsequent setup commands
-install the corresponding plugins from the matching repository tag. Run setup again to refresh an existing
-installation. Hermes integration requires Hermes Agent v0.20.4 or newer; see the
-[Hermes integration guide](integrations/hermes/README.md) for configuration and project-local installation.
-
-### Pi Coding Agent
-
-With Pi installed, use a PowerContext ref that includes the native Pi package. The following commands use the current
-`master` branch:
-
-```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
-powercontext setup pi --source oceanbase/powercontext --ref master
-powercontext doctor pi
-```
-
-For a tagged release that includes Pi, replace `master` with the same tag in the first two commands. See
-[Configure Pi](docs/en/docs/how-to/configure-pi.md) for requirements, configuration, and the project-context workflow.
+install the corresponding integrations from the matching repository tag. Run setup again to refresh an existing
+installation.
 
 ### 2. Start and verify the local Server
 
@@ -91,10 +76,10 @@ model.
 
 ---
 
-## Plugins
+## Integrations
 
 PowerContext provides official integrations and installation guides for Codex, Claude Code, DeepSeek Harness, Hermes
-Agent, and Pi Coding Agent. All five integrations use the same scoped data and history-preserving contracts through
+Agent, and Pi Coding Agent. These integrations use the same scoped data and history-preserving contracts through
 PowerContext Server; the host integrations do not start or embed the Server.
 
 ### Official integrations
@@ -108,9 +93,6 @@ PowerContext Server; the host integrations do not start or embed the Server.
 <td align="center" width="120"><a href="docs/en/docs/how-to/configure-pi.md"><img src="https://github.com/earendil-works.png?size=120" alt="Pi Coding Agent" width="48" height="48" /><br /><sub><b>Pi Coding Agent</b></sub></a></td>
 </tr>
 </table>
-
-Pi Coding Agent is provided as a native package rather than a host plugin. See
-[Configure Pi](docs/en/docs/how-to/configure-pi.md) for its project-context workflow.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ install the corresponding plugins from the matching repository tag. Run setup ag
 installation. Hermes integration requires Hermes Agent v0.20.4 or newer; see the
 [Hermes integration guide](integrations/hermes/README.md) for configuration and project-local installation.
 
+### Pi Coding Agent
+
+With Pi installed, use a PowerContext ref that includes the native Pi package. The following commands use the current
+`master` branch:
+
+```bash
+uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+powercontext setup pi --source oceanbase/powercontext --ref master
+powercontext doctor pi
+```
+
+For a tagged release that includes Pi, replace `master` with the same tag in the first two commands. See
+[Configure Pi](docs/en/docs/how-to/configure-pi.md) for requirements, configuration, and the project-context workflow.
+
 ### 2. Start and verify the local Server
 
 Keep the Server running in one terminal:
@@ -79,9 +93,9 @@ model.
 
 ## Plugins
 
-PowerContext provides official plugins and installation guides for Codex, Claude Code, DeepSeek Harness, Hermes
-Agent, and Pi. All five integrations use the same scoped data and history-preserving contracts through PowerContext
-Server; the host integrations do not start or embed the Server.
+PowerContext provides official integrations and installation guides for Codex, Claude Code, DeepSeek Harness, Hermes
+Agent, and Pi Coding Agent. All five integrations use the same scoped data and history-preserving contracts through
+PowerContext Server; the host integrations do not start or embed the Server.
 
 ### Official integrations
 
@@ -91,11 +105,13 @@ Server; the host integrations do not start or embed the Server.
 <td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
 <td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
 <td align="center" width="120"><a href="integrations/hermes/README.md"><img src="https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/logo.png?raw=true&size=120" alt="Hermes Agent" width="48" height="48" /><br /><sub><b>Hermes Agent</b></sub></a></td>
+<td align="center" width="120"><a href="docs/en/docs/how-to/configure-pi.md"><img src="https://github.com/earendil-works.png?size=120" alt="Pi Coding Agent" width="48" height="48" /><br /><sub><b>Pi Coding Agent</b></sub></a></td>
 </tr>
 </table>
 
-Pi is provided as a native package; see [Configure Pi](docs/en/docs/how-to/configure-pi.md) for its project-context
-workflow.
+Pi Coding Agent is provided as a native package rather than a host plugin. See
+[Configure Pi](docs/en/docs/how-to/configure-pi.md) for its project-context workflow.
+
 ## Development
 
 Install the locked development environment and hooks:

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,6 +30,19 @@ powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
 Plugin。如需刷新现有安装，请再次运行 setup。Hermes 集成需要 Hermes Agent v0.20.4 或更高版本；配置和项目本地
 安装方式详见 [Hermes 集成指南](integrations/hermes/README.md)。
 
+### Pi Coding Agent
+
+安装 Pi 后，请使用包含原生 Pi package 的 PowerContext 版本。以下命令以当前 `master` 分支为例：
+
+```bash
+uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+powercontext setup pi --source oceanbase/powercontext --ref master
+powercontext doctor pi
+```
+
+如使用包含 Pi 的正式 tag，请在前两条命令中将 `master` 替换为同一 tag。有关依赖、配置和项目上下文工作流，请参阅
+[配置 Pi](docs/zh/docs/how-to/configure-pi.md)。
+
 ### 2. 启动并验证本地 Server
 
 在一个终端中保持 Server 运行：
@@ -75,8 +88,8 @@ SQLite 数据库。显式 Memory 操作无需配置 inference provider 即可使
 
 ## 插件
 
-PowerContext 为 Codex、Claude Code、DeepSeek Harness 和 Hermes Agent 提供官方插件与安装指南。四个集成都通过
-PowerContext Server 使用同一套作用域数据和保留历史的契约；插件不会自行启动或内嵌 Server。
+PowerContext 为 Codex、Claude Code、DeepSeek Harness、Hermes Agent 和 Pi Coding Agent 提供官方集成与安装指南。
+五种集成都通过 PowerContext Server 使用同一套作用域数据和保留历史的契约；Host 集成不会自行启动或内嵌 Server。
 
 ### 官方集成
 
@@ -86,8 +99,11 @@ PowerContext Server 使用同一套作用域数据和保留历史的契约；插
 <td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
 <td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
 <td align="center" width="120"><a href="integrations/hermes/README.md"><img src="https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/logo.png?raw=true&size=120" alt="Hermes Agent" width="48" height="48" /><br /><sub><b>Hermes Agent</b></sub></a></td>
+<td align="center" width="120"><a href="docs/zh/docs/how-to/configure-pi.md"><img src="https://github.com/earendil-works.png?size=120" alt="Pi Coding Agent" width="48" height="48" /><br /><sub><b>Pi Coding Agent</b></sub></a></td>
 </tr>
 </table>
+
+Pi Coding Agent 通过原生 package 而非 Host plugin 接入；详见[配置 Pi](docs/zh/docs/how-to/configure-pi.md)。
 
 ## 开发
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -14,7 +14,7 @@ PowerContext 是 [PowerMem](https://www.powermem.ai/) 的升级版本，也是�
 
 你需要 macOS 或 Linux、Python 3.11 或更高版本、[`uv`](https://docs.astral.sh/uv/)，以及至少一个支持的 Agent Host。
 
-### 1. 安装 PowerContext 和 Plugin
+### 1. 安装 PowerContext 和集成
 
 ```bash
 uv tool install "powercontext[cli,server]==0.0.2"
@@ -27,21 +27,7 @@ powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
 ```
 
 第一条命令会在隔离环境中安装 CLI 和本地 Server。后续 setup 命令会从匹配的仓库 tag 安装对应的
-Plugin。如需刷新现有安装，请再次运行 setup。Hermes 集成需要 Hermes Agent v0.20.4 或更高版本；配置和项目本地
-安装方式详见 [Hermes 集成指南](integrations/hermes/README.md)。
-
-### Pi Coding Agent
-
-安装 Pi 后，请使用包含原生 Pi package 的 PowerContext 版本。以下命令以当前 `master` 分支为例：
-
-```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
-powercontext setup pi --source oceanbase/powercontext --ref master
-powercontext doctor pi
-```
-
-如使用包含 Pi 的正式 tag，请在前两条命令中将 `master` 替换为同一 tag。有关依赖、配置和项目上下文工作流，请参阅
-[配置 Pi](docs/zh/docs/how-to/configure-pi.md)。
+集成。如需刷新现有安装，请再次运行 setup。
 
 ### 2. 启动并验证本地 Server
 
@@ -86,10 +72,10 @@ SQLite 数据库。显式 Memory 操作无需配置 inference provider 即可使
 
 ---
 
-## 插件
+## 集成
 
 PowerContext 为 Codex、Claude Code、DeepSeek Harness、Hermes Agent 和 Pi Coding Agent 提供官方集成与安装指南。
-五种集成都通过 PowerContext Server 使用同一套作用域数据和保留历史的契约；Host 集成不会自行启动或内嵌 Server。
+这些集成都通过 PowerContext Server 使用同一套作用域数据和保留历史的契约；宿主集成不会自行启动或内嵌 Server。
 
 ### 官方集成
 
@@ -102,8 +88,6 @@ PowerContext 为 Codex、Claude Code、DeepSeek Harness、Hermes Agent 和 Pi Co
 <td align="center" width="120"><a href="docs/zh/docs/how-to/configure-pi.md"><img src="https://github.com/earendil-works.png?size=120" alt="Pi Coding Agent" width="48" height="48" /><br /><sub><b>Pi Coding Agent</b></sub></a></td>
 </tr>
 </table>
-
-Pi Coding Agent 通过原生 package 而非 Host plugin 接入；详见[配置 Pi](docs/zh/docs/how-to/configure-pi.md)。
 
 ## 开发
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -33,6 +33,20 @@ powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
 再実行してください。Hermes インテグレーションには Hermes Agent v0.20.4 以降が必要です。設定とプロジェクトローカルの
 インストール方法については、[Hermes インテグレーションガイド](integrations/hermes/README.md)を参照してください。
 
+### Pi Coding Agent
+
+Pi をインストールしたうえで、ネイティブ Pi package を含む PowerContext の ref を使用します。以下は現在の
+`master` ブランチを使う例です。
+
+```bash
+uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
+powercontext setup pi --source oceanbase/powercontext --ref master
+powercontext doctor pi
+```
+
+Pi を含むリリース tag を使う場合は、最初の 2 つのコマンドの `master` を同じ tag に置き換えてください。必要な
+環境、設定、プロジェクトコンテキストのワークフローは [Configure Pi](docs/en/docs/how-to/configure-pi.md) を参照してください。
+
 ### 2. ローカル Server を起動して検証する
 
 1 つのターミナルで Server を起動したままにします。
@@ -79,9 +93,9 @@ powercontext doctor codex  # または: claude-code / dsh / hermes
 
 ## プラグイン
 
-PowerContext は Codex、Claude Code、DeepSeek Harness、Hermes Agent 向けの公式プラグインとインストールガイドを提供します。
-4 つのインテグレーションはすべて、PowerContext Server を通じて同じスコープ付きデータと履歴を保持する契約を
-使用します。プラグインが Server を自動的に起動したり、組み込んだりすることはありません。
+PowerContext は Codex、Claude Code、DeepSeek Harness、Hermes Agent、Pi Coding Agent 向けの公式インテグレーションと
+インストールガイドを提供します。5 つのインテグレーションはすべて、PowerContext Server を通じて同じスコープ付きデータと
+履歴を保持する契約を使用します。Host インテグレーションが Server を自動的に起動したり、組み込んだりすることはありません。
 
 ### 公式インテグレーション
 
@@ -91,8 +105,12 @@ PowerContext は Codex、Claude Code、DeepSeek Harness、Hermes Agent 向けの
 <td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
 <td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
 <td align="center" width="120"><a href="integrations/hermes/README.md"><img src="https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/logo.png?raw=true&size=120" alt="Hermes Agent" width="48" height="48" /><br /><sub><b>Hermes Agent</b></sub></a></td>
+<td align="center" width="120"><a href="docs/en/docs/how-to/configure-pi.md"><img src="https://github.com/earendil-works.png?size=120" alt="Pi Coding Agent" width="48" height="48" /><br /><sub><b>Pi Coding Agent</b></sub></a></td>
 </tr>
 </table>
+
+Pi Coding Agent は Host plugin ではなくネイティブ package として提供されます。プロジェクトコンテキストのワークフローは
+[Configure Pi](docs/en/docs/how-to/configure-pi.md) を参照してください。
 
 ## 開発
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -16,7 +16,7 @@ PowerContext は [PowerMem](https://www.powermem.ai/) のアップグレード�
 
 macOS または Linux、Python 3.11 以降、[`uv`](https://docs.astral.sh/uv/)、および少なくとも 1 つの対応 Agent Host が必要です。
 
-### 1. PowerContext とプラグインをインストールする
+### 1. PowerContext とインテグレーションをインストールする
 
 ```bash
 uv tool install "powercontext[cli,server]==0.0.2"
@@ -29,23 +29,8 @@ powercontext setup hermes --source oceanbase/powercontext --ref v0.0.2
 ```
 
 最初のコマンドは、隔離された環境に CLI とローカル Server をインストールします。以降の setup コマンドは、
-対応するリポジトリの tag から各プラグインをインストールします。既存のインストールを更新するには、setup を
-再実行してください。Hermes インテグレーションには Hermes Agent v0.20.4 以降が必要です。設定とプロジェクトローカルの
-インストール方法については、[Hermes インテグレーションガイド](integrations/hermes/README.md)を参照してください。
-
-### Pi Coding Agent
-
-Pi をインストールしたうえで、ネイティブ Pi package を含む PowerContext の ref を使用します。以下は現在の
-`master` ブランチを使う例です。
-
-```bash
-uv tool install --force "powercontext[cli,server] @ git+https://github.com/oceanbase/powercontext.git@master"
-powercontext setup pi --source oceanbase/powercontext --ref master
-powercontext doctor pi
-```
-
-Pi を含むリリース tag を使う場合は、最初の 2 つのコマンドの `master` を同じ tag に置き換えてください。必要な
-環境、設定、プロジェクトコンテキストのワークフローは [Configure Pi](docs/en/docs/how-to/configure-pi.md) を参照してください。
+対応するリポジトリの tag から各インテグレーションをインストールします。既存のインストールを更新するには、setup を
+再実行してください。
 
 ### 2. ローカル Server を起動して検証する
 
@@ -91,11 +76,11 @@ powercontext doctor codex  # または: claude-code / dsh / hermes
 
 ---
 
-## プラグイン
+## インテグレーション
 
 PowerContext は Codex、Claude Code、DeepSeek Harness、Hermes Agent、Pi Coding Agent 向けの公式インテグレーションと
-インストールガイドを提供します。5 つのインテグレーションはすべて、PowerContext Server を通じて同じスコープ付きデータと
-履歴を保持する契約を使用します。Host インテグレーションが Server を自動的に起動したり、組み込んだりすることはありません。
+インストールガイドを提供します。これらのインテグレーションは、PowerContext Server を通じて同じスコープ付きデータと
+履歴を保持する契約を使用します。ホストインテグレーションが Server を自動的に起動したり、組み込んだりすることはありません。
 
 ### 公式インテグレーション
 
@@ -108,9 +93,6 @@ PowerContext は Codex、Claude Code、DeepSeek Harness、Hermes Agent、Pi Codi
 <td align="center" width="120"><a href="docs/en/docs/how-to/configure-pi.md"><img src="https://github.com/earendil-works.png?size=120" alt="Pi Coding Agent" width="48" height="48" /><br /><sub><b>Pi Coding Agent</b></sub></a></td>
 </tr>
 </table>
-
-Pi Coding Agent は Host plugin ではなくネイティブ package として提供されます。プロジェクトコンテキストのワークフローは
-[Configure Pi](docs/en/docs/how-to/configure-pi.md) を参照してください。
 
 ## 開発
 


### PR DESCRIPTION
# Which issue or RFC does this PR close?

Related to #1259.

# Rationale for this change

Pi Coding Agent is now a supported PowerContext integration. The root READMEs need an immediately visible, accurate installation path so users can discover and start using it.

# What changes are included in this PR?

- Add a Pi Coding Agent quickstart to the English, Chinese, and Japanese READMEs.
- Explain how to install the CLI and native Pi package from the same PowerContext ref, using `master` as the current working example.
- Add Pi Coding Agent to every official-integration table and link to its detailed configuration guide.
- Clarify that Pi uses a native package rather than a host plugin.

# Are there any user-facing changes?

Yes. The READMEs now advertise Pi Coding Agent support and provide working installation and verification commands.

# How was this change tested?

- `mise exec -- make docs-test`
- `mise exec -- make check`

# AI usage statement

Built with Codex (GPT-5).
