### PR TITLE
chore: ignore local agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@ docs/source
 .superpowers/
 
 # Local agent artifacts and generated outputs.
-/.omx/
-/docs/superpowers/
-/output/
+.omx/
+docs/superpowers/
+output/
 
 # From https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ docs/source
 # Local visual brainstorming sessions.
 .superpowers/
 
+# Local agent artifacts and generated outputs.
+/.omx/
+/docs/superpowers/
+/output/
+
 # From https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
 
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
# Which issue or RFC does this PR close?

No linked issue or RFC.

# Rationale for this change

Local agent runtime data, generated design artifacts, and generated output files were appearing as untracked repository changes. Ignoring these directories reduces status noise and avoids accidental commits of local artifacts.

# What changes are included in this PR?

- Ignore `.omx/` directories.
- Ignore the repository `docs/superpowers/` directory.
- Ignore `output/` directories.

The ignore rules do not use a leading `/`. No directory contents are deleted.

# Are there any user-facing changes?

No. This only changes local Git ignore behavior and does not affect the package, public APIs, persisted formats, or documentation site output.

# How was this change tested?

- `git diff --check`
- `git check-ignore -v .omx docs/superpowers output`
- `uv run prek run --files .gitignore`

The full test suite was not run because no runtime or test code changed.

# AI usage statement

OpenAI Codex was used to inspect repository state, make the scoped `.gitignore` update, and run the validation commands listed above.