### PR TITLE
fix(server): display uvicorn lifecycle logs without an error logger name

### DIFF
--- a/src/powercontext/server/logging.py
+++ b/src/powercontext/server/logging.py
@@ -91,6 +91,22 @@ class _HumanContextFilter(OperationalContextFilter):
         return True
 
 
+class _UvicornDisplayNameFilter(logging.Filter):
+    """Rewrite uvicorn's lifecycle logger name for display.
+
+    uvicorn hardcodes "uvicorn.error" for its lifecycle logger, which mostly
+    carries INFO startup lines but reads like an error channel. Rewriting the
+    record name here is display-only: the logger tree, level routing, and any
+    filtering keyed on the original name are untouched.
+    """
+
+    @override
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.name == "uvicorn.error":
+            record.name = "uvicorn"
+        return True
+
+
 def configure_server_logging(config: ServerLoggingConfig) -> None:
     """Configure process logging for the foreground Server command."""
 
@@ -106,7 +122,10 @@ def configure_server_logging(config: ServerLoggingConfig) -> None:
     logging.config.dictConfig({
         "version": 1,
         "disable_existing_loggers": False,
-        "filters": {"operational": {"()": _HumanContextFilter}},
+        "filters": {
+            "operational": {"()": _HumanContextFilter},
+            "uvicorn_display_name": {"()": _UvicornDisplayNameFilter},
+        },
         "formatters": {"server": formatter},
         "handlers": {
             "server": {
@@ -126,6 +145,7 @@ def configure_server_logging(config: ServerLoggingConfig) -> None:
                 "handlers": ["server"],
                 "level": config.level,
                 "propagate": False,
+                "filters": ["uvicorn_display_name"],
             },
         },
     })

--- a/src/powercontext/server/logging.py
+++ b/src/powercontext/server/logging.py
@@ -92,12 +92,13 @@ class _HumanContextFilter(OperationalContextFilter):
 
 
 class _UvicornDisplayNameFilter(logging.Filter):
-    """Rewrite uvicorn's lifecycle logger name for display.
+    """Rewrite uvicorn's logger name for downstream display.
 
-    uvicorn hardcodes "uvicorn.error" for its lifecycle logger, which mostly
-    carries INFO startup lines but reads like an error channel. Rewriting the
-    record name here is display-only: the logger tree, level routing, and any
-    filtering keyed on the original name are untouched.
+    Uvicorn emits lifecycle and error records through ``uvicorn.error``.
+    Logger selection, hierarchy, and effective-level checks use that logger.
+    This filter then rewrites only ``record.name``, so later filters on the
+    same logger and downstream handler filters and formatters observe
+    ``uvicorn``. Parent logger filters are not applied during propagation.
     """
 
     @override

--- a/tests/test_server_logging.py
+++ b/tests/test_server_logging.py
@@ -16,41 +16,59 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
+import sys
 
 from fastapi.testclient import TestClient
 
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.server.factory import create_server_app
-from powercontext.server.logging import JsonFormatter, OperationalContextFilter, _UvicornDisplayNameFilter
+from powercontext.server.logging import JsonFormatter, OperationalContextFilter
 from powercontext.server.settings import McpConfig, ServerLoggingConfig, ServerSettings
 
 
-def test_uvicorn_error_records_are_displayed_as_uvicorn() -> None:
-    record = logging.makeLogRecord({
-        "name": "uvicorn.error",
-        "levelno": logging.INFO,
-        "levelname": "INFO",
-        "msg": "Started server process",
-    })
+def _run_configured_logging_probe(log_format: str) -> list[str]:
+    script = f"""
+import logging
 
-    _UvicornDisplayNameFilter().filter(record)
+from powercontext.server.logging import configure_server_logging
+from powercontext.server.settings import ServerLoggingConfig
 
-    payload = json.loads(JsonFormatter().format(record))
-    assert payload["logger"] == "uvicorn"
-    assert payload["message"] == "Started server process"
+configure_server_logging(ServerLoggingConfig(format={log_format!r}))
+logging.getLogger("uvicorn.error").info("Started server process")
+logging.getLogger("uvicorn.error").error("Server startup failed")
+logging.getLogger("powercontext.server.factory").info("PowerContext Server is ready")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return result.stdout.splitlines()
 
 
-def test_uvicorn_display_name_filter_leaves_other_loggers_untouched() -> None:
-    record = logging.makeLogRecord({
-        "name": "powercontext.server.factory",
-        "levelno": logging.INFO,
-        "levelname": "INFO",
-        "msg": "PowerContext Server is ready",
-    })
+def test_configured_console_logging_uses_uvicorn_display_name() -> None:
+    lines = _run_configured_logging_probe("console")
 
-    _UvicornDisplayNameFilter().filter(record)
+    assert len(lines) == 3
+    messages = [line.split(" ", 1)[1] for line in lines]
+    assert messages == [
+        "INFO uvicorn Started server process",
+        "ERROR uvicorn Server startup failed",
+        "INFO powercontext.server.factory PowerContext Server is ready",
+    ]
 
-    assert record.name == "powercontext.server.factory"
+
+def test_configured_json_logging_uses_uvicorn_display_name() -> None:
+    payloads = [json.loads(line) for line in _run_configured_logging_probe("json")]
+
+    assert [(payload["level"], payload["logger"], payload["message"]) for payload in payloads] == [
+        ("INFO", "uvicorn", "Started server process"),
+        ("ERROR", "uvicorn", "Server startup failed"),
+        ("INFO", "powercontext.server.factory", "PowerContext Server is ready"),
+    ]
 
 
 def test_json_formatter_emits_stable_operational_fields() -> None:

--- a/tests/test_server_logging.py
+++ b/tests/test_server_logging.py
@@ -21,8 +21,36 @@ from fastapi.testclient import TestClient
 
 from powercontext.builtin.persistence.sqlite import SQLiteConfig
 from powercontext.server.factory import create_server_app
-from powercontext.server.logging import JsonFormatter, OperationalContextFilter
+from powercontext.server.logging import JsonFormatter, OperationalContextFilter, _UvicornDisplayNameFilter
 from powercontext.server.settings import McpConfig, ServerLoggingConfig, ServerSettings
+
+
+def test_uvicorn_error_records_are_displayed_as_uvicorn() -> None:
+    record = logging.makeLogRecord({
+        "name": "uvicorn.error",
+        "levelno": logging.INFO,
+        "levelname": "INFO",
+        "msg": "Started server process",
+    })
+
+    _UvicornDisplayNameFilter().filter(record)
+
+    payload = json.loads(JsonFormatter().format(record))
+    assert payload["logger"] == "uvicorn"
+    assert payload["message"] == "Started server process"
+
+
+def test_uvicorn_display_name_filter_leaves_other_loggers_untouched() -> None:
+    record = logging.makeLogRecord({
+        "name": "powercontext.server.factory",
+        "levelno": logging.INFO,
+        "levelname": "INFO",
+        "msg": "PowerContext Server is ready",
+    })
+
+    _UvicornDisplayNameFilter().filter(record)
+
+    assert record.name == "powercontext.server.factory"
 
 
 def test_json_formatter_emits_stable_operational_fields() -> None:


### PR DESCRIPTION
# Which issue or RFC does this PR close?

N/A — discovered during local usage; no tracking issue exists.

# Rationale for this change

uvicorn hardcodes `uvicorn.error` as its lifecycle logger name, which mostly
carries INFO startup lines but reads like an error channel. New users routinely
misread startup logs such as `INFO uvicorn.error Started server process` as an
error. The `Logger.name` attribute is read-only, so the fix rewrites the record
name in the display layer only.

# What changes are included in this PR?

- `src/powercontext/server/logging.py`: add `_UvicornDisplayNameFilter`,
  registered in the dictConfig and attached to the `uvicorn.error` logger
  (attached to the logger, not the shared handler, so powercontext's own
  loggers are unaffected). It rewrites `record.name` to `uvicorn` for display;
  the logger tree, level routing, and any filtering keyed on the original name
  are untouched.
- `tests/test_server_logging.py`: add 2 unit tests — the rewrite makes the JSON
  formatter emit `"logger":"uvicorn"`, and other logger names are left untouched.

# Are there any user-facing changes?

Display-only: server startup/shutdown logs now render as `INFO uvicorn ...`
instead of `INFO uvicorn.error ...`. No API, config, or persisted format
changes. JSON-formatted logs emit `"logger":"uvicorn"` as well. Real errors
still render as `ERROR uvicorn ...`.

# How was this change tested?

- `uv run python -m pytest tests/test_server_logging.py`: 6 passed
- `uv run ruff check src/powercontext/server/logging.py tests/test_server_logging.py`: passed
- Manual: started the server and verified startup/shutdown lines render as
  `INFO uvicorn ...`; a simulated error still renders as `ERROR uvicorn ...`

# AI usage statement

An AI assistant (WorkBuddy) was used to implement the filter and draft this PR
description; the implementation was validated locally with tests and manual
runs.
