### PR TITLE
fix(doc): missing link entries in the integrations table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ PowerContext Server; the host integrations do not start or embed the Server.
 
 <table>
 <tr>
-<td align="center" width="120"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></td>
-<td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
-<td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
+<td align="center" width="120"><a href="docs/en/docs/how-to/configure-codex.md"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></a></td>
+<td align="center" width="120"><a href="docs/en/docs/how-to/configure-claude-code.md"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></a></td>
+<td align="center" width="120"><a href="docs/en/docs/how-to/configure-dsh.md"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></a></td>
 <td align="center" width="120"><a href="integrations/hermes/README.md"><img src="https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/logo.png?raw=true&size=120" alt="Hermes Agent" width="48" height="48" /><br /><sub><b>Hermes Agent</b></sub></a></td>
 <td align="center" width="120"><a href="docs/en/docs/how-to/configure-pi.md"><img src="https://github.com/earendil-works.png?size=120" alt="Pi Coding Agent" width="48" height="48" /><br /><sub><b>Pi Coding Agent</b></sub></a></td>
 </tr>

--- a/README_CN.md
+++ b/README_CN.md
@@ -81,9 +81,9 @@ PowerContext 为 Codex、Claude Code、DeepSeek Harness、Hermes Agent 和 Pi Co
 
 <table>
 <tr>
-<td align="center" width="120"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></td>
-<td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
-<td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
+<td align="center" width="120"><a href="docs/zh/docs/how-to/configure-codex.md"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></a></td>
+<td align="center" width="120"><a href="docs/zh/docs/how-to/configure-claude-code.md"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></a></td>
+<td align="center" width="120"><a href="docs/zh/docs/how-to/configure-dsh.md"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></a></td>
 <td align="center" width="120"><a href="integrations/hermes/README.md"><img src="https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/logo.png?raw=true&size=120" alt="Hermes Agent" width="48" height="48" /><br /><sub><b>Hermes Agent</b></sub></a></td>
 <td align="center" width="120"><a href="docs/zh/docs/how-to/configure-pi.md"><img src="https://github.com/earendil-works.png?size=120" alt="Pi Coding Agent" width="48" height="48" /><br /><sub><b>Pi Coding Agent</b></sub></a></td>
 </tr>

--- a/README_JP.md
+++ b/README_JP.md
@@ -86,9 +86,9 @@ PowerContext は Codex、Claude Code、DeepSeek Harness、Hermes Agent、Pi Codi
 
 <table>
 <tr>
-<td align="center" width="120"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></td>
-<td align="center" width="120"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></td>
-<td align="center" width="120"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></td>
+<td align="center" width="120"><a href="docs/en/docs/how-to/configure-codex.md"><img src="https://github.com/openai.png?size=120" alt="Codex" width="48" height="48" /><br /><sub><b>Codex</b></sub></a></td>
+<td align="center" width="120"><a href="docs/en/docs/how-to/configure-claude-code.md"><img src="https://github.com/anthropics.png?size=120" alt="Claude Code" width="48" height="48" /><br /><sub><b>Claude Code</b></sub></a></td>
+<td align="center" width="120"><a href="docs/en/docs/how-to/configure-dsh.md"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48" /><br /><sub><b>DeepSeek Harness</b></sub></a></td>
 <td align="center" width="120"><a href="integrations/hermes/README.md"><img src="https://github.com/NousResearch/hermes-agent/blob/main/website/static/img/logo.png?raw=true&size=120" alt="Hermes Agent" width="48" height="48" /><br /><sub><b>Hermes Agent</b></sub></a></td>
 <td align="center" width="120"><a href="docs/en/docs/how-to/configure-pi.md"><img src="https://github.com/earendil-works.png?size=120" alt="Pi Coding Agent" width="48" height="48" /><br /><sub><b>Pi Coding Agent</b></sub></a></td>
 </tr>


### PR DESCRIPTION
# Which issue or RFC does this PR close?

None.

# Rationale for this change

The "Official integrations" table in the root READMEs only linked two of the five entries. Codex, Claude Code, and DeepSeek Harness rendered as plain image+text with no clickable target, while Hermes Agent and Pi Coding Agent were wrapped in `<a>` and showed up as blue underlined links. The result was inconsistent visual styling and three dead cards where users expected to land on a configuration guide.

This PR wraps all five cells in `<a>` and points Codex, Claude Code, and DeepSeek Harness at their existing configuration guides. Hermes Agent continues to point at its in-tree `integrations/hermes/README.md`, and Pi Coding Agent at `docs/{en,zh}/docs/how-to/configure-pi.md`.

# What changes are included in this PR?

- `README.md`: link Codex, Claude Code, and DeepSeek Harness to their English `docs/en/docs/how-to/configure-*.md` guides.
- `README_CN.md`: same three cells linked to the Chinese `docs/zh/docs/how-to/configure-*.md` guides.
- `README_JP.md`: same three cells linked to the English guides (no Japanese translation is available).
- All five cells in every README are now wrapped in `<a>`, so the row renders consistently.

No public API, HTTP/MCP contract, configuration, or persisted format changes.

# Are there any user-facing changes?

Yes. Clicking the Codex, Claude Code, or DeepSeek Harness card in any of the three READMEs now navigates to the corresponding configuration guide, matching the behavior of Hermes Agent and Pi Coding Agent.

# How was this change tested?

- `git diff --check origin/master...HEAD`
- Manual visual check: opened each rendered README on GitHub and confirmed all five cards display as centered clickable cards with consistent styling, and that each link resolves to an existing file in the repo.

The full test suite was not run because only README markdown was changed.

# AI usage statement

OpenAI Codex (GPT-5) was used to inspect the rendered output, write the link updates across the three READMEs, and draft this PR description.