### PR TITLE
Fix/windows hook unicode prompts

### DIFF
--- a/integrations/claude-code/plugins/powercontext/hooks/user_prompt_submit.py
+++ b/integrations/claude-code/plugins/powercontext/hooks/user_prompt_submit.py
@@ -92,7 +92,11 @@ def main(settings: ClaudeCodePluginSettings | None = None) -> int:
 
     try:
         settings = ClaudeCodePluginSettings.from_environment() if settings is None else settings
-        payload = cast(dict[str, Any], json.load(sys.stdin))
+        stdin = sys.stdin
+        if hasattr(stdin, "buffer"):
+            payload = cast(dict[str, Any], json.loads(stdin.buffer.read().decode("utf-8")))
+        else:
+            payload = cast(dict[str, Any], json.load(stdin))
         if not _is_user_prompt_submit(payload.get("hook_event_name")):
             return 0
         prompt = _prompt(payload)

--- a/integrations/codex/plugins/powercontext/hooks/recall.py
+++ b/integrations/codex/plugins/powercontext/hooks/recall.py
@@ -95,7 +95,11 @@ def main(settings: CodexPluginSettings | None = None) -> int:
     try:
         settings = CodexPluginSettings() if settings is None else settings
         http_deadline = monotonic() + settings.http_budget_seconds
-        payload = cast(dict[str, Any], json.load(sys.stdin))
+        stdin = sys.stdin
+        if hasattr(stdin, "buffer"):
+            payload = cast(dict[str, Any], json.loads(stdin.buffer.read().decode("utf-8")))
+        else:
+            payload = cast(dict[str, Any], json.load(stdin))
         if not _is_user_prompt_submit(payload.get("hook_event_name")):
             return 0
         prompt = payload.get("prompt")

--- a/src/powercontext/server/app.py
+++ b/src/powercontext/server/app.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from contextlib import suppress
 from copy import deepcopy
 from datetime import UTC, datetime
@@ -1468,7 +1468,7 @@ def _error_response(
 def _validation_error_details(error: RequestValidationError) -> list[Any]:
     details: list[Any] = []
     for item in error.errors():
-        if isinstance(item, Mapping):
+        if isinstance(item, dict):
             details.append({key: value for key, value in item.items() if key != "input"})
         else:
             details.append(item)

--- a/src/powercontext/server/app.py
+++ b/src/powercontext/server/app.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import suppress
 from copy import deepcopy
 from datetime import UTC, datetime
@@ -607,7 +607,7 @@ def create_app(
             status.HTTP_422_UNPROCESSABLE_CONTENT,
             code="invalid_request",
             message="The request violates the API contract.",
-            details={"errors": error.errors()},
+            details={"errors": _validation_error_details(error)},
         )
 
     @app.exception_handler(_RuntimeNotReadyError)
@@ -1463,6 +1463,16 @@ def _error_response(
 ) -> JSONResponse:
     error = ErrorResponse(error=ErrorDetail(code=code, message=message, details=details))
     return JSONResponse(status_code=response_status, content=error.model_dump(mode="json"))
+
+
+def _validation_error_details(error: RequestValidationError) -> list[Any]:
+    details: list[Any] = []
+    for item in error.errors():
+        if isinstance(item, Mapping):
+            details.append({key: value for key, value in item.items() if key != "input"})
+        else:
+            details.append(item)
+    return details
 
 
 def _map_error(error: Exception) -> tuple[int, str, str, dict[str, Any] | None]:

--- a/tests/claude_code_plugin/test_hook.py
+++ b/tests/claude_code_plugin/test_hook.py
@@ -109,6 +109,46 @@ def test_user_prompt_submit_injects_prepared_context_and_captures_prompt(
     assert captured == [("What decisions apply?", "git:github.com/oceanbase/powercontext")]
 
 
+def test_user_prompt_submit_reads_utf8_stdin_on_windows_encodings(
+    hook_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared_content = "prepared context"
+    captured: list[str] = []
+    monkeypatch.setattr(
+        hook_module,
+        "_prepare_context",
+        lambda _query, _scope, *, settings, deadline: _prepared(prepared_content),
+    )
+    monkeypatch.setattr(
+        hook_module,
+        "resolve_scope_id",
+        lambda _cwd, *, configured_scope_id: "git:github.com/oceanbase/powercontext",
+    )
+    monkeypatch.setattr(
+        hook_module,
+        "_capture_prompt",
+        lambda _payload, *, prompt, cwd, scope_id, settings, deadline: captured.append(prompt) or {"position": 1},
+    )
+
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "cwd": "/workspace/project",
+        "prompt": "查看当前记忆",
+    }
+    stdin = io.TextIOWrapper(
+        io.BytesIO(json.dumps(payload, ensure_ascii=False).encode("utf-8")),
+        encoding="cp1252",
+    )
+    monkeypatch.setattr(sys, "stdin", stdin)
+    output = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", output)
+
+    assert hook_module.main() == 0
+    assert captured == ["查看当前记忆"]
+    assert json.loads(output.getvalue())["hookSpecificOutput"]["additionalContext"] == prepared_content
+
+
 def test_user_prompt_compatibility_fallback_is_supported(
     hook_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/codex_plugin/test_recall.py
+++ b/tests/codex_plugin/test_recall.py
@@ -101,6 +101,46 @@ def test_recall_emits_bounded_untrusted_context(
     assert captured == [("What decisions apply?", "project:test")]
 
 
+def test_recall_reads_utf8_stdin_on_windows_encodings(
+    recall_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared_content = "prepared context"
+    captured: list[str] = []
+    monkeypatch.setattr(
+        recall_module,
+        "_prepare_context",
+        lambda _query, _scope, *, settings, deadline: _prepared(prepared_content),
+    )
+    monkeypatch.setattr(
+        recall_module,
+        "resolve_scope_id",
+        lambda _cwd, *, configured_scope_id: "project:test",
+    )
+    monkeypatch.setattr(
+        recall_module,
+        "_capture_prompt",
+        lambda _payload, *, prompt, cwd, scope_id, settings, deadline: captured.append(prompt) or {"position": 1},
+    )
+
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "cwd": "/workspace/project",
+        "prompt": "查看当前记忆",
+    }
+    stdin = io.TextIOWrapper(
+        io.BytesIO(json.dumps(payload, ensure_ascii=False).encode("utf-8")),
+        encoding="cp1252",
+    )
+    monkeypatch.setattr(sys, "stdin", stdin)
+    output = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", output)
+
+    assert recall_module.main() == 0
+    assert captured == ["查看当前记忆"]
+    assert json.loads(output.getvalue())["hookSpecificOutput"]["additionalContext"] == prepared_content
+
+
 def test_recall_failure_is_non_blocking(
     recall_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -558,6 +558,30 @@ def test_prepare_context_rejects_memory_specific_tuning_fields(tmp_path) -> None
     assert response.json()["error"]["code"] == "invalid_request"
 
 
+def test_prepare_context_rejects_invalid_request_without_input_field(tmp_path) -> None:
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+            mcp=McpConfig(enabled=False),
+        )
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/prepare",
+            json={
+                "scope_id": "project:test",
+                "query": "query",
+                "candidate_limit": 2,
+            },
+        )
+
+    assert response.status_code == 422
+    error = response.json()["error"]
+    assert error["code"] == "invalid_request"
+    assert "input" not in error["details"]["errors"][0]
+
+
 def test_stats_returns_inclusive_utc_periods_for_empty_scope(tmp_path) -> None:
     app = create_server_app(
         settings=ServerSettings(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -558,6 +558,31 @@ def test_prepare_context_rejects_memory_specific_tuning_fields(tmp_path) -> None
     assert response.json()["error"]["code"] == "invalid_request"
 
 
+def test_prepare_context_rejects_unicode_surrogates_without_crashing(tmp_path) -> None:
+    app = create_server_app(
+        settings=ServerSettings(
+            database=SQLiteConfig(url=f"sqlite+aiosqlite:///{tmp_path / 'runtime.db'}"),
+            mcp=McpConfig(enabled=False),
+        )
+    )
+
+    body = '{"scope_id":"project:test","query":"\\udcaa"}'.encode(
+        "utf-8",
+        "surrogatepass",
+    )
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/context/prepare",
+            content=body,
+            headers={"content-type": "application/json"},
+        )
+
+    assert response.status_code == 422
+    error = response.json()["error"]
+    assert error["code"] == "invalid_request"
+    assert "input" not in error["details"]["errors"][0]
+
+
 def test_prepare_context_rejects_invalid_request_without_input_field(tmp_path) -> None:
     app = create_server_app(
         settings=ServerSettings(


### PR DESCRIPTION
# Which issue or RFC does this PR close?

<!--
Link the related issue or RFC using GitHub syntax.
For example, `Closes #123` indicates that this PR will close issue #123.
If this PR implements an RFC, link the RFC and any existing tracking issue.
-->

Closes #1305 

# Rationale for this change

<!--
Explain why this change is needed. If the linked issue or RFC already explains the rationale clearly, a short summary is enough.
-->

On Windows, the Claude Code and Codex hook scripts could read stdin using the local console encoding instead of UTF-8. That corrupted non-ASCII prompts and could produce lone surrogate characters. The server then failed while rendering the 422 validation response because the raw invalid input was included in the returned error details.

# What changes are included in this PR?

<!--
Summarize the important changes. Focus on behavior, API, docs, tests, and migration impact.
-->

The Claude Code and Codex hook scripts now read JSON payloads from `sys.stdin.buffer` and decode them as UTF-8 before parsing.
The server’s `RequestValidationError` handler now removes the raw `input` field from validation errors before returning the 422 response.
Regression tests were added for UTF-8 stdin handling on Windows and for surrogate-safe validation responses.

# Are there any user-facing changes?

<!--
If there are user-facing changes, documentation may need to be updated before approval.
If there are breaking changes to public APIs or persisted formats, call them out explicitly.
-->

Yes. Windows users submitting non-ASCII prompts through Claude Code or Codex hooks should no longer see corrupted prompts or broken validation responses.
The API still returns 422 for invalid requests, but it no longer echoes the raw invalid input in the error details.

# How was this change tested?

<!--
List commands run, tests added or updated, and any manual validation performed.
-->

- `pytest tests/test_server.py -q -k "invalid_request_without_input_field or unicode_surrogates_without_crashing"`
- `pytest tests/claude_code_plugin/test_hook.py tests/codex_plugin/test_recall.py -q`

# AI usage statement

<!--
If AI tools were used to build this PR, describe the tool and model where possible.
If not applicable, write `Not used`.
-->
AI tools were used to implement and verify this change.
