### PR TITLE
fix(test): improve Windows compatibility of the test suite

### DIFF
--- a/tests/builtin/artifacts/skill/test_external.py
+++ b/tests/builtin/artifacts/skill/test_external.py
@@ -112,8 +112,8 @@ def test_scan_skips_invalid_or_symlinked_packages(tmp_path: Path) -> None:
     try:
         (package / "linked").symlink_to(invalid, target_is_directory=True)
     except OSError as error:
-# Windows requires SeCreateSymbolicLinkPrivilege (WinError 1314) for this test fixture.
-# Enable Windows Developer Mode or run the test as Administrator to gain this privilege.
+        # Windows requires SeCreateSymbolicLinkPrivilege (WinError 1314) for this test fixture.
+        # Enable Windows Developer Mode or run the test as Administrator to gain this privilege.
 
         if os.name != "nt" or getattr(error, "winerror", None) != 1314:
             raise

--- a/tests/builtin/artifacts/skill/test_external.py
+++ b/tests/builtin/artifacts/skill/test_external.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from pathlib import Path
 
 import pytest
@@ -107,12 +108,26 @@ def test_scan_skips_invalid_or_symlinked_packages(tmp_path: Path) -> None:
     invalid = root / "missing-frontmatter"
     invalid.mkdir()
     (invalid / "SKILL.md").write_text("# Missing frontmatter\n", encoding="utf-8")
-    (package / "linked").symlink_to(invalid, target_is_directory=True)
+    symlink_created = False
+    try:
+        (package / "linked").symlink_to(invalid, target_is_directory=True)
+    except OSError as error:
+# Windows requires SeCreateSymbolicLinkPrivilege (WinError 1314) for this test fixture.
+# Enable Windows Developer Mode or run the test as Administrator to gain this privilege.
+
+        if os.name != "nt" or getattr(error, "winerror", None) != 1314:
+            raise
+    else:
+        symlink_created = True
 
     scan = _provider(root).scan()
 
-    assert scan.registrations == ()
-    assert scan.skipped == 2
+    expected_skipped = 2 if symlink_created else 1
+    assert scan.skipped == expected_skipped
+    if symlink_created:
+        assert scan.registrations == ()
+    else:
+        assert [registration.name for registration in scan.registrations] == ["friendly-python"]
 
 
 def test_codex_provider_requires_unique_stable_root_ids(tmp_path: Path) -> None:

--- a/tests/codex_plugin/test_contract.py
+++ b/tests/codex_plugin/test_contract.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from types import ModuleType
 
@@ -68,7 +69,8 @@ def test_scope_binding_is_persisted_in_git_private_state(
     assert scope_module.resolve_scope_id(str(tmp_path)) == "handoff-ui-review"
     assert scope_module.resolve_scope_id(str(tmp_path), configured_scope_id="scope:override") == "scope:override"
     state_path = git_directory / "powercontext" / "codex-workspace.json"
-    assert state_path.stat().st_mode & 0o777 == 0o600
+    if os.name != "nt":
+        assert state_path.stat().st_mode & 0o777 == 0o600
 
     assert scope_module.clear_workstream_scope(str(tmp_path)) is True
     assert scope_module.read_bound_scope_id(str(tmp_path)) is None
@@ -176,7 +178,7 @@ def test_codex_settings_normalize_the_mcp_path_to_http_base(
 
 
 def test_project_context_skill_uses_the_high_level_work_continuity_loop() -> None:
-    content = (PLUGIN_ROOT / "skills" / "project-context" / "SKILL.md").read_text()
+    content = (PLUGIN_ROOT / "skills" / "project-context" / "SKILL.md").read_text(encoding="utf-8")
 
     assert 'description: Create and commit a current-work Handoff when the user says "交接"' in content
     assert '"$PLUGIN_ROOT/.venv/bin/python" "$PLUGIN_ROOT/scripts/project_scope.py"' in content

--- a/tests/codex_plugin/test_recall.py
+++ b/tests/codex_plugin/test_recall.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import stat
 import sys
 import threading
@@ -222,7 +223,8 @@ def test_recall_records_exact_injected_context_only_when_eval_trace_is_enabled(
     }
     assert event["injected_text"] == prepared_context
     assert event["observed_at"].endswith("Z")
-    assert stat.S_IMODE(trace.stat().st_mode) == 0o600
+    if os.name != "nt":
+        assert stat.S_IMODE(trace.stat().st_mode) == 0o600
 
 
 def test_recall_does_not_write_an_evaluation_trace_by_default(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,7 @@ from powercontext.http import (
     ReadinessResponse,
     ReadinessStatus,
 )
+from powercontext.paths import sqlite_url
 from powercontext.server.app import create_app
 from powercontext.server.factory import create_server_app
 from powercontext.server.settings import BearerAuthConfig, McpConfig, ServerSettings
@@ -138,7 +139,7 @@ def test_server_settings_vec1_preserves_file_database(tmp_path, monkeypatch) -> 
 
     settings = ServerSettings()
 
-    assert settings.database.url == f"sqlite+aiosqlite:///{data_dir / 'powercontext.db'}"
+    assert settings.database.url == sqlite_url(data_dir / "powercontext.db")
 
 
 def test_server_settings_select_oceanbase(monkeypatch) -> None:


### PR DESCRIPTION
# Which issue or RFC does this PR close?

<!--
Link the related issue or RFC using GitHub syntax.
For example, `Closes #123` indicates that this PR will close issue #123.
If this PR implements an RFC, link the RFC and any existing tracking issue.
-->

Closes #1308.

# Rationale for this change

The PowerContext test suite runs successfully on Windows, but five tests failed.Because they assumed POSIX filesystem behavior, Unix permission bits, the platform default text encoding, or POSIX SQLite path formatting. These failures did not indicate runtime or end-to-end failures. The changes make the existing tests portable across Windows and Mac/Linux without changing production behavior.
<img width="1330" height="420" alt="image" src="https://github.com/user-attachments/assets/9acb722a-5406-4850-b2d4-8bacdeca8744" />


<!--
Explain why this change is needed. If the linked issue or RFC already explains the rationale clearly, a short summary is enough.
-->

# What changes are included in this PR?

| Area | Windows failure | Change |
| --- | --- | --- |
| External Skill scan | Creating a test symlink requires `SeCreateSymbolicLinkPrivilege` and raised `WinError 1314` | Handle the missing privilege and continue testing invalid package handling; preserve symlink assertions when available |
| Codex scope state | Windows `stat()` does not expose POSIX `0o600` permission bits | Keep the permission assertion on POSIX only |
| Codex Skill contract | UTF-8 Chinese content was read using the Windows default encoding | Read the Skill file with `encoding="utf-8"` |
| Codex recall trace | Windows `stat()` does not expose POSIX `0o600` permission bits | Keep the permission assertion on POSIX only |
| SQLite settings | Windows path separators were inserted directly into the expected SQLite URL | Build the expected URL through the existing `sqlite_url()` helper |

No production runtime code, generated API code, or public API was changed.
<!--
Summarize the important changes. Focus on behavior, API, docs, tests, and migration impact.
-->

# Are there any user-facing changes?
No. This PR only updates platform-specific test assumptions.
<!--
If there are user-facing changes, documentation may need to be updated before approval.
If there are breaking changes to public APIs or persisted formats, call them out explicitly.
-->

# How was this change tested?

Tested on Windows 10 with Python 3.12.4.

- `uv sync --link-mode=copy`
- `uv run python -m pytest tests/builtin/artifacts/skill tests/codex_plugin/test_contract.py tests/codex_plugin/test_recall.py tests/test_server.py -q`
  - `78 passed`
- `uv run python -m pytest tests/e2e -q`
  - `passed`
- `uv run python -m pytest --doctest-modules -q -rs`
  - `625 passed, 14 skipped`
- `uv run ruff check tests/builtin/artifacts/skill/test_external.py tests/codex_plugin/test_contract.py tests/codex_plugin/test_recall.py tests/test_server.py`
  - `passed`

The skipped tests require a dedicated OceanBase test database, a configured Vec1 extension, or intentionally cover a POSIX virtual-environment symlink scenario.The test run also emitted intermittent Windows `access violation` diagnostics,but pytest exited successfully with no test failures. 
<img width="1324" height="510" alt="image" src="https://github.com/user-attachments/assets/5a7cca1b-0441-4222-959c-7ae10d1a79d0" />

<!--
List commands run, tests added or updated, and any manual validation performed.
-->

# AI usage statement
OpenAI Codex was used to implement and test these changes.
<!--
If AI tools were used to build this PR, describe the tool and model where possible.
If not applicable, write `Not used`.
-->
